### PR TITLE
feat: add CMS-driven home hero alignment

### DIFF
--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -134,6 +134,30 @@ const heroMarkdownComponents: MarkdownComponents = {
     ),
 };
 
+type HeroHorizontalAlignment = 'left' | 'center';
+type HeroVerticalAlignment = 'top' | 'middle' | 'bottom';
+
+const HERO_HORIZONTAL_ALIGNMENT_CONTAINER_CLASSES: Record<HeroHorizontalAlignment, string> = {
+  left: 'items-start text-left',
+  center: 'items-center text-center',
+};
+
+const HERO_HORIZONTAL_TEXT_ALIGNMENT_CLASSES: Record<HeroHorizontalAlignment, string> = {
+  left: 'text-left',
+  center: 'text-center',
+};
+
+const HERO_CTA_ALIGNMENT_CLASSES: Record<HeroHorizontalAlignment, string> = {
+  left: 'sm:justify-start',
+  center: 'sm:justify-center',
+};
+
+const HERO_VERTICAL_ALIGNMENT_CLASSES: Record<HeroVerticalAlignment, string> = {
+  top: 'justify-start',
+  middle: 'justify-center',
+  bottom: 'justify-end',
+};
+
 interface BestsellersProps {
     intro?: string;
     introFieldPath?: string;
@@ -663,6 +687,16 @@ const Home: React.FC = () => {
   const heroLayoutHint = pageContent?.heroLayoutHint ?? 'image-full';
   const heroImageLeft = sanitizeString(pageContent?.heroImageLeft);
   const heroImageRight = sanitizeString(pageContent?.heroImageRight);
+  const heroAlignX: HeroHorizontalAlignment = pageContent?.heroAlignX === 'center' ? 'center' : 'left';
+  const heroAlignY: HeroVerticalAlignment =
+    pageContent?.heroAlignY === 'top'
+      ? 'top'
+      : pageContent?.heroAlignY === 'middle'
+        ? 'middle'
+        : 'bottom';
+  const heroAlignmentClasses = `${HERO_HORIZONTAL_ALIGNMENT_CONTAINER_CLASSES[heroAlignX]} ${HERO_VERTICAL_ALIGNMENT_CLASSES[heroAlignY]}`;
+  const heroTextAlignmentClass = HERO_HORIZONTAL_TEXT_ALIGNMENT_CLASSES[heroAlignX];
+  const heroCtaAlignmentClass = HERO_CTA_ALIGNMENT_CLASSES[heroAlignX];
 
   let heroInlineImage: string | undefined;
   if (heroLayoutHint === 'image-left') {
@@ -699,13 +733,13 @@ const Home: React.FC = () => {
   const heroGridClasses = shouldRenderInlineImage
     ? 'grid grid-cols-1 lg:grid-cols-2 gap-12 items-center'
     : 'flex flex-col items-center text-center';
-  const heroTextWrapperClasses = shouldRenderInlineImage
-    ? `${heroLayoutHint === 'image-left' ? 'order-1 lg:order-2' : 'order-1'} space-y-6 max-w-xl text-left`
-    : 'space-y-6 max-w-3xl mx-auto text-center';
+  const heroTextWrapperBaseClasses = shouldRenderInlineImage
+    ? `${heroLayoutHint === 'image-left' ? 'order-1 lg:order-2' : 'order-1'} space-y-6 max-w-xl`
+    : 'space-y-6 max-w-3xl mx-auto';
+  const heroTextWrapperClasses = `${heroTextWrapperBaseClasses} ${heroTextAlignmentClass}`;
   const heroImageWrapperClasses = shouldRenderInlineImage
     ? `${heroLayoutHint === 'image-left' ? 'order-2 lg:order-1' : 'order-2'} w-full`
     : '';
-  const heroCtaAlignmentClass = shouldRenderInlineImage ? 'sm:justify-start' : 'sm:justify-center';
   const heroImageAlt = heroHeadline;
 
   const homeSections = pageContent?.sections ?? [];
@@ -728,7 +762,7 @@ const Home: React.FC = () => {
         data-nlv-field-path="site.home.heroImage"
       >
         <div className="absolute inset-0" style={overlayStyle}></div>
-        <div className="relative h-full flex items-center justify-center">
+        <div className={`relative h-full flex ${heroAlignmentClasses}`}>
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}

--- a/types.ts
+++ b/types.ts
@@ -328,6 +328,8 @@ export interface PageContent {
   heroImageLeft?: string;
   heroImageRight?: string;
   heroLayoutHint?: 'image-left' | 'image-right' | 'image-full';
+  heroAlignX?: 'left' | 'center';
+  heroAlignY?: 'top' | 'middle' | 'bottom';
   clinicsBlock?: ClinicsBlockContent;
   valueProps?: ValuePropItem[];
   bestsellersIntro?: string;


### PR DESCRIPTION
## Summary
- respect the home hero alignment settings from the CMS with sensible defaults
- map horizontal and vertical alignment choices to the hero text container and CTA layout
- extend the page content typing to cover the new alignment fields

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d855aa3aa083209d7ed08b10b8b47b