### PR TITLE
Add videos and training pages with CMS integrations

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -25,6 +25,8 @@ import CartPage from './pages/CartPage';
 import PolicyPage from './pages/PolicyPage';
 import Academy from './pages/Academy';
 import Method from './pages/Method';
+import Videos from './pages/Videos';
+import Training from './pages/Training';
 
 const pageVariants = {
   initial: {
@@ -105,6 +107,8 @@ const AnimatedRoutes: React.FC = () => {
         <Route path="/product/:id" element={<PageWrapper pageKey="product"><ProductDetail /></PageWrapper>} />
         <Route path="/learn" element={<PageWrapper pageKey="learn"><Learn /></PageWrapper>} />
         <Route path="/learn/:slug" element={<PageWrapper pageKey="article"><ArticlePage /></PageWrapper>} />
+        <Route path="/videos" element={<PageWrapper pageKey="videos"><Videos /></PageWrapper>} />
+        <Route path="/training" element={<PageWrapper pageKey="training"><Training /></PageWrapper>} />
         <Route path="/method" element={<PageWrapper pageKey="method"><Method /></PageWrapper>} />
         <Route path="/for-clinics" element={<PageWrapper pageKey="clinics"><ForClinics /></PageWrapper>} />
         <Route path="/academy" element={<PageWrapper pageKey="academy"><Academy /></PageWrapper>} />

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -81,6 +81,12 @@ collections:
                   - '^https://'
                   - "Please enter a secure HTTPS link."
                 required: false
+          - label: Feature Flags
+            name: featureFlags
+            widget: object
+            fields:
+              - { label: Enable Videos Page, name: videos, widget: boolean, default: false, required: false }
+              - { label: Enable Training Page, name: training, widget: boolean, default: false, required: false }
           - label: Footer
             name: footer
             widget: object
@@ -256,6 +262,147 @@ collections:
                       - { label: Title, name: title, widget: text }
                       - { label: Description, name: description, widget: markdown }
                       - { label: Image, name: image, widget: image, choose_url: true, required: false }
+      - name: videos_en
+        label: Videos Page (English)
+        file: content/pages/en/videos.json
+        format: json
+        fields:
+          - label: Sections
+            name: sections
+            widget: list
+            types:
+              - label: Video Gallery
+                name: videoGallery
+                widget: object
+                fields:
+                  - { label: Title, name: title, widget: string, required: false }
+                  - { label: Description, name: description, widget: text, required: false }
+                  - label: Videos
+                    name: entries
+                    widget: list
+                    summary: "{{fields.title}}"
+                    fields:
+                      - { label: Title, name: title, widget: string, required: false }
+                      - { label: Description, name: description, widget: text, required: false }
+                      - { label: Video URL, name: videoUrl, widget: string, required: false }
+                      - { label: Thumbnail, name: thumbnail, widget: image, choose_url: true, required: false }
+      - name: videos_pt
+        label: Videos Page (Portuguese)
+        file: content/pages/pt/videos.json
+        format: json
+        fields:
+          - label: Sections
+            name: sections
+            widget: list
+            types:
+              - label: Video Gallery
+                name: videoGallery
+                widget: object
+                fields:
+                  - { label: Title, name: title, widget: string, required: false }
+                  - { label: Description, name: description, widget: text, required: false }
+                  - label: Videos
+                    name: entries
+                    widget: list
+                    summary: "{{fields.title}}"
+                    fields:
+                      - { label: Title, name: title, widget: string, required: false }
+                      - { label: Description, name: description, widget: text, required: false }
+                      - { label: Video URL, name: videoUrl, widget: string, required: false }
+                      - { label: Thumbnail, name: thumbnail, widget: image, choose_url: true, required: false }
+      - name: videos_es
+        label: Videos Page (Spanish)
+        file: content/pages/es/videos.json
+        format: json
+        fields:
+          - label: Sections
+            name: sections
+            widget: list
+            types:
+              - label: Video Gallery
+                name: videoGallery
+                widget: object
+                fields:
+                  - { label: Title, name: title, widget: string, required: false }
+                  - { label: Description, name: description, widget: text, required: false }
+                  - label: Videos
+                    name: entries
+                    widget: list
+                    summary: "{{fields.title}}"
+                    fields:
+                      - { label: Title, name: title, widget: string, required: false }
+                      - { label: Description, name: description, widget: text, required: false }
+                      - { label: Video URL, name: videoUrl, widget: string, required: false }
+                      - { label: Thumbnail, name: thumbnail, widget: image, choose_url: true, required: false }
+      - name: training_en
+        label: Training Page (English)
+        file: content/pages/en/training.json
+        format: json
+        fields:
+          - label: Sections
+            name: sections
+            widget: list
+            types:
+              - label: Training List
+                name: trainingList
+                widget: object
+                fields:
+                  - { label: Title, name: title, widget: string, required: false }
+                  - { label: Description, name: description, widget: text, required: false }
+                  - label: Trainings
+                    name: entries
+                    widget: list
+                    summary: "{{fields.courseTitle}}"
+                    fields:
+                      - { label: Course Title, name: courseTitle, widget: string, required: false }
+                      - { label: Course Summary, name: courseSummary, widget: text, required: false }
+                      - { label: Link URL, name: linkUrl, widget: string, required: false }
+      - name: training_pt
+        label: Training Page (Portuguese)
+        file: content/pages/pt/training.json
+        format: json
+        fields:
+          - label: Sections
+            name: sections
+            widget: list
+            types:
+              - label: Training List
+                name: trainingList
+                widget: object
+                fields:
+                  - { label: Title, name: title, widget: string, required: false }
+                  - { label: Description, name: description, widget: text, required: false }
+                  - label: Trainings
+                    name: entries
+                    widget: list
+                    summary: "{{fields.courseTitle}}"
+                    fields:
+                      - { label: Course Title, name: courseTitle, widget: string, required: false }
+                      - { label: Course Summary, name: courseSummary, widget: text, required: false }
+                      - { label: Link URL, name: linkUrl, widget: string, required: false }
+      - name: training_es
+        label: Training Page (Spanish)
+        file: content/pages/es/training.json
+        format: json
+        fields:
+          - label: Sections
+            name: sections
+            widget: list
+            types:
+              - label: Training List
+                name: trainingList
+                widget: object
+                fields:
+                  - { label: Title, name: title, widget: string, required: false }
+                  - { label: Description, name: description, widget: text, required: false }
+                  - label: Trainings
+                    name: entries
+                    widget: list
+                    summary: "{{fields.courseTitle}}"
+                    fields:
+                      - { label: Course Title, name: courseTitle, widget: string, required: false }
+                      - { label: Course Summary, name: courseSummary, widget: text, required: false }
+                      - { label: Link URL, name: linkUrl, widget: string, required: false }
   - name: translations
     label: Translations
     files:
@@ -271,6 +418,8 @@ collections:
             fields:
               - { label: Shop Link, name: shop, widget: string }
               - { label: Learn Link, name: learn, widget: string }
+              - { label: Videos Link, name: videos, widget: string }
+              - { label: Training Link, name: training, widget: string }
               - { label: Method Link, name: method, widget: string }
               - { label: Clinics Link, name: forClinics, widget: string }
               - { label: About Link, name: about, widget: string }
@@ -645,6 +794,50 @@ collections:
             label: Portuguese
             name: pt
           - <<: *learn_fields
+            label: Spanish
+            name: es
+      - name: videos
+        label: Videos Page
+        file: content/translations/videos.json
+        format: json
+        fields:
+          - &videos_fields
+            label: English
+            name: en
+            widget: object
+            fields:
+              - { label: Meta Title, name: metaTitle, widget: string }
+              - { label: Meta Description, name: metaDescription, widget: text }
+              - { label: Page Title, name: title, widget: string }
+              - { label: Subtitle, name: subtitle, widget: text }
+              - { label: Empty State Copy, name: emptyState, widget: text }
+              - { label: Watch Label, name: watchLabel, widget: string }
+          - <<: *videos_fields
+            label: Portuguese
+            name: pt
+          - <<: *videos_fields
+            label: Spanish
+            name: es
+      - name: training
+        label: Training Page
+        file: content/translations/training.json
+        format: json
+        fields:
+          - &training_fields
+            label: English
+            name: en
+            widget: object
+            fields:
+              - { label: Meta Title, name: metaTitle, widget: string }
+              - { label: Meta Description, name: metaDescription, widget: text }
+              - { label: Page Title, name: title, widget: string }
+              - { label: Subtitle, name: subtitle, widget: text }
+              - { label: Empty State Copy, name: emptyState, widget: text }
+              - { label: Learn More Label, name: learnMore, widget: string }
+          - <<: *training_fields
+            label: Portuguese
+            name: pt
+          - <<: *training_fields
             label: Spanish
             name: es
       - name: about
@@ -1329,6 +1522,39 @@ collections:
               - { label: Image, name: imageUrl, widget: image, choose_url: true }
               - { label: Price, name: price, widget: number, value_type: float }
               - { label: Enroll Link, name: enrollLink, widget: string }
+  - name: videoEntries
+    label: Video Entries
+    files:
+      - name: videos
+        label: Video Library
+        file: content/videos.json
+        format: json
+        fields:
+          - label: Videos
+            name: videos
+            widget: list
+            summary: "{{fields.title}}"
+            fields:
+              - { label: Title, name: title, widget: string, required: false }
+              - { label: Description, name: description, widget: text, required: false }
+              - { label: Video URL, name: videoUrl, widget: string, required: false }
+              - { label: Thumbnail, name: thumbnail, widget: image, choose_url: true, required: false }
+  - name: trainingEntries
+    label: Training Entries
+    files:
+      - name: training
+        label: Training Catalog
+        file: content/training.json
+        format: json
+        fields:
+          - label: Trainings
+            name: trainings
+            widget: list
+            summary: "{{fields.courseTitle}}"
+            fields:
+              - { label: Course Title, name: courseTitle, widget: string, required: false }
+              - { label: Course Summary, name: courseSummary, widget: text, required: false }
+              - { label: Link URL, name: linkUrl, widget: string, required: false }
   - name: doctors
     label: Doctors
     files:

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -80,14 +80,22 @@ const Header: React.FC = () => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  const featureFlags = settings.featureFlags ?? {};
+
   const navLinks = [
     { to: '/shop', label: t('nav.shop'), fieldPath: `translations.${language}.nav.shop` },
     { to: '/learn', label: t('nav.learn'), fieldPath: `translations.${language}.nav.learn` },
+    featureFlags.videos
+      ? { to: '/videos', label: t('nav.videos'), fieldPath: `translations.${language}.nav.videos` }
+      : null,
+    featureFlags.training
+      ? { to: '/training', label: t('nav.training'), fieldPath: `translations.${language}.nav.training` }
+      : null,
     { to: '/method', label: t('nav.method'), fieldPath: `translations.${language}.nav.method` },
     { to: '/for-clinics', label: t('nav.forClinics'), fieldPath: `translations.${language}.nav.forClinics` },
     { to: '/about', label: t('nav.about'), fieldPath: `translations.${language}.nav.about` },
     { to: '/contact', label: t('nav.contact'), fieldPath: `translations.${language}.nav.contact` },
-  ];
+  ].filter((link): link is { to: string; label: string; fieldPath: string } => link !== null);
 
   return (
     <>

--- a/components/SectionRenderer.tsx
+++ b/components/SectionRenderer.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import TimelineSection from './TimelineSection';
 import ImageTextHalf from './sections/ImageTextHalf';
 import ImageGrid from './sections/ImageGrid';
+import VideoGallery from './VideoGallery';
+import TrainingList from './TrainingList';
 import type { PageSection } from '../types';
 
 interface SectionRendererProps {
@@ -44,6 +46,26 @@ const SectionRenderer: React.FC<SectionRendererProps> = ({ sections, fieldPath }
               <ImageGrid
                 key={`image-grid-${index}`}
                 items={section.items}
+                fieldPath={sectionFieldPath}
+              />
+            );
+          case 'videoGallery':
+            return (
+              <VideoGallery
+                key={`video-gallery-${index}`}
+                title={section.title}
+                description={section.description}
+                entries={section.entries}
+                fieldPath={sectionFieldPath}
+              />
+            );
+          case 'trainingList':
+            return (
+              <TrainingList
+                key={`training-list-${index}`}
+                title={section.title}
+                description={section.description}
+                entries={section.entries}
                 fieldPath={sectionFieldPath}
               />
             );

--- a/components/TrainingList.tsx
+++ b/components/TrainingList.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+import type { TrainingCatalogContent, TrainingEntry } from '../types';
+import { useLanguage } from '../contexts/LanguageContext';
+
+interface TrainingListProps {
+  title?: string;
+  description?: string;
+  entries?: TrainingEntry[];
+  fieldPath?: string;
+}
+
+const loadTrainingCatalog = async (): Promise<TrainingEntry[]> => {
+  try {
+    const response = await fetch('/content/training.json');
+    if (!response.ok) {
+      return [];
+    }
+
+    const data = (await response.json()) as TrainingCatalogContent;
+    if (!data || !Array.isArray(data.trainings)) {
+      return [];
+    }
+
+    return data.trainings.filter((entry): entry is TrainingEntry => typeof entry === 'object' && entry !== null);
+  } catch (error) {
+    console.error('Failed to load training entries', error);
+    return [];
+  }
+};
+
+const TrainingList: React.FC<TrainingListProps> = ({ title, description, entries, fieldPath }) => {
+  const [catalogEntries, setCatalogEntries] = useState<TrainingEntry[]>([]);
+  const { t, language } = useLanguage();
+
+  useEffect(() => {
+    if (entries && entries.length > 0) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const fetchTrainings = async () => {
+      const trainings = await loadTrainingCatalog();
+      if (isMounted) {
+        setCatalogEntries(trainings);
+      }
+    };
+
+    void fetchTrainings();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [entries]);
+
+  const items = useMemo(() => {
+    if (entries && entries.length > 0) {
+      return entries;
+    }
+    return catalogEntries;
+  }, [entries, catalogEntries]);
+
+  if (!title && !description && items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="py-16 sm:py-24" data-nlv-field-path={fieldPath}>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        {(title || description) && (
+          <div className="mb-12 max-w-3xl">
+            {title && (
+              <motion.h2
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.5 }}
+                className="text-3xl sm:text-4xl font-semibold tracking-tight text-stone-900"
+                data-nlv-field-path={fieldPath ? `${fieldPath}.title` : undefined}
+              >
+                {title}
+              </motion.h2>
+            )}
+            {description && (
+              <motion.p
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.5, delay: 0.05 }}
+                className="mt-4 text-lg text-stone-600"
+                data-nlv-field-path={fieldPath ? `${fieldPath}.description` : undefined}
+              >
+                {description}
+              </motion.p>
+            )}
+          </div>
+        )}
+
+        {items.length === 0 ? (
+          <p
+            className="text-stone-500"
+            data-nlv-field-path={`translations.${language}.training.emptyState`}
+          >
+            {t('training.emptyState')}
+          </p>
+        ) : (
+          <div className="grid gap-8 md:grid-cols-2">
+            {items.map((item, index) => {
+              const key = `${item.courseTitle ?? 'training'}-${index}`;
+              const itemFieldPath = fieldPath ? `${fieldPath}.entries.${index}` : undefined;
+
+              return (
+                <motion.article
+                  key={key}
+                  initial={{ opacity: 0, y: 24 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.45, delay: index * 0.05 }}
+                  className="flex h-full flex-col justify-between rounded-3xl border border-stone-200 bg-white p-8 shadow-sm shadow-stone-100"
+                  data-nlv-field-path={itemFieldPath}
+                >
+                  <div>
+                    {item.courseTitle && (
+                      <h3
+                        className="text-xl font-semibold text-stone-900"
+                        data-nlv-field-path={itemFieldPath ? `${itemFieldPath}.courseTitle` : undefined}
+                      >
+                        {item.courseTitle}
+                      </h3>
+                    )}
+                    {item.courseSummary && (
+                      <p
+                        className="mt-4 text-sm text-stone-600"
+                        data-nlv-field-path={itemFieldPath ? `${itemFieldPath}.courseSummary` : undefined}
+                      >
+                        {item.courseSummary}
+                      </p>
+                    )}
+                  </div>
+                  <div className="mt-6 flex items-center gap-3">
+                    <a
+                      href={item.linkUrl ?? '#'}
+                      className={`inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-semibold transition ${
+                        item.linkUrl
+                          ? 'bg-stone-900 text-white hover:bg-stone-700'
+                          : 'cursor-not-allowed bg-stone-200 text-stone-500'
+                      }`}
+                      target={item.linkUrl ? '_blank' : undefined}
+                      rel={item.linkUrl ? 'noopener noreferrer' : undefined}
+                      aria-disabled={!item.linkUrl}
+                      data-nlv-field-path={itemFieldPath ? `${itemFieldPath}.linkUrl` : undefined}
+                    >
+                      <span data-nlv-field-path={`translations.${language}.training.learnMore`}>
+                        {t('training.learnMore')}
+                      </span>
+                    </a>
+                  </div>
+                </motion.article>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default TrainingList;

--- a/components/VideoGallery.tsx
+++ b/components/VideoGallery.tsx
@@ -1,0 +1,188 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Play } from 'lucide-react';
+import type { VideoEntry, VideoLibraryContent } from '../types';
+import { useLanguage } from '../contexts/LanguageContext';
+
+interface VideoGalleryProps {
+  title?: string;
+  description?: string;
+  entries?: VideoEntry[];
+  fieldPath?: string;
+}
+
+const placeholderThumbnailClasses =
+  'flex h-48 items-center justify-center rounded-xl bg-stone-200 text-stone-500';
+
+const loadVideoLibrary = async (): Promise<VideoEntry[]> => {
+  try {
+    const response = await fetch('/content/videos.json');
+    if (!response.ok) {
+      return [];
+    }
+
+    const data = (await response.json()) as VideoLibraryContent;
+    if (!data || !Array.isArray(data.videos)) {
+      return [];
+    }
+
+    return data.videos.filter((video): video is VideoEntry => typeof video === 'object' && video !== null);
+  } catch (error) {
+    console.error('Failed to load video entries', error);
+    return [];
+  }
+};
+
+const VideoGallery: React.FC<VideoGalleryProps> = ({ title, description, entries, fieldPath }) => {
+  const [libraryEntries, setLibraryEntries] = useState<VideoEntry[]>([]);
+  const { t, language } = useLanguage();
+
+  useEffect(() => {
+    if (entries && entries.length > 0) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const fetchVideos = async () => {
+      const videos = await loadVideoLibrary();
+      if (isMounted) {
+        setLibraryEntries(videos);
+      }
+    };
+
+    void fetchVideos();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [entries]);
+
+  const items = useMemo(() => {
+    if (entries && entries.length > 0) {
+      return entries;
+    }
+    return libraryEntries;
+  }, [entries, libraryEntries]);
+
+  if (!title && !description && items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="py-16 sm:py-24" data-nlv-field-path={fieldPath}>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        {(title || description) && (
+          <div className="mb-12 max-w-3xl">
+            {title && (
+              <motion.h2
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.5 }}
+                className="text-3xl sm:text-4xl font-semibold tracking-tight text-stone-900"
+                data-nlv-field-path={fieldPath ? `${fieldPath}.title` : undefined}
+              >
+                {title}
+              </motion.h2>
+            )}
+            {description && (
+              <motion.p
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.5, delay: 0.05 }}
+                className="mt-4 text-lg text-stone-600"
+                data-nlv-field-path={fieldPath ? `${fieldPath}.description` : undefined}
+              >
+                {description}
+              </motion.p>
+            )}
+          </div>
+        )}
+
+        {items.length === 0 ? (
+          <p
+            className="text-stone-500"
+            data-nlv-field-path={`translations.${language}.videos.emptyState`}
+          >
+            {t('videos.emptyState')}
+          </p>
+        ) : (
+          <div className="grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
+            {items.map((item, index) => {
+              const key = `${item.title ?? 'video'}-${index}`;
+              const itemFieldPath = fieldPath ? `${fieldPath}.entries.${index}` : undefined;
+              const hasThumbnail = typeof item.thumbnail === 'string' && item.thumbnail.trim().length > 0;
+
+              return (
+                <motion.article
+                  key={key}
+                  initial={{ opacity: 0, y: 24 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.45, delay: index * 0.05 }}
+                  className="rounded-3xl bg-white p-6 shadow-sm shadow-stone-200"
+                  data-nlv-field-path={itemFieldPath}
+                >
+                  <div className="relative overflow-hidden rounded-xl">
+                    {hasThumbnail ? (
+                      <img
+                        src={item.thumbnail}
+                        alt={item.title ?? 'Video thumbnail'}
+                        className="h-48 w-full object-cover"
+                        loading="lazy"
+                        data-nlv-field-path={itemFieldPath ? `${itemFieldPath}.thumbnail` : undefined}
+                      />
+                    ) : (
+                      <div className={placeholderThumbnailClasses}>Thumbnail coming soon</div>
+                    )}
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/80 backdrop-blur">
+                        <Play className="h-6 w-6 text-stone-800" />
+                      </div>
+                    </div>
+                  </div>
+
+                  {item.title && (
+                    <h3
+                      className="mt-6 text-xl font-semibold text-stone-900"
+                      data-nlv-field-path={itemFieldPath ? `${itemFieldPath}.title` : undefined}
+                    >
+                      {item.title}
+                    </h3>
+                  )}
+
+                  {item.description && (
+                    <p
+                      className="mt-3 text-sm text-stone-600"
+                      data-nlv-field-path={itemFieldPath ? `${itemFieldPath}.description` : undefined}
+                    >
+                      {item.description}
+                    </p>
+                  )}
+
+                  {item.videoUrl && (
+                    <a
+                      href={item.videoUrl}
+                      className="mt-6 inline-flex items-center text-sm font-semibold text-stone-900 underline decoration-stone-300 decoration-2 underline-offset-4 transition hover:decoration-stone-500"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      data-nlv-field-path={itemFieldPath ? `${itemFieldPath}.videoUrl` : undefined}
+                    >
+                      <span data-nlv-field-path={`translations.${language}.videos.watchLabel`}>
+                        {t('videos.watchLabel')}
+                      </span>
+                    </a>
+                  )}
+                </motion.article>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default VideoGallery;

--- a/content/pages/en/training.json
+++ b/content/pages/en/training.json
@@ -1,0 +1,11 @@
+{
+  "sections": [
+    {
+      "type": "trainingList",
+      "title": "",
+      "description": "",
+      "entries": []
+    }
+  ],
+  "type": "page"
+}

--- a/content/pages/en/videos.json
+++ b/content/pages/en/videos.json
@@ -1,0 +1,11 @@
+{
+  "sections": [
+    {
+      "type": "videoGallery",
+      "title": "",
+      "description": "",
+      "entries": []
+    }
+  ],
+  "type": "page"
+}

--- a/content/pages/es/training.json
+++ b/content/pages/es/training.json
@@ -1,0 +1,11 @@
+{
+  "sections": [
+    {
+      "type": "trainingList",
+      "title": "",
+      "description": "",
+      "entries": []
+    }
+  ],
+  "type": "page"
+}

--- a/content/pages/es/videos.json
+++ b/content/pages/es/videos.json
@@ -1,0 +1,11 @@
+{
+  "sections": [
+    {
+      "type": "videoGallery",
+      "title": "",
+      "description": "",
+      "entries": []
+    }
+  ],
+  "type": "page"
+}

--- a/content/pages/pt/training.json
+++ b/content/pages/pt/training.json
@@ -1,0 +1,11 @@
+{
+  "sections": [
+    {
+      "type": "trainingList",
+      "title": "",
+      "description": "",
+      "entries": []
+    }
+  ],
+  "type": "page"
+}

--- a/content/pages/pt/videos.json
+++ b/content/pages/pt/videos.json
@@ -1,0 +1,11 @@
+{
+  "sections": [
+    {
+      "type": "videoGallery",
+      "title": "",
+      "description": "",
+      "entries": []
+    }
+  ],
+  "type": "page"
+}

--- a/content/site.json
+++ b/content/site.json
@@ -24,6 +24,10 @@
   "clinics": {
     "ctaLink": "https://kapunka.com/#/contact"
   },
+  "featureFlags": {
+    "videos": false,
+    "training": false
+  },
   "footer": {
     "legalName": "Kapunka Skincare",
     "socialLinks": [

--- a/content/training.json
+++ b/content/training.json
@@ -1,0 +1,19 @@
+{
+  "trainings": [
+    {
+      "courseTitle": "",
+      "courseSummary": "",
+      "linkUrl": ""
+    },
+    {
+      "courseTitle": "",
+      "courseSummary": "",
+      "linkUrl": ""
+    },
+    {
+      "courseTitle": "",
+      "courseSummary": "",
+      "linkUrl": ""
+    }
+  ]
+}

--- a/content/translations/nav.json
+++ b/content/translations/nav.json
@@ -2,6 +2,8 @@
   "en": {
     "shop": "Shop",
     "learn": "Learn",
+    "videos": "Videos",
+    "training": "Training",
     "method": "Method",
     "forClinics": "For Clinics",
     "about": "About",
@@ -10,6 +12,8 @@
   "pt": {
     "shop": "Loja",
     "learn": "Aprender",
+    "videos": "Vídeos",
+    "training": "Treinamento",
     "method": "Método",
     "forClinics": "Para Clínicas",
     "about": "Sobre",
@@ -18,6 +22,8 @@
   "es": {
     "shop": "Tienda",
     "learn": "Aprender",
+    "videos": "Videos",
+    "training": "Formación",
     "method": "Método",
     "forClinics": "Para Clínicas",
     "about": "Nosotros",

--- a/content/translations/training.json
+++ b/content/translations/training.json
@@ -1,0 +1,26 @@
+{
+  "en": {
+    "title": "Training Hub",
+    "subtitle": "Stay ahead with courses and professional content curated for practitioners and partners.",
+    "metaTitle": "Training Hub",
+    "metaDescription": "Browse Kapunka's training catalog featuring professional development, product education, and partner resources.",
+    "emptyState": "Training resources are coming soon.",
+    "learnMore": "Learn More"
+  },
+  "pt": {
+    "title": "Centro de Treinamento",
+    "subtitle": "Atualize-se com cursos e conteúdos profissionais selecionados para praticantes e parceiros.",
+    "metaTitle": "Centro de Treinamento",
+    "metaDescription": "Conheça o catálogo de treinamentos Kapunka com desenvolvimento profissional, educação sobre produtos e recursos para parceiros.",
+    "emptyState": "Os recursos de treinamento estarão disponíveis em breve.",
+    "learnMore": "Saiba mais"
+  },
+  "es": {
+    "title": "Centro de Formación",
+    "subtitle": "Mantente al día con cursos y contenidos profesionales creados para practicantes y socios.",
+    "metaTitle": "Centro de Formación",
+    "metaDescription": "Explora el catálogo de formación de Kapunka con desarrollo profesional, educación sobre productos y recursos para socios.",
+    "emptyState": "Los recursos de formación estarán disponibles pronto.",
+    "learnMore": "Más información"
+  }
+}

--- a/content/translations/videos.json
+++ b/content/translations/videos.json
@@ -1,0 +1,26 @@
+{
+  "en": {
+    "title": "Video Library",
+    "subtitle": "Discover tutorials, rituals, and behind-the-scenes moments from the Kapunka world.",
+    "metaTitle": "Video Library",
+    "metaDescription": "Explore Kapunka's video tutorials, founder stories, and educational moments curated for our community.",
+    "emptyState": "Video programming is coming soon.",
+    "watchLabel": "Watch Video"
+  },
+  "pt": {
+    "title": "Videoteca",
+    "subtitle": "Descubra tutoriais, rituais e bastidores do universo Kapunka.",
+    "metaTitle": "Videoteca",
+    "metaDescription": "Explore tutoriais em vídeo, histórias da marca e conteúdos educativos Kapunka para a nossa comunidade.",
+    "emptyState": "Os vídeos estarão disponíveis em breve.",
+    "watchLabel": "Assistir ao vídeo"
+  },
+  "es": {
+    "title": "Videoteca",
+    "subtitle": "Descubre tutoriales, rituales y momentos detrás de escena del mundo Kapunka.",
+    "metaTitle": "Videoteca",
+    "metaDescription": "Explora los tutoriales en video, historias de la marca y contenidos educativos de Kapunka para nuestra comunidad.",
+    "emptyState": "El contenido en video estará disponible pronto.",
+    "watchLabel": "Ver video"
+  }
+}

--- a/content/videos.json
+++ b/content/videos.json
@@ -1,0 +1,22 @@
+{
+  "videos": [
+    {
+      "title": "",
+      "description": "",
+      "videoUrl": "",
+      "thumbnail": ""
+    },
+    {
+      "title": "",
+      "description": "",
+      "videoUrl": "",
+      "thumbnail": ""
+    },
+    {
+      "title": "",
+      "description": "",
+      "videoUrl": "",
+      "thumbnail": ""
+    }
+  ]
+}

--- a/metadata.json
+++ b/metadata.json
@@ -102,6 +102,24 @@
       "label": "Policies",
       "urlPath": "/policy/{id}",
       "collectionId": "policies"
+    },
+    {
+      "id": "videos",
+      "label": "Videos",
+      "urlPath": "/videos",
+      "page": {
+        "type": "static",
+        "filePath": "pages/Videos.tsx"
+      }
+    },
+    {
+      "id": "training",
+      "label": "Training",
+      "urlPath": "/training",
+      "page": {
+        "type": "static",
+        "filePath": "pages/Training.tsx"
+      }
     }
   ],
   "collections": [
@@ -425,6 +443,23 @@
                   "type": "text"
                 }
               ]
+            }
+          ]
+        },
+        {
+          "name": "featureFlags",
+          "label": "Feature Flags",
+          "type": "object",
+          "fields": [
+            {
+              "name": "videos",
+              "label": "Enable Videos Page",
+              "type": "boolean"
+            },
+            {
+              "name": "training",
+              "label": "Enable Training Page",
+              "type": "boolean"
             }
           ]
         }
@@ -2002,6 +2037,16 @@
               "type": "string"
             },
             {
+              "name": "videos",
+              "label": "Videos Link",
+              "type": "string"
+            },
+            {
+              "name": "training",
+              "label": "Training Link",
+              "type": "string"
+            },
+            {
               "name": "method",
               "label": "Method Link",
               "type": "string"
@@ -2039,6 +2084,16 @@
               "type": "string"
             },
             {
+              "name": "videos",
+              "label": "Videos Link",
+              "type": "string"
+            },
+            {
+              "name": "training",
+              "label": "Training Link",
+              "type": "string"
+            },
+            {
               "name": "method",
               "label": "Method Link",
               "type": "string"
@@ -2073,6 +2128,16 @@
             {
               "name": "learn",
               "label": "Learn Link",
+              "type": "string"
+            },
+            {
+              "name": "videos",
+              "label": "Videos Link",
+              "type": "string"
+            },
+            {
+              "name": "training",
+              "label": "Training Link",
               "type": "string"
             },
             {
@@ -5924,6 +5989,319 @@
             {
               "name": "partnersTitle",
               "label": "Partners Title",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "videos",
+      "label": "Videos",
+      "type": "data",
+      "singleInstance": true,
+      "filePath": "content/videos.json",
+      "fields": [
+        {
+          "name": "videos",
+          "label": "Videos",
+          "type": "list",
+          "items": {
+            "type": "object",
+            "fields": [
+              {
+                "name": "title",
+                "label": "Title",
+                "type": "string"
+              },
+              {
+                "name": "description",
+                "label": "Description",
+                "type": "text"
+              },
+              {
+                "name": "videoUrl",
+                "label": "Video URL",
+                "type": "string"
+              },
+              {
+                "name": "thumbnail",
+                "label": "Thumbnail",
+                "type": "image"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "training",
+      "label": "Training",
+      "type": "data",
+      "singleInstance": true,
+      "filePath": "content/training.json",
+      "fields": [
+        {
+          "name": "trainings",
+          "label": "Trainings",
+          "type": "list",
+          "items": {
+            "type": "object",
+            "fields": [
+              {
+                "name": "courseTitle",
+                "label": "Course Title",
+                "type": "string"
+              },
+              {
+                "name": "courseSummary",
+                "label": "Course Summary",
+                "type": "text"
+              },
+              {
+                "name": "linkUrl",
+                "label": "Link URL",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "translations_videos",
+      "label": "Videos Page",
+      "type": "data",
+      "singleInstance": true,
+      "filePath": "content/translations/videos.json",
+      "fields": [
+        {
+          "name": "en",
+          "label": "English",
+          "type": "object",
+          "fields": [
+            {
+              "name": "metaTitle",
+              "label": "Meta Title",
+              "type": "string"
+            },
+            {
+              "name": "metaDescription",
+              "label": "Meta Description",
+              "type": "text"
+            },
+            {
+              "name": "title",
+              "label": "Page Title",
+              "type": "string"
+            },
+            {
+              "name": "subtitle",
+              "label": "Subtitle",
+              "type": "text"
+            },
+            {
+              "name": "emptyState",
+              "label": "Empty State Copy",
+              "type": "text"
+            },
+            {
+              "name": "watchLabel",
+              "label": "Watch Label",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "pt",
+          "label": "Portuguese",
+          "type": "object",
+          "fields": [
+            {
+              "name": "metaTitle",
+              "label": "Meta Title",
+              "type": "string"
+            },
+            {
+              "name": "metaDescription",
+              "label": "Meta Description",
+              "type": "text"
+            },
+            {
+              "name": "title",
+              "label": "Page Title",
+              "type": "string"
+            },
+            {
+              "name": "subtitle",
+              "label": "Subtitle",
+              "type": "text"
+            },
+            {
+              "name": "emptyState",
+              "label": "Empty State Copy",
+              "type": "text"
+            },
+            {
+              "name": "watchLabel",
+              "label": "Watch Label",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "es",
+          "label": "Spanish",
+          "type": "object",
+          "fields": [
+            {
+              "name": "metaTitle",
+              "label": "Meta Title",
+              "type": "string"
+            },
+            {
+              "name": "metaDescription",
+              "label": "Meta Description",
+              "type": "text"
+            },
+            {
+              "name": "title",
+              "label": "Page Title",
+              "type": "string"
+            },
+            {
+              "name": "subtitle",
+              "label": "Subtitle",
+              "type": "text"
+            },
+            {
+              "name": "emptyState",
+              "label": "Empty State Copy",
+              "type": "text"
+            },
+            {
+              "name": "watchLabel",
+              "label": "Watch Label",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "translations_training",
+      "label": "Training Page",
+      "type": "data",
+      "singleInstance": true,
+      "filePath": "content/translations/training.json",
+      "fields": [
+        {
+          "name": "en",
+          "label": "English",
+          "type": "object",
+          "fields": [
+            {
+              "name": "metaTitle",
+              "label": "Meta Title",
+              "type": "string"
+            },
+            {
+              "name": "metaDescription",
+              "label": "Meta Description",
+              "type": "text"
+            },
+            {
+              "name": "title",
+              "label": "Page Title",
+              "type": "string"
+            },
+            {
+              "name": "subtitle",
+              "label": "Subtitle",
+              "type": "text"
+            },
+            {
+              "name": "emptyState",
+              "label": "Empty State Copy",
+              "type": "text"
+            },
+            {
+              "name": "learnMore",
+              "label": "Learn More Label",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "pt",
+          "label": "Portuguese",
+          "type": "object",
+          "fields": [
+            {
+              "name": "metaTitle",
+              "label": "Meta Title",
+              "type": "string"
+            },
+            {
+              "name": "metaDescription",
+              "label": "Meta Description",
+              "type": "text"
+            },
+            {
+              "name": "title",
+              "label": "Page Title",
+              "type": "string"
+            },
+            {
+              "name": "subtitle",
+              "label": "Subtitle",
+              "type": "text"
+            },
+            {
+              "name": "emptyState",
+              "label": "Empty State Copy",
+              "type": "text"
+            },
+            {
+              "name": "learnMore",
+              "label": "Learn More Label",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "es",
+          "label": "Spanish",
+          "type": "object",
+          "fields": [
+            {
+              "name": "metaTitle",
+              "label": "Meta Title",
+              "type": "string"
+            },
+            {
+              "name": "metaDescription",
+              "label": "Meta Description",
+              "type": "text"
+            },
+            {
+              "name": "title",
+              "label": "Page Title",
+              "type": "string"
+            },
+            {
+              "name": "subtitle",
+              "label": "Subtitle",
+              "type": "text"
+            },
+            {
+              "name": "emptyState",
+              "label": "Empty State Copy",
+              "type": "text"
+            },
+            {
+              "name": "learnMore",
+              "label": "Learn More Label",
               "type": "string"
             }
           ]

--- a/pages/Training.tsx
+++ b/pages/Training.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { motion } from 'framer-motion';
+import SectionRenderer from '../components/SectionRenderer';
+import { useLanguage } from '../contexts/LanguageContext';
+import type { PageContent, PageSection } from '../types';
+
+const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
+  'timeline',
+  'imageTextHalf',
+  'imageGrid',
+  'videoGallery',
+  'trainingList',
+]);
+
+const isPageSection = (value: unknown): value is PageSection => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const section = value as Record<string, unknown>;
+  const type = section.type;
+
+  if (typeof type !== 'string' || !SUPPORTED_SECTION_TYPES.has(type as PageSection['type'])) {
+    return false;
+  }
+
+  if (type === 'imageGrid') {
+    return Array.isArray(section.items);
+  }
+
+  if (type === 'timeline') {
+    return Array.isArray(section.entries);
+  }
+
+  if (type === 'imageTextHalf') {
+    return true;
+  }
+
+  if (type === 'videoGallery') {
+    return section.entries === undefined || Array.isArray(section.entries);
+  }
+
+  if (type === 'trainingList') {
+    return section.entries === undefined || Array.isArray(section.entries);
+  }
+
+  return false;
+};
+
+const isPageContent = (value: unknown): value is PageContent => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const content = value as Record<string, unknown>;
+  if (!Array.isArray(content.sections)) {
+    return false;
+  }
+
+  return content.sections.every(isPageSection);
+};
+
+const Training: React.FC = () => {
+  const { t, language } = useLanguage();
+  const [sections, setSections] = useState<PageSection[]>([]);
+
+  useEffect(() => {
+    let isMounted = true;
+    setSections([]);
+
+    const loadSections = async () => {
+      const localesToTry = [language, 'en'].filter((locale, index, arr) => arr.indexOf(locale) === index);
+
+      for (const locale of localesToTry) {
+        try {
+          const response = await fetch(`/content/pages/${locale}/training.json`);
+          if (!response.ok) {
+            continue;
+          }
+
+          const data = (await response.json()) as unknown;
+          if (!isMounted) {
+            return;
+          }
+
+          if (isPageContent(data)) {
+            setSections(data.sections);
+            return;
+          }
+        } catch (error) {
+          if (locale === localesToTry[localesToTry.length - 1]) {
+            console.error('Failed to load training page content', error);
+          }
+        }
+      }
+
+      if (isMounted) {
+        setSections([]);
+      }
+    };
+
+    void loadSections();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [language]);
+
+  const sectionsFieldPath = `pages.training_${language}.sections`;
+
+  return (
+    <div>
+      <Helmet>
+        <title>{`${t('training.metaTitle')} | Kapunka Skincare`}</title>
+        <meta name="description" content={t('training.metaDescription')} />
+      </Helmet>
+
+      <header className="py-20 sm:py-28 bg-stone-100">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <motion.h1
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+            className="text-4xl sm:text-5xl font-semibold tracking-tight"
+            data-nlv-field-path={`translations.${language}.training.title`}
+          >
+            {t('training.title')}
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+            className="mt-4 text-lg text-stone-600 max-w-2xl mx-auto"
+            data-nlv-field-path={`translations.${language}.training.subtitle`}
+          >
+            {t('training.subtitle')}
+          </motion.p>
+        </div>
+      </header>
+
+      {sections.length > 0 ? (
+        <SectionRenderer sections={sections} fieldPath={sectionsFieldPath} />
+      ) : (
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-16">
+          <p className="text-center text-stone-500" data-nlv-field-path={`translations.${language}.common.loading`}>
+            {t('common.loading')}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Training;

--- a/pages/Videos.tsx
+++ b/pages/Videos.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { motion } from 'framer-motion';
+import SectionRenderer from '../components/SectionRenderer';
+import { useLanguage } from '../contexts/LanguageContext';
+import type { PageContent, PageSection } from '../types';
+
+const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
+  'timeline',
+  'imageTextHalf',
+  'imageGrid',
+  'videoGallery',
+  'trainingList',
+]);
+
+const isPageSection = (value: unknown): value is PageSection => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const section = value as Record<string, unknown>;
+  const type = section.type;
+
+  if (typeof type !== 'string' || !SUPPORTED_SECTION_TYPES.has(type as PageSection['type'])) {
+    return false;
+  }
+
+  if (type === 'imageGrid') {
+    return Array.isArray(section.items);
+  }
+
+  if (type === 'timeline') {
+    return Array.isArray(section.entries);
+  }
+
+  if (type === 'imageTextHalf') {
+    return true;
+  }
+
+  if (type === 'videoGallery') {
+    return section.entries === undefined || Array.isArray(section.entries);
+  }
+
+  if (type === 'trainingList') {
+    return section.entries === undefined || Array.isArray(section.entries);
+  }
+
+  return false;
+};
+
+const isPageContent = (value: unknown): value is PageContent => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const content = value as Record<string, unknown>;
+  if (!Array.isArray(content.sections)) {
+    return false;
+  }
+
+  return content.sections.every(isPageSection);
+};
+
+const Videos: React.FC = () => {
+  const { t, language } = useLanguage();
+  const [sections, setSections] = useState<PageSection[]>([]);
+
+  useEffect(() => {
+    let isMounted = true;
+    setSections([]);
+
+    const loadSections = async () => {
+      const localesToTry = [language, 'en'].filter((locale, index, arr) => arr.indexOf(locale) === index);
+
+      for (const locale of localesToTry) {
+        try {
+          const response = await fetch(`/content/pages/${locale}/videos.json`);
+          if (!response.ok) {
+            continue;
+          }
+
+          const data = (await response.json()) as unknown;
+          if (!isMounted) {
+            return;
+          }
+
+          if (isPageContent(data)) {
+            setSections(data.sections);
+            return;
+          }
+        } catch (error) {
+          if (locale === localesToTry[localesToTry.length - 1]) {
+            console.error('Failed to load videos page content', error);
+          }
+        }
+      }
+
+      if (isMounted) {
+        setSections([]);
+      }
+    };
+
+    void loadSections();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [language]);
+
+  const sectionsFieldPath = `pages.videos_${language}.sections`;
+
+  return (
+    <div>
+      <Helmet>
+        <title>{`${t('videos.metaTitle')} | Kapunka Skincare`}</title>
+        <meta name="description" content={t('videos.metaDescription')} />
+      </Helmet>
+
+      <header className="py-20 sm:py-28 bg-stone-100">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <motion.h1
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+            className="text-4xl sm:text-5xl font-semibold tracking-tight"
+            data-nlv-field-path={`translations.${language}.videos.title`}
+          >
+            {t('videos.title')}
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+            className="mt-4 text-lg text-stone-600 max-w-2xl mx-auto"
+            data-nlv-field-path={`translations.${language}.videos.subtitle`}
+          >
+            {t('videos.subtitle')}
+          </motion.p>
+        </div>
+      </header>
+
+      {sections.length > 0 ? (
+        <SectionRenderer sections={sections} fieldPath={sectionsFieldPath} />
+      ) : (
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-16">
+          <p className="text-center text-stone-500" data-nlv-field-path={`translations.${language}.common.loading`}>
+            {t('common.loading')}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Videos;

--- a/stackbit.config.js
+++ b/stackbit.config.js
@@ -38,6 +38,16 @@ const pageModels = [
     urlPath: '/learn/{slug}',
   },
   {
+    name: 'videos',
+    type: 'page',
+    urlPath: '/videos',
+  },
+  {
+    name: 'training',
+    type: 'page',
+    urlPath: '/training',
+  },
+  {
     name: 'policies',
     type: 'page',
     urlPath: '/policy/{id}',

--- a/stackbit.config.mjs
+++ b/stackbit.config.mjs
@@ -33,6 +33,16 @@ const pageModels = [
     urlPath: '/learn/{slug}',
   },
   {
+    name: 'videos',
+    type: 'page',
+    urlPath: '/videos',
+  },
+  {
+    name: 'training',
+    type: 'page',
+    urlPath: '/training',
+  },
+  {
     name: 'policies',
     type: 'page',
     urlPath: '/policy/{id}',

--- a/types.ts
+++ b/types.ts
@@ -172,6 +172,10 @@ export interface SiteSettings {
         socialLinks?: SocialLink[];
     };
     seo?: SeoSettings;
+    featureFlags?: {
+        videos?: boolean;
+        training?: boolean;
+    };
 }
 
 export interface TimelineEntry {
@@ -205,12 +209,49 @@ export interface ImageGridSectionContent {
   items: ImageGridItem[];
 }
 
+export interface VideoEntry {
+  title?: string;
+  description?: string;
+  videoUrl?: string;
+  thumbnail?: string;
+}
+
+export interface VideoGallerySectionContent {
+  type: 'videoGallery';
+  title?: string;
+  description?: string;
+  entries?: VideoEntry[];
+}
+
+export interface TrainingEntry {
+  courseTitle?: string;
+  courseSummary?: string;
+  linkUrl?: string;
+}
+
+export interface TrainingListSectionContent {
+  type: 'trainingList';
+  title?: string;
+  description?: string;
+  entries?: TrainingEntry[];
+}
+
 export type PageSection =
   | TimelineSectionContent
   | ImageTextHalfSectionContent
-  | ImageGridSectionContent;
+  | ImageGridSectionContent
+  | VideoGallerySectionContent
+  | TrainingListSectionContent;
 
 export interface PageContent {
   sections: PageSection[];
   type?: string;
+}
+
+export interface VideoLibraryContent {
+  videos?: VideoEntry[];
+}
+
+export interface TrainingCatalogContent {
+  trainings?: TrainingEntry[];
 }


### PR DESCRIPTION
## Summary
- add dedicated Videos and Training page components that load localized section content and reuse the shared SectionRenderer
- introduce VideoGallery and TrainingList sections with translation-aware empty states and data fallbacks from JSON collections
- extend CMS configuration, metadata, and navigation with feature flags, new collections, and translations to manage video and training content

## Testing
- npm run build *(fails: Rollup could not resolve react-markdown import)*

------
https://chatgpt.com/codex/tasks/task_b_68d5c8581f98832091f5be087a119abe