### PR TITLE
Fix Stackbit config format for Visual Editor

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -84,9 +84,9 @@ The project follows a standard feature-based directory structure.
 
 ### Netlify Visual Editor Workflow
 
-- The project is wired for the **Netlify Visual Editor**. The integration relies on `netlify.toml` (see the `[visual_editor]` section), the page model map in `stackbit.config.ts`, the editing schema in `metadata.json`, and the starter content in `site/content/`.
+- The project is wired for the **Netlify Visual Editor**. The integration relies on `netlify.toml` (see the `[visual_editor]` section), the page model map in `stackbit.config.mjs`, the editing schema in `metadata.json`, and the starter content in `site/content/`.
 - **Keep Decap CMS and the Visual Editor in sync.** Whenever you add, rename, or remove fields in `admin/config.yml`, mirror the same structure in the JSON documents under `/content` and regenerate/update `metadata.json` so on-page editing exposes the new fields.
-- Register every new route or page component in `stackbit.config.ts`. If a page is missing from the config, the Visual Editor cannot open it for live editing.
+- Register every new route or page component in `stackbit.config.mjs`. If a page is missing from the config, the Visual Editor cannot open it for live editing.
 - Preserve the JSON shapes that components expect. If you must change a schema, migrate the existing entries in `/content` and `site/content/` so that Visual Editor previews do not break.
 - Do not change the Visual Editor dev command or ports in `netlify.toml` unless you also update the Netlify dashboard configuration. Local Visual Editor sessions depend on `npm run dev` running on port `5173`.
 - Commit any Visual Editor metadata updates (`metadata.json`, additions under `site/content/`, etc.) together with the related feature so the deployed site and editor stay aligned.

--- a/stackbit.config.mjs
+++ b/stackbit.config.mjs
@@ -1,12 +1,9 @@
-import type { StackbitConfig } from '@stackbit/types';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { FileSystemContentSource } from '@stackbit/cms-git';
 
 const metadataPath = resolve(process.cwd(), 'metadata.json');
-const metadata = JSON.parse(readFileSync(metadataPath, 'utf8')) as {
-  models: Array<{ name: string }>;
-};
+const metadata = JSON.parse(readFileSync(metadataPath, 'utf8'));
 
 const contentSource = new FileSystemContentSource({
   rootPath: process.cwd(),
@@ -14,7 +11,7 @@ const contentSource = new FileSystemContentSource({
   models: metadata.models,
 });
 
-const pageModels: { name: string; type: 'page'; urlPath: string }[] = [
+const pageModels = [
   {
     name: 'shop',
     type: 'page',
@@ -47,6 +44,7 @@ const pageModels: { name: string; type: 'page'; urlPath: string }[] = [
   },
 ];
 
+/** @type {import('@stackbit/types').StackbitConfig} */
 const config = {
   stackbitVersion: '~0.6.0',
   contentSources: [contentSource],
@@ -59,6 +57,6 @@ const config = {
     return [...models, ...additional];
   },
   modelExtensions: pageModels,
-} satisfies StackbitConfig;
+};
 
 export default config;


### PR DESCRIPTION
## Summary
- convert the Stackbit configuration to an ESM JavaScript module so the Netlify Visual Editor can load it without TypeScript tooling
- update the contributor guidelines to reference the new configuration filename

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d4f62a7f0c8320a589bf476b7514de