### PR TITLE
feat: manage About page imagery via site settings

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -47,6 +47,28 @@ collections:
               - { label: Email Address, name: email, widget: string }
               - { label: Phone Number, name: phone, widget: string }
               - { label: WhatsApp Link, name: whatsapp, widget: string }
+          - label: About Page Imagery
+            name: about
+            widget: object
+            fields:
+              - label: Brand Story Image
+                name: storyImage
+                widget: image
+                choose_url: true
+                hint: "Recommended minimum 2000×1300 JPG or WEBP to preserve the hero layout."
+              - label: Brand Story Alt Text
+                name: storyAlt
+                widget: string
+                hint: "Provide localized alt copy describing the hero image."
+              - label: Argan Sourcing Image
+                name: sourcingImage
+                widget: image
+                choose_url: true
+                hint: "Recommended minimum 2000×1300 JPG or WEBP to preserve the secondary layout."
+              - label: Argan Sourcing Alt Text
+                name: sourcingAlt
+                widget: string
+                hint: "Provide localized alt copy describing the sourcing photograph."
           - label: Footer
             name: footer
             widget: object

--- a/content/site.json
+++ b/content/site.json
@@ -15,6 +15,12 @@
     "phone": "+1 (234) 567-890",
     "whatsapp": "https://wa.me/1234567890"
   },
+  "about": {
+    "storyImage": "https://images.unsplash.com/photo-1598555769781-8714b14a293f?q=80&w=1974&auto=format&fit=crop",
+    "sourcingImage": "https://images.unsplash.com/photo-1616893904984-7a57a3b35338?q=80&w=1964&auto=format&fit=crop",
+    "storyAlt": "Brand story",
+    "sourcingAlt": "Sourcing argan oil"
+  },
   "footer": {
     "legalName": "Kapunka Skincare",
     "socialLinks": [

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -2,10 +2,18 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { motion } from 'framer-motion';
 import { useLanguage } from '../contexts/LanguageContext';
+import { useSiteSettings } from '../contexts/SiteSettingsContext';
 
 const About: React.FC = () => {
     const { t, language } = useLanguage();
+    const { settings } = useSiteSettings();
     const aboutFieldPath = `translations.${language}.about`;
+    const defaultStoryImage = 'https://images.unsplash.com/photo-1598555769781-8714b14a293f?q=80&w=1974&auto=format&fit=crop';
+    const defaultSourcingImage = 'https://images.unsplash.com/photo-1616893904984-7a57a3b35338?q=80&w=1964&auto=format&fit=crop';
+    const storyImage = settings.about?.storyImage || defaultStoryImage;
+    const sourcingImage = settings.about?.sourcingImage || defaultSourcingImage;
+    const storyAlt = settings.about?.storyAlt || 'Brand story';
+    const sourcingAlt = settings.about?.sourcingAlt || t('about.sourcingImageAlt');
   return (
     <div>
         <Helmet>
@@ -66,9 +74,10 @@ const About: React.FC = () => {
                 transition={{ duration: 0.6 }}
             >
               <img
-                src="https://images.unsplash.com/photo-1598555769781-8714b14a293f?q=80&w=1974&auto=format&fit=crop"
-                alt="Brand story"
+                src={storyImage}
+                alt={storyAlt}
                 className="rounded-lg shadow-lg"
+                data-nlv-field-path="site.about.storyImage"
               />
             </motion.div>
           </div>
@@ -104,10 +113,10 @@ const About: React.FC = () => {
                 className="md:order-1"
             >
               <img
-                src="https://images.unsplash.com/photo-1616893904984-7a57a3b35338?q=80&w=1964&auto=format&fit=crop"
-                alt={t('about.sourcingImageAlt')}
+                src={sourcingImage}
+                alt={sourcingAlt}
                 className="rounded-lg shadow-lg"
-                data-nlv-field-path={`${aboutFieldPath}.sourcingImageAlt`}
+                data-nlv-field-path="site.about.sourcingImage"
               />
             </motion.div>
           </div>

--- a/types.ts
+++ b/types.ts
@@ -151,6 +151,12 @@ export interface SiteSettings {
         phone: string;
         whatsapp: string;
     };
+    about?: {
+        storyImage?: string;
+        sourcingImage?: string;
+        storyAlt?: string;
+        sourcingAlt?: string;
+    };
     footer?: {
         legalName?: string;
         socialLinks?: SocialLink[];


### PR DESCRIPTION
## Summary
- add About image and alt fields to the site settings schema and CMS configuration with editor guidance
- extend site settings types and About page to read imagery from CMS with sensible defaults

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d561f9fef0832083b9959ace6af62e