### PR TITLE
fix: clarify home hero image fallback warning

### DIFF
--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -658,7 +658,7 @@ const Home: React.FC = () => {
             const heroImageLeftUrl = typedData.heroImageLeftRef || typedData.heroImageLeft || null;
             const heroImageRightUrl = typedData.heroImageRightRef || typedData.heroImageRight || null;
             if (!heroImageLeftUrl && !heroImageRightUrl && !hasWarnedMissingHeroImages) {
-              console.warn('Home hero images are not configured.');
+              console.warn('Home hero images are not configured. Add hero image references or legacy URLs in the CMS.');
               hasWarnedMissingHeroImages = true;
             }
             const dataWithHeroImages: HomePageContent = {


### PR DESCRIPTION
## Summary
- clarify the CMS warning shown when no hero images are configured on the home page
- continue preferring hero image references while falling back to legacy URLs for display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d958058b0c832091e2bf08717498c3