### PR TITLE
Fix CMS config comment syntax

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,4 +1,4 @@
-// SINGLE SOURCE OF TRUTH for Decap CMS (production /admin). Do not edit site/admin/config.yml.
+# SINGLE SOURCE OF TRUTH for Decap CMS (production /admin). Do not edit site/admin/config.yml.
 backend:
   name: git-gateway
   branch: main


### PR DESCRIPTION
## Summary
- replace the invalid JavaScript-style comment at the top of the Decap CMS config with a YAML-compatible comment so the file parses correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d86f38ad248320aa66094371efbe5e