### PR TITLE
Add hero image relations to home page schema

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -194,17 +194,33 @@ collections:
             default: 48
             hint: "Set the overlay opacity (0 clears the overlay, 90 is nearly opaque)."
           - label: Hero Image (Left)
-            name: heroImageLeft
-            widget: image
-            choose_url: true
-            hint: "Shown when layout is Image Left or Full Image (desktop uses this slot)."
+            name: heroImageLeftRef
+            widget: relation
+            collection: assets_images
+            search_fields: ["title", "tags.*"]
+            value_field: image
+            display_fields: ["title"]
             required: false
+            hint: "Shown when layout is Image Left or Full Image (desktop uses this slot)."
+          - label: Hero Image (Left)
+            name: heroImageLeft
+            widget: string
+            required: false
+            hint: "legacy: will be ignored if Ref is set"
+          - label: Hero Image (Right)
+            name: heroImageRightRef
+            widget: relation
+            collection: assets_images
+            search_fields: ["title", "tags.*"]
+            value_field: image
+            display_fields: ["title"]
+            required: false
+            hint: "Displayed when layout is Image Right; keep empty if not used."
           - label: Hero Image (Right)
             name: heroImageRight
-            widget: image
-            choose_url: true
-            hint: "Displayed when layout is Image Right; keep empty if not used."
+            widget: string
             required: false
+            hint: "legacy: will be ignored if Ref is set"
           - label: Hero Layout Hint
             name: heroLayoutHint
             widget: select
@@ -384,17 +400,33 @@ collections:
             default: 48
             hint: "Set the overlay opacity (0 clears the overlay, 90 is nearly opaque)."
           - label: Hero Image (Left)
-            name: heroImageLeft
-            widget: image
-            choose_url: true
-            hint: "Shown when layout is Image Left or Full Image (desktop uses this slot)."
+            name: heroImageLeftRef
+            widget: relation
+            collection: assets_images
+            search_fields: ["title", "tags.*"]
+            value_field: image
+            display_fields: ["title"]
             required: false
+            hint: "Shown when layout is Image Left or Full Image (desktop uses this slot)."
+          - label: Hero Image (Left)
+            name: heroImageLeft
+            widget: string
+            required: false
+            hint: "legacy: will be ignored if Ref is set"
+          - label: Hero Image (Right)
+            name: heroImageRightRef
+            widget: relation
+            collection: assets_images
+            search_fields: ["title", "tags.*"]
+            value_field: image
+            display_fields: ["title"]
+            required: false
+            hint: "Displayed when layout is Image Right; keep empty if not used."
           - label: Hero Image (Right)
             name: heroImageRight
-            widget: image
-            choose_url: true
-            hint: "Displayed when layout is Image Right; keep empty if not used."
+            widget: string
             required: false
+            hint: "legacy: will be ignored if Ref is set"
           - label: Hero Layout Hint
             name: heroLayoutHint
             widget: select
@@ -567,17 +599,33 @@ collections:
             default: 48
             hint: "Set the overlay opacity (0 clears the overlay, 90 is nearly opaque)."
           - label: Hero Image (Left)
-            name: heroImageLeft
-            widget: image
-            choose_url: true
-            hint: "Shown when layout is Image Left or Full Image (desktop uses this slot)."
+            name: heroImageLeftRef
+            widget: relation
+            collection: assets_images
+            search_fields: ["title", "tags.*"]
+            value_field: image
+            display_fields: ["title"]
             required: false
+            hint: "Shown when layout is Image Left or Full Image (desktop uses this slot)."
+          - label: Hero Image (Left)
+            name: heroImageLeft
+            widget: string
+            required: false
+            hint: "legacy: will be ignored if Ref is set"
+          - label: Hero Image (Right)
+            name: heroImageRightRef
+            widget: relation
+            collection: assets_images
+            search_fields: ["title", "tags.*"]
+            value_field: image
+            display_fields: ["title"]
+            required: false
+            hint: "Displayed when layout is Image Right; keep empty if not used."
           - label: Hero Image (Right)
             name: heroImageRight
-            widget: image
-            choose_url: true
-            hint: "Displayed when layout is Image Right; keep empty if not used."
+            widget: string
             required: false
+            hint: "legacy: will be ignored if Ref is set"
           - label: Hero Layout Hint
             name: heroLayoutHint
             widget: select

--- a/site/admin/config.yml
+++ b/site/admin/config.yml
@@ -193,17 +193,33 @@ collections:
             default: 48
             hint: "Set the overlay opacity (0 clears the overlay, 90 is nearly opaque)."
           - label: Hero Image (Left)
-            name: heroImageLeft
-            widget: image
-            choose_url: true
-            hint: "Shown when layout is Image Left or Full Image (desktop uses this slot)."
+            name: heroImageLeftRef
+            widget: relation
+            collection: assets_images
+            search_fields: ["title", "tags.*"]
+            value_field: image
+            display_fields: ["title"]
             required: false
+            hint: "Shown when layout is Image Left or Full Image (desktop uses this slot)."
+          - label: Hero Image (Left)
+            name: heroImageLeft
+            widget: string
+            required: false
+            hint: "legacy: will be ignored if Ref is set"
+          - label: Hero Image (Right)
+            name: heroImageRightRef
+            widget: relation
+            collection: assets_images
+            search_fields: ["title", "tags.*"]
+            value_field: image
+            display_fields: ["title"]
+            required: false
+            hint: "Displayed when layout is Image Right; keep empty if not used."
           - label: Hero Image (Right)
             name: heroImageRight
-            widget: image
-            choose_url: true
-            hint: "Displayed when layout is Image Right; keep empty if not used."
+            widget: string
             required: false
+            hint: "legacy: will be ignored if Ref is set"
           - label: Hero Layout Hint
             name: heroLayoutHint
             widget: select
@@ -383,17 +399,33 @@ collections:
             default: 48
             hint: "Set the overlay opacity (0 clears the overlay, 90 is nearly opaque)."
           - label: Hero Image (Left)
-            name: heroImageLeft
-            widget: image
-            choose_url: true
-            hint: "Shown when layout is Image Left or Full Image (desktop uses this slot)."
+            name: heroImageLeftRef
+            widget: relation
+            collection: assets_images
+            search_fields: ["title", "tags.*"]
+            value_field: image
+            display_fields: ["title"]
             required: false
+            hint: "Shown when layout is Image Left or Full Image (desktop uses this slot)."
+          - label: Hero Image (Left)
+            name: heroImageLeft
+            widget: string
+            required: false
+            hint: "legacy: will be ignored if Ref is set"
+          - label: Hero Image (Right)
+            name: heroImageRightRef
+            widget: relation
+            collection: assets_images
+            search_fields: ["title", "tags.*"]
+            value_field: image
+            display_fields: ["title"]
+            required: false
+            hint: "Displayed when layout is Image Right; keep empty if not used."
           - label: Hero Image (Right)
             name: heroImageRight
-            widget: image
-            choose_url: true
-            hint: "Displayed when layout is Image Right; keep empty if not used."
+            widget: string
             required: false
+            hint: "legacy: will be ignored if Ref is set"
           - label: Hero Layout Hint
             name: heroLayoutHint
             widget: select
@@ -566,17 +598,33 @@ collections:
             default: 48
             hint: "Set the overlay opacity (0 clears the overlay, 90 is nearly opaque)."
           - label: Hero Image (Left)
-            name: heroImageLeft
-            widget: image
-            choose_url: true
-            hint: "Shown when layout is Image Left or Full Image (desktop uses this slot)."
+            name: heroImageLeftRef
+            widget: relation
+            collection: assets_images
+            search_fields: ["title", "tags.*"]
+            value_field: image
+            display_fields: ["title"]
             required: false
+            hint: "Shown when layout is Image Left or Full Image (desktop uses this slot)."
+          - label: Hero Image (Left)
+            name: heroImageLeft
+            widget: string
+            required: false
+            hint: "legacy: will be ignored if Ref is set"
+          - label: Hero Image (Right)
+            name: heroImageRightRef
+            widget: relation
+            collection: assets_images
+            search_fields: ["title", "tags.*"]
+            value_field: image
+            display_fields: ["title"]
+            required: false
+            hint: "Displayed when layout is Image Right; keep empty if not used."
           - label: Hero Image (Right)
             name: heroImageRight
-            widget: image
-            choose_url: true
-            hint: "Displayed when layout is Image Right; keep empty if not used."
+            widget: string
             required: false
+            hint: "legacy: will be ignored if Ref is set"
           - label: Hero Layout Hint
             name: heroLayoutHint
             widget: select


### PR DESCRIPTION
## Summary
- allow the home page hero fields to reference existing images from the Media / Images library in both admin configs
- retain legacy hero image string fields as optional fallbacks with guidance on when they are ignored

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68d953616fb88320acf177d42ce9ea91