### PR TITLE
feat: add hero text position overrides

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -185,6 +185,21 @@ collections:
               - { label: Bottom, value: bottom }
             default: bottom
             required: false
+          - label: Hero Text Position
+            name: heroTextPosition
+            widget: select
+            options:
+              - { label: "Top Left", value: "top-left" }
+              - { label: "Top Center", value: "top-center" }
+              - { label: "Top Right", value: "top-right" }
+              - { label: "Middle Left", value: "middle-left" }
+              - { label: "Middle Center", value: "middle-center" }
+              - { label: "Middle Right", value: "middle-right" }
+              - { label: "Bottom Left", value: "bottom-left" }
+              - { label: "Bottom Center", value: "bottom-center" }
+              - { label: "Bottom Right", value: "bottom-right" }
+            required: false
+            hint: "Overrides Align X/Y if set."
           - label: Hero Overlay Strength
             name: heroOverlay
             widget: number
@@ -391,6 +406,21 @@ collections:
               - { label: Bottom, value: bottom }
             default: bottom
             required: false
+          - label: Hero Text Position
+            name: heroTextPosition
+            widget: select
+            options:
+              - { label: "Top Left", value: "top-left" }
+              - { label: "Top Center", value: "top-center" }
+              - { label: "Top Right", value: "top-right" }
+              - { label: "Middle Left", value: "middle-left" }
+              - { label: "Middle Center", value: "middle-center" }
+              - { label: "Middle Right", value: "middle-right" }
+              - { label: "Bottom Left", value: "bottom-left" }
+              - { label: "Bottom Center", value: "bottom-center" }
+              - { label: "Bottom Right", value: "bottom-right" }
+            required: false
+            hint: "Overrides Align X/Y if set."
           - label: Hero Overlay Strength
             name: heroOverlay
             widget: number
@@ -590,6 +620,21 @@ collections:
               - { label: Bottom, value: bottom }
             default: bottom
             required: false
+          - label: Hero Text Position
+            name: heroTextPosition
+            widget: select
+            options:
+              - { label: "Top Left", value: "top-left" }
+              - { label: "Top Center", value: "top-center" }
+              - { label: "Top Right", value: "top-right" }
+              - { label: "Middle Left", value: "middle-left" }
+              - { label: "Middle Center", value: "middle-center" }
+              - { label: "Middle Right", value: "middle-right" }
+              - { label: "Bottom Left", value: "bottom-left" }
+              - { label: "Bottom Center", value: "bottom-center" }
+              - { label: "Bottom Right", value: "bottom-right" }
+            required: false
+            hint: "Overrides Align X/Y if set."
           - label: Hero Overlay Strength
             name: heroOverlay
             widget: number

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -134,7 +134,7 @@ const heroMarkdownComponents: MarkdownComponents = {
     ),
 };
 
-type HeroHorizontalAlignment = 'left' | 'center';
+type HeroHorizontalAlignment = 'left' | 'center' | 'right';
 type HeroVerticalAlignment = 'top' | 'middle' | 'bottom';
 
 type HomePageContent = PageContent & {
@@ -147,22 +147,40 @@ type HomePageContent = PageContent & {
 const HERO_HORIZONTAL_ALIGNMENT_CONTAINER_CLASSES: Record<HeroHorizontalAlignment, string> = {
   left: 'items-start text-left',
   center: 'items-center text-center',
+  right: 'items-end text-right',
 };
 
 const HERO_HORIZONTAL_TEXT_ALIGNMENT_CLASSES: Record<HeroHorizontalAlignment, string> = {
   left: 'text-left',
   center: 'text-center',
+  right: 'text-right',
 };
 
 const HERO_CTA_ALIGNMENT_CLASSES: Record<HeroHorizontalAlignment, string> = {
   left: 'sm:justify-start',
   center: 'sm:justify-center',
+  right: 'sm:justify-end',
 };
 
 const HERO_VERTICAL_ALIGNMENT_CLASSES: Record<HeroVerticalAlignment, string> = {
   top: 'justify-start',
   middle: 'justify-center',
   bottom: 'justify-end',
+};
+
+const HERO_TEXT_POSITION_MAP: Record<
+  NonNullable<PageContent['heroTextPosition']>,
+  [HeroHorizontalAlignment, HeroVerticalAlignment]
+> = {
+  'top-left': ['left', 'top'],
+  'top-center': ['center', 'top'],
+  'top-right': ['right', 'top'],
+  'middle-left': ['left', 'middle'],
+  'middle-center': ['center', 'middle'],
+  'middle-right': ['right', 'middle'],
+  'bottom-left': ['left', 'bottom'],
+  'bottom-center': ['center', 'bottom'],
+  'bottom-right': ['right', 'bottom'],
 };
 
 let hasWarnedMissingHeroImages = false;
@@ -702,11 +720,23 @@ const Home: React.FC = () => {
   const heroImageRightUrl = pageContent?.heroImageRightUrl ?? pageContent?.heroImageRightRef ?? pageContent?.heroImageRight ?? null;
   const heroImageLeft = sanitizeString(heroImageLeftUrl);
   const heroImageRight = sanitizeString(heroImageRightUrl);
-  const heroAlignX: HeroHorizontalAlignment = pageContent?.heroAlignX === 'center' ? 'center' : 'left';
+  const heroTextPosition = pageContent?.heroTextPosition ?? undefined;
+  const [rawHeroAlignX, rawHeroAlignY] =
+    heroTextPosition && HERO_TEXT_POSITION_MAP[heroTextPosition]
+      ? HERO_TEXT_POSITION_MAP[heroTextPosition]
+      : [pageContent?.heroAlignX, pageContent?.heroAlignY];
+
+  const heroAlignX: HeroHorizontalAlignment =
+    rawHeroAlignX === 'center'
+      ? 'center'
+      : rawHeroAlignX === 'right'
+        ? 'right'
+        : 'left';
+
   const heroAlignY: HeroVerticalAlignment =
-    pageContent?.heroAlignY === 'top'
+    rawHeroAlignY === 'top'
       ? 'top'
-      : pageContent?.heroAlignY === 'middle'
+      : rawHeroAlignY === 'middle'
         ? 'middle'
         : 'bottom';
   const heroAlignmentClasses = `${HERO_HORIZONTAL_ALIGNMENT_CONTAINER_CLASSES[heroAlignX]} ${HERO_VERTICAL_ALIGNMENT_CLASSES[heroAlignY]}`;

--- a/site/admin/config.yml
+++ b/site/admin/config.yml
@@ -184,6 +184,21 @@ collections:
               - { label: Bottom, value: bottom }
             default: bottom
             required: false
+          - label: Hero Text Position
+            name: heroTextPosition
+            widget: select
+            options:
+              - { label: "Top Left", value: "top-left" }
+              - { label: "Top Center", value: "top-center" }
+              - { label: "Top Right", value: "top-right" }
+              - { label: "Middle Left", value: "middle-left" }
+              - { label: "Middle Center", value: "middle-center" }
+              - { label: "Middle Right", value: "middle-right" }
+              - { label: "Bottom Left", value: "bottom-left" }
+              - { label: "Bottom Center", value: "bottom-center" }
+              - { label: "Bottom Right", value: "bottom-right" }
+            required: false
+            hint: "Overrides Align X/Y if set."
           - label: Hero Overlay Strength
             name: heroOverlay
             widget: number
@@ -390,6 +405,21 @@ collections:
               - { label: Bottom, value: bottom }
             default: bottom
             required: false
+          - label: Hero Text Position
+            name: heroTextPosition
+            widget: select
+            options:
+              - { label: "Top Left", value: "top-left" }
+              - { label: "Top Center", value: "top-center" }
+              - { label: "Top Right", value: "top-right" }
+              - { label: "Middle Left", value: "middle-left" }
+              - { label: "Middle Center", value: "middle-center" }
+              - { label: "Middle Right", value: "middle-right" }
+              - { label: "Bottom Left", value: "bottom-left" }
+              - { label: "Bottom Center", value: "bottom-center" }
+              - { label: "Bottom Right", value: "bottom-right" }
+            required: false
+            hint: "Overrides Align X/Y if set."
           - label: Hero Overlay Strength
             name: heroOverlay
             widget: number
@@ -589,6 +619,21 @@ collections:
               - { label: Bottom, value: bottom }
             default: bottom
             required: false
+          - label: Hero Text Position
+            name: heroTextPosition
+            widget: select
+            options:
+              - { label: "Top Left", value: "top-left" }
+              - { label: "Top Center", value: "top-center" }
+              - { label: "Top Right", value: "top-right" }
+              - { label: "Middle Left", value: "middle-left" }
+              - { label: "Middle Center", value: "middle-center" }
+              - { label: "Middle Right", value: "middle-right" }
+              - { label: "Bottom Left", value: "bottom-left" }
+              - { label: "Bottom Center", value: "bottom-center" }
+              - { label: "Bottom Right", value: "bottom-right" }
+            required: false
+            hint: "Overrides Align X/Y if set."
           - label: Hero Overlay Strength
             name: heroOverlay
             widget: number

--- a/types.ts
+++ b/types.ts
@@ -328,8 +328,18 @@ export interface PageContent {
   heroImageLeft?: string;
   heroImageRight?: string;
   heroLayoutHint?: 'image-left' | 'image-right' | 'image-full';
-  heroAlignX?: 'left' | 'center';
+  heroAlignX?: 'left' | 'center' | 'right';
   heroAlignY?: 'top' | 'middle' | 'bottom';
+  heroTextPosition?:
+    | 'top-left'
+    | 'top-center'
+    | 'top-right'
+    | 'middle-left'
+    | 'middle-center'
+    | 'middle-right'
+    | 'bottom-left'
+    | 'bottom-center'
+    | 'bottom-right';
   brandIntro?: {
     title?: string;
     text?: string;


### PR DESCRIPTION
## Summary
- add a hero text position select to each Decap home page entry for all locales and the Visual Editor mirror
- derive hero alignment from the new field in the Home page and extend alignments to support right alignment
- update shared types to expose the new CMS field and alignment option

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d95943d0c88320b9e18675fcbee91c