### PR TITLE
Copy CMS content into Netlify build output

### DIFF
--- a/content/uploads/README.md
+++ b/content/uploads/README.md
@@ -1,0 +1,3 @@
+# Kapunka Uploads
+
+Place product, article, and doctor imagery files in this folder so they are deployed alongside the rest of the CMS content.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/postbuild.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,0 +1,33 @@
+import { cpSync, existsSync, mkdirSync, rmSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const distDir = path.join(rootDir, 'dist');
+
+function ensureDir(directory) {
+  if (!existsSync(directory)) {
+    mkdirSync(directory, { recursive: true });
+  }
+}
+
+function copyFolder(sourceRelative, destinationRelative) {
+  const source = path.join(rootDir, sourceRelative);
+  const destination = path.join(rootDir, destinationRelative);
+
+  if (!existsSync(source)) {
+    console.warn(`[postbuild] Skipping missing source: ${sourceRelative}`);
+    return;
+  }
+
+  rmSync(destination, { recursive: true, force: true });
+  cpSync(source, destination, { recursive: true });
+  console.log(`[postbuild] Copied ${sourceRelative} -> ${destinationRelative}`);
+}
+
+ensureDir(distDir);
+
+copyFolder('content', path.join('dist', 'content'));
+copyFolder('admin', path.join('dist', 'admin'));


### PR DESCRIPTION
## Summary
- copy CMS `content` and `admin` directories into the Vite build output so Netlify can serve JSON data and CMS assets
- add an empty `content/uploads` directory (with `.gitkeep`) for future image uploads referenced by content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d157c8fde08320aab8a06d2b9bff57