### PR TITLE
chore: sync home hero schema

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,3 +1,4 @@
+// SINGLE SOURCE OF TRUTH for Decap CMS (production /admin). Do not edit site/admin/config.yml.
 backend:
   name: git-gateway
   branch: main
@@ -133,6 +134,25 @@ collections:
             required: false
           - { label: Primary CTA Label, name: heroPrimaryCta, widget: string, required: false }
           - { label: Secondary CTA Label, name: heroSecondaryCta, widget: string, required: false }
+          - { label: Primary CTA Text, name: ctaPrimary, widget: string, required: false }
+          - { label: Secondary CTA Text, name: ctaSecondary, widget: string, required: false }
+          - label: Hero Horizontal Alignment
+            name: heroAlignX
+            widget: select
+            options:
+              - { label: Left, value: left }
+              - { label: Center, value: center }
+            default: left
+            required: false
+          - label: Hero Vertical Alignment
+            name: heroAlignY
+            widget: select
+            options:
+              - { label: Top, value: top }
+              - { label: Middle, value: middle }
+              - { label: Bottom, value: bottom }
+            default: bottom
+            required: false
           - { label: Hero Overlay, name: heroOverlay, widget: string, required: false, default: "rgba(0,0,0,0.48)" }
           - label: Hero Image (Left)
             name: heroImageLeft
@@ -283,6 +303,25 @@ collections:
             required: false
           - { label: Primary CTA Label, name: heroPrimaryCta, widget: string, required: false }
           - { label: Secondary CTA Label, name: heroSecondaryCta, widget: string, required: false }
+          - { label: Primary CTA Text, name: ctaPrimary, widget: string, required: false }
+          - { label: Secondary CTA Text, name: ctaSecondary, widget: string, required: false }
+          - label: Hero Horizontal Alignment
+            name: heroAlignX
+            widget: select
+            options:
+              - { label: Left, value: left }
+              - { label: Center, value: center }
+            default: left
+            required: false
+          - label: Hero Vertical Alignment
+            name: heroAlignY
+            widget: select
+            options:
+              - { label: Top, value: top }
+              - { label: Middle, value: middle }
+              - { label: Bottom, value: bottom }
+            default: bottom
+            required: false
           - { label: Hero Overlay, name: heroOverlay, widget: string, required: false, default: "rgba(0,0,0,0.48)" }
           - label: Hero Image (Left)
             name: heroImageLeft
@@ -433,6 +472,25 @@ collections:
             required: false
           - { label: Primary CTA Label, name: heroPrimaryCta, widget: string, required: false }
           - { label: Secondary CTA Label, name: heroSecondaryCta, widget: string, required: false }
+          - { label: Primary CTA Text, name: ctaPrimary, widget: string, required: false }
+          - { label: Secondary CTA Text, name: ctaSecondary, widget: string, required: false }
+          - label: Hero Horizontal Alignment
+            name: heroAlignX
+            widget: select
+            options:
+              - { label: Left, value: left }
+              - { label: Center, value: center }
+            default: left
+            required: false
+          - label: Hero Vertical Alignment
+            name: heroAlignY
+            widget: select
+            options:
+              - { label: Top, value: top }
+              - { label: Middle, value: middle }
+              - { label: Bottom, value: bottom }
+            default: bottom
+            required: false
           - { label: Hero Overlay, name: heroOverlay, widget: string, required: false, default: "rgba(0,0,0,0.48)" }
           - label: Hero Image (Left)
             name: heroImageLeft

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -695,6 +695,7 @@ const Home: React.FC = () => {
         ? 'middle'
         : 'bottom';
   const heroAlignmentClasses = `${HERO_HORIZONTAL_ALIGNMENT_CONTAINER_CLASSES[heroAlignX]} ${HERO_VERTICAL_ALIGNMENT_CLASSES[heroAlignY]}`;
+  const heroMiddleNudge = heroLayoutHint === 'image-full' && heroAlignY === 'middle' ? 'pb-24 md:pb-28' : '';
   const heroTextAlignmentClass = HERO_HORIZONTAL_TEXT_ALIGNMENT_CLASSES[heroAlignX];
   const heroCtaAlignmentClass = HERO_CTA_ALIGNMENT_CLASSES[heroAlignX];
 
@@ -762,7 +763,7 @@ const Home: React.FC = () => {
         data-nlv-field-path="site.home.heroImage"
       >
         <div className="absolute inset-0" style={overlayStyle}></div>
-        <div className={`relative h-full flex ${heroAlignmentClasses}`}>
+        <div className={`relative h-full flex ${heroAlignmentClasses} ${heroMiddleNudge}`}>
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}

--- a/site/admin/config.yml
+++ b/site/admin/config.yml
@@ -2041,3 +2041,5 @@ collections:
                   - { label: English, name: en, widget: markdown }
                   - { label: Portuguese, name: pt, widget: markdown }
                   - { label: Spanish, name: es, widget: markdown }
+
+// Deprecated mirror; production uses /admin/config.yml. Kept temporarily to avoid Visual Editor confusion.


### PR DESCRIPTION
## Summary
- unify the Decap home page hero fields so production /admin exposes CTA text and alignment options
- annotate the primary admin config as the single source of truth and mark the site mirror as deprecated
- nudge hero text downward when using the image-full layout with middle alignment to maintain spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d8643b05188320b7192d48f4e26c18