### PR TITLE
Add brand intro section to home page

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -173,6 +173,13 @@ collections:
               - { label: Image Left, value: image-left }
               - { label: Image Right, value: image-right }
               - { label: Full Image, value: image-full }
+          - label: Brand Intro
+            name: brandIntro
+            widget: object
+            required: false
+            fields:
+              - { label: Title, name: title, widget: string, required: false }
+              - { label: Text, name: text, widget: text, required: false }
           - label: Clinics Block
             name: clinicsBlock
             widget: object

--- a/content/pages/en/home.json
+++ b/content/pages/en/home.json
@@ -128,6 +128,10 @@
   },
   "heroSubheadline": "Gentle argan rituals from Morocco, made for sensitive and post-procedure skin. Welcome to Kapunka 2.0—care that feels human.",
   "heroImageRight": "",
+  "brandIntro": {
+    "title": "Born from gratitude",
+    "text": "Kapunka means “thank you.” We make pure argan care with clinical respect—simple routines that comfort skin and support healing. Our oil is cooperatively sourced in Morocco and clarified without solvents."
+  },
   "bestsellersIntro": "Meet the three-step ritual clinics retail most—cleanse, replenish, and seal with nutrient-dense argan care.",
   "brandMini": {
     "title": "Why Kapunka",

--- a/content/pages/es/home.json
+++ b/content/pages/es/home.json
@@ -17,6 +17,10 @@
   "heroImageLeft": "",
   "heroImageRight": "",
   "heroLayoutHint": "image-full",
+  "brandIntro": {
+    "title": "Nacido del agradecimiento",
+    "text": "Kapunka significa “gracias”. Hacemos cuidado de argán puro con respeto clínico—rutinas simples que calman la piel y apoyan la recuperación. Nuestro aceite procede de cooperativas en Marruecos y se clarifica sin disolventes."
+  },
   "clinicsBlock": {
     "clinicsTitle": "Preferido por dermatólogas, medspas y clínicas holísticas",
     "clinicsBody": "Nuestros tratamientos se integran en protocolos de peeling, láser y microagujas con absorción rápida, envasado estéril y tolerancia comprobada. La formación dedicada y el soporte mayorista mantienen a tus equipos seguros.",

--- a/content/pages/pt/home.json
+++ b/content/pages/pt/home.json
@@ -17,6 +17,10 @@
   "heroImageLeft": "",
   "heroImageRight": "",
   "heroLayoutHint": "image-full",
+  "brandIntro": {
+    "title": "Nascido da gratidão",
+    "text": "Kapunka significa “obrigado”. Criamos cuidados de argão puros com rigor clínico—rotinas simples que acalmam a pele e apoiam a recuperação. O nosso óleo é obtido de cooperativas em Marrocos e clarificado sem solventes."
+  },
   "clinicsBlock": {
     "clinicsTitle": "Preferido por dermatologistas, medspas e clínicas holísticas",
     "clinicsBody": "Nossos tratamentos se encaixam em protocolos de peeling, laser e microagulhamento com absorção rápida, envase estéril e tolerância comprovada. Treinamentos dedicados e suporte em atacado mantêm as equipes confiantes.",

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -750,6 +750,8 @@ const Home: React.FC = () => {
   const clinicsBlockData = pageContent?.clinicsBlock;
   const galleryRowsData = pageContent?.galleryRows;
   const bestsellersIntro = sanitizeString(pageContent?.bestsellersIntro);
+  const brandIntroTitle = sanitizeString(pageContent?.brandIntro?.title);
+  const brandIntroText = sanitizeString(pageContent?.brandIntro?.text);
 
   return (
     <div>
@@ -818,6 +820,26 @@ const Home: React.FC = () => {
           </motion.div>
         </div>
       </div>
+      {(brandIntroTitle || brandIntroText) && (
+        <div className="container mx-auto max-w-3xl px-4 py-16 md:py-24">
+          {brandIntroTitle && (
+            <h2
+              className="text-3xl sm:text-4xl font-semibold text-center"
+              data-nlv-field-path={`${homeFieldPath}.brandIntro.title`}
+            >
+              {brandIntroTitle}
+            </h2>
+          )}
+          {brandIntroText && (
+            <p
+              className="mt-6 prose prose-stone max-w-none text-stone-700 text-center"
+              data-nlv-field-path={`${homeFieldPath}.brandIntro.text`}
+            >
+              {brandIntroText}
+            </p>
+          )}
+        </div>
+      )}
       <ClinicsBlock
         data={clinicsBlockData}
         fieldPath={`${homeFieldPath}.clinicsBlock`}

--- a/site/content/en/pages/home.json
+++ b/site/content/en/pages/home.json
@@ -17,6 +17,10 @@
   "heroImageLeft": "",
   "heroImageRight": "",
   "heroLayoutHint": "image-right",
+  "brandIntro": {
+    "title": "Born from gratitude",
+    "text": "Kapunka means “thank you.” We make pure argan care with clinical respect—simple routines that comfort skin and support healing. Our oil is cooperatively sourced in Morocco and clarified without solvents."
+  },
   "clinicsBlock": {
     "clinicsTitle": "Trusted by dermatologists and aesthetic clinics",
     "clinicsBody": "Clinics choose Kapunka for its purity and performance in post-laser and sensitive-skin care. Our minimalist routines support recovery comfort, barrier integrity, and calm skin.",

--- a/site/content/es/pages/home.json
+++ b/site/content/es/pages/home.json
@@ -17,6 +17,10 @@
   "heroImageLeft": "",
   "heroImageRight": "",
   "heroLayoutHint": "image-right",
+  "brandIntro": {
+    "title": "Nacido del agradecimiento",
+    "text": "Kapunka significa “gracias”. Hacemos cuidado de argán puro con respeto clínico—rutinas simples que calman la piel y apoyan la recuperación. Nuestro aceite procede de cooperativas en Marruecos y se clarifica sin disolventes."
+  },
   "clinicsBlock": {
     "clinicsTitle": "Confiado por dermatólogos y clínicas estéticas",
     "clinicsBody": "Las clínicas eligen Kapunka por su pureza y rendimiento en cuidados post-láser y piel sensible. Nuestras rutinas minimalistas favorecen confort, integridad de la barrera y calma visible.",

--- a/site/content/pt/pages/home.json
+++ b/site/content/pt/pages/home.json
@@ -17,6 +17,10 @@
   "heroImageLeft": "",
   "heroImageRight": "",
   "heroLayoutHint": "image-right",
+  "brandIntro": {
+    "title": "Nascido da gratidão",
+    "text": "Kapunka significa “obrigado”. Criamos cuidados de argão puros com rigor clínico—rotinas simples que acalmam a pele e apoiam a recuperação. O nosso óleo é obtido de cooperativas em Marrocos e clarificado sem solventes."
+  },
   "clinicsBlock": {
     "clinicsTitle": "Confiado por dermatologistas e clínicas estéticas",
     "clinicsBody": "As clínicas escolhem Kapunka pela pureza e desempenho no pós-laser e no cuidado de peles sensíveis. Nossas rutinas minimalistas favorecem conforto, integridade da barreira e calma visível.",

--- a/types.ts
+++ b/types.ts
@@ -330,6 +330,10 @@ export interface PageContent {
   heroLayoutHint?: 'image-left' | 'image-right' | 'image-full';
   heroAlignX?: 'left' | 'center';
   heroAlignY?: 'top' | 'middle' | 'bottom';
+  brandIntro?: {
+    title?: string;
+    text?: string;
+  };
   clinicsBlock?: ClinicsBlockContent;
   valueProps?: ValuePropItem[];
   bestsellersIntro?: string;


### PR DESCRIPTION
## Summary
- add an optional brand intro object to the home page schema and types
- render the brand intro content after the hero when present
- seed localized brand intro content for en, pt, and es locales (including site mirror)

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d8698d1ca48320b93d4a84d30390ba