### PR TITLE
Add media assets images collection to Decap

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -118,6 +118,25 @@ collections:
                       - { label: LinkedIn, value: linkedin }
                       - { label: YouTube, value: youtube }
                       - { label: Globe, value: globe }
+  - name: "assets_images"
+    label: "Media / Images"
+    folder: "content/assets/images"
+    create: true
+    slug: "{{slug}}"
+    identifier_field: "title"
+    fields:
+      - { label: "Title", name: "title", widget: "string" }
+      - { label: "Image", name: "image", widget: "image", choose_url: false }
+      - { label: "Alt text", name: "alt", widget: "string", required: false, hint: "Descriptive text for accessibility/SEO" }
+      - { label: "Credit / Source", name: "credit", widget: "string", required: false }
+      - { label: "Tags", name: "tags", widget: "list", required: false }
+      - label: "Focal point"
+        name: "focal"
+        widget: "object"
+        required: false
+        fields:
+          - { label: "x (0..1)", name: "x", widget: "number", value_type: "float", min: 0, max: 1, required: false }
+          - { label: "y (0..1)", name: "y", widget: "number", value_type: "float", min: 0, max: 1, required: false }
   - name: pages
     label: Pages
     files:

--- a/site/admin/config.yml
+++ b/site/admin/config.yml
@@ -117,6 +117,25 @@ collections:
                       - { label: LinkedIn, value: linkedin }
                       - { label: YouTube, value: youtube }
                       - { label: Globe, value: globe }
+  - name: "assets_images"
+    label: "Media / Images"
+    folder: "content/assets/images"
+    create: true
+    slug: "{{slug}}"
+    identifier_field: "title"
+    fields:
+      - { label: "Title", name: "title", widget: "string" }
+      - { label: "Image", name: "image", widget: "image", choose_url: false }
+      - { label: "Alt text", name: "alt", widget: "string", required: false, hint: "Descriptive text for accessibility/SEO" }
+      - { label: "Credit / Source", name: "credit", widget: "string", required: false }
+      - { label: "Tags", name: "tags", widget: "list", required: false }
+      - label: "Focal point"
+        name: "focal"
+        widget: "object"
+        required: false
+        fields:
+          - { label: "x (0..1)", name: "x", widget: "number", value_type: "float", min: 0, max: 1, required: false }
+          - { label: "y (0..1)", name: "y", widget: "number", value_type: "float", min: 0, max: 1, required: false }
   - name: pages
     label: Pages
     files:


### PR DESCRIPTION
## Summary
- add an `assets_images` folder collection to the Decap CMS configuration for both admin entry points
- create the `content/assets/images` directory for reusable media assets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d950e0e4188320aa3028d4e659ab13