### PR TITLE
Add enriched argan oil description and tips

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -147,6 +147,13 @@ collections:
                   - { label: English, name: en, widget: string }
                   - { label: Portuguese, name: pt, widget: string }
                   - { label: Spanish, name: es, widget: string }
+              - label: Description
+                name: description
+                widget: object
+                fields:
+                  - { label: English, name: en, widget: text }
+                  - { label: Portuguese, name: pt, widget: text }
+                  - { label: Spanish, name: es, widget: text }
               - { label: Image, name: imageUrl, widget: image, choose_url: true }
               - label: Sizes
                 name: sizes
@@ -209,6 +216,33 @@ collections:
                   - { label: English, name: en, widget: text }
                   - { label: Portuguese, name: pt, widget: text }
                   - { label: Spanish, name: es, widget: text }
+              - label: Good to Know
+                name: goodToKnow
+                widget: object
+                fields:
+                  - label: Title
+                    name: title
+                    widget: object
+                    fields:
+                      - { label: English, name: en, widget: string }
+                      - { label: Portuguese, name: pt, widget: string }
+                      - { label: Spanish, name: es, widget: string }
+                  - label: Items
+                    name: items
+                    widget: object
+                    fields:
+                      - label: English
+                        name: en
+                        widget: list
+                        field: { label: Item, name: item, widget: string }
+                      - label: Portuguese
+                        name: pt
+                        widget: list
+                        field: { label: Item, name: item, widget: string }
+                      - label: Spanish
+                        name: es
+                        widget: list
+                        field: { label: Item, name: item, widget: string }
               - label: Knowledge Hub
                 name: knowledge
                 widget: object

--- a/content/products/index.json
+++ b/content/products/index.json
@@ -16,6 +16,11 @@
         "pt": "Certificado ECOCERT, Primeira Prensagem a Frio",
         "es": "Certificado ECOCERT, Primera Presión en Frío"
       },
+      "description": {
+        "en": "Kapunka Pure Argan Oil (100 ml) is cold-pressed, single-origin from Morocco. Certified by ECOCERT, 100% vegan, no additives. Rich in vitamin E and essential fatty acids, it deeply nourishes skin, supports hair shine, soothes stretch marks, and aids skin regeneration without clogging pores.",
+        "pt": "Óleo de Argan puro Kapunka (100 ml) é prensado a frio, de origem única do Marrocos. Certificado pela ECOCERT, 100 % vegano, sem aditivos. Rico em vitamina E e ácidos gordos essenciais, nutre profundamente a pele, dá brilho ao cabelo, suaviza estrias e favorece a regeneração cutânea sem obstruir os poros.",
+        "es": "Aceite de Argán puro Kapunka (100 ml) se obtiene por prensado en frío, origen único de Marruecos. Certificado por ECOCERT, 100 % vegano, sin aditivos. Rico en vitamina E y ácidos grasos esenciales, nutre profundamente la piel, da brillo al cabello, suaviza estrías y favorece la regeneración cutánea sin obstruir los poros."
+      },
       "badges": {
         "en": [
           "ECOCERT Certified",
@@ -37,6 +42,33 @@
         "en": "Our Argan Oil is ECOCERT certified, guaranteeing its organic purity and ethical sourcing from the women's cooperatives of Morocco.",
         "pt": "O nosso Óleo de Argan é certificado pela ECOCERT, garantindo a sua pureza orgânica e origem ética das cooperativas de mulheres de Marrocos.",
         "es": "Nuestro Aceite de Argán está certificado por ECOCERT, garantizando su pureza orgánica y su origen ético de las cooperativas de mujeres de Marruecos."
+      },
+      "goodToKnow": {
+        "title": {
+          "en": "Good to know",
+          "pt": "Bom saber",
+          "es": "Para tener en cuenta"
+        },
+        "items": {
+          "en": [
+            "Texture: lightweight, non-greasy",
+            "Absorption: fast absorb-in, leaves subtle glow",
+            "Recommended use: AM/PM, mix with moisturizer or use alone",
+            "Shelf life: 12 months after opening"
+          ],
+          "pt": [
+            "Textura: leve, não gordurosa",
+            "Absorção: rápida, deixa um brilho sutil",
+            "Uso recomendado: manhã/noite, misture ao hidratante ou use sozinho",
+            "Validade: 12 meses após a abertura"
+          ],
+          "es": [
+            "Textura: ligera, no grasa",
+            "Absorción: rápida, deja un brillo sutil",
+            "Uso recomendado: mañana/noche, mézclalo con hidratante o úsalo solo",
+            "Caducidad: 12 meses después de abrir"
+          ]
+        }
       },
       "sizes": [
         {

--- a/pages/ProductDetail.tsx
+++ b/pages/ProductDetail.tsx
@@ -103,6 +103,14 @@ const ProductDetail: React.FC = () => {
                         <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6, delay: 0.1 }}>
                             <h1 className="text-3xl sm:text-4xl font-semibold" data-nlv-field-path={productFieldPath ? `${productFieldPath}.name.en` : undefined}>{translate(product.name)}</h1>
                             <p className="text-lg text-stone-500 mt-2" data-nlv-field-path={productFieldPath ? `${productFieldPath}.tagline.en` : undefined}>{translate(product.tagline)}</p>
+                            {product.description && (
+                                <p
+                                    className="mt-4 text-base text-stone-600 leading-relaxed"
+                                    data-nlv-field-path={productFieldPath ? `${productFieldPath}.description.en` : undefined}
+                                >
+                                    {translate(product.description)}
+                                </p>
+                            )}
                         </motion.div>
 
                         <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6, delay: 0.2 }}>
@@ -192,6 +200,26 @@ const ProductDetail: React.FC = () => {
                                 )}
                                 {activeTab === 'labTested' && (
                                     <p data-nlv-field-path={productFieldPath ? `${productFieldPath}.labTestedNote.en` : undefined}>{translate(product.labTestedNote)}</p>
+                                )}
+                                {product.goodToKnow && (
+                                    <div className="mt-8">
+                                        <h4
+                                            className="text-sm font-semibold uppercase tracking-wide text-stone-500"
+                                            data-nlv-field-path={productFieldPath ? `${productFieldPath}.goodToKnow.title.en` : undefined}
+                                        >
+                                            {translate(product.goodToKnow.title)}
+                                        </h4>
+                                        <ul className="mt-3 list-disc pl-5 space-y-2">
+                                            {(translate(product.goodToKnow.items) as string[]).map((item: string, index: number) => (
+                                                <li
+                                                    key={index}
+                                                    data-nlv-field-path={productFieldPath ? `${productFieldPath}.goodToKnow.items.en.${index}` : undefined}
+                                                >
+                                                    {item}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
                                 )}
                             </div>
                         </motion.div>

--- a/types.ts
+++ b/types.ts
@@ -31,10 +31,16 @@ export interface ProductFaq {
   answer: Translatable;
 }
 
+export interface ProductGoodToKnow {
+  title: Translatable;
+  items: TranslatableArray;
+}
+
 export interface Product {
   id: string;
   name: Translatable;
   tagline: Translatable;
+  description?: Translatable;
   imageUrl: string;
   sizes: ProductSize[];
   badges: TranslatableArray;
@@ -44,6 +50,7 @@ export interface Product {
   labTestedNote: Translatable;
   knowledge: ProductKnowledge;
   faqs: ProductFaq[];
+  goodToKnow?: ProductGoodToKnow;
 }
 
 export interface CartItem {


### PR DESCRIPTION
## Summary
- add localized product description and Good to Know bullets for pure argan oil via Decap content
- extend product types and CMS config to capture the new description and guidance fields
- render the optional description and Good to Know list on the product detail page without altering layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d2df95d1608320b08595ff41ee3612