### PR TITLE
Extend CMS schemas for about and method pages

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -794,6 +794,24 @@ collections:
         file: content/pages/en/story.json
         format: json
         fields:
+          - { label: Meta Title, name: metaTitle, widget: string, required: false }
+          - { label: Meta Description, name: metaDescription, widget: text, required: false }
+          - { label: Intro Tagline, name: tagline, widget: string, required: false }
+          - label: Story Blocks
+            name: story
+            widget: list
+            required: false
+            fields:
+              - { label: Heading, name: heading, widget: string }
+              - { label: Body, name: body, widget: markdown }
+              - label: Image (Ref)
+                name: imageRef
+                widget: relation
+                collection: assets_images
+                search_fields: ["title", "tags.*"]
+                value_field: image
+                display_fields: ["title"]
+                required: false
           - label: Sections
             name: sections
             widget: list
@@ -817,6 +835,24 @@ collections:
         file: content/pages/pt/story.json
         format: json
         fields:
+          - { label: Meta Title, name: metaTitle, widget: string, required: false }
+          - { label: Meta Description, name: metaDescription, widget: text, required: false }
+          - { label: Intro Tagline, name: tagline, widget: string, required: false }
+          - label: Story Blocks
+            name: story
+            widget: list
+            required: false
+            fields:
+              - { label: Heading, name: heading, widget: string }
+              - { label: Body, name: body, widget: markdown }
+              - label: Image (Ref)
+                name: imageRef
+                widget: relation
+                collection: assets_images
+                search_fields: ["title", "tags.*"]
+                value_field: image
+                display_fields: ["title"]
+                required: false
           - label: Sections
             name: sections
             widget: list
@@ -840,6 +876,24 @@ collections:
         file: content/pages/es/story.json
         format: json
         fields:
+          - { label: Meta Title, name: metaTitle, widget: string, required: false }
+          - { label: Meta Description, name: metaDescription, widget: text, required: false }
+          - { label: Intro Tagline, name: tagline, widget: string, required: false }
+          - label: Story Blocks
+            name: story
+            widget: list
+            required: false
+            fields:
+              - { label: Heading, name: heading, widget: string }
+              - { label: Body, name: body, widget: markdown }
+              - label: Image (Ref)
+                name: imageRef
+                widget: relation
+                collection: assets_images
+                search_fields: ["title", "tags.*"]
+                value_field: image
+                display_fields: ["title"]
+                required: false
           - label: Sections
             name: sections
             widget: list
@@ -1603,6 +1657,16 @@ collections:
           - { label: Meta Description, name: metaDescription, widget: text, required: false }
           - { label: Hero Title, name: heroTitle, widget: string, required: false }
           - { label: Hero Subtitle, name: heroSubtitle, widget: text, required: false }
+          - label: Clinical Notes
+            name: clinicalNotes
+            widget: list
+            required: false
+            fields:
+              - { label: Title, name: title, widget: string }
+              - label: Bullets
+                name: bullets
+                widget: list
+                field: { label: Item, name: item, widget: string }
           - label: Sections
             name: sections
             widget: list
@@ -1645,6 +1709,16 @@ collections:
           - { label: Meta Description, name: metaDescription, widget: text, required: false }
           - { label: Hero Title, name: heroTitle, widget: string, required: false }
           - { label: Hero Subtitle, name: heroSubtitle, widget: text, required: false }
+          - label: Clinical Notes
+            name: clinicalNotes
+            widget: list
+            required: false
+            fields:
+              - { label: Title, name: title, widget: string }
+              - label: Bullets
+                name: bullets
+                widget: list
+                field: { label: Item, name: item, widget: string }
           - label: Sections
             name: sections
             widget: list
@@ -1687,6 +1761,16 @@ collections:
           - { label: Meta Description, name: metaDescription, widget: text, required: false }
           - { label: Hero Title, name: heroTitle, widget: string, required: false }
           - { label: Hero Subtitle, name: heroSubtitle, widget: text, required: false }
+          - label: Clinical Notes
+            name: clinicalNotes
+            widget: list
+            required: false
+            fields:
+              - { label: Title, name: title, widget: string }
+              - label: Bullets
+                name: bullets
+                widget: list
+                field: { label: Item, name: item, widget: string }
           - label: Sections
             name: sections
             widget: list

--- a/content/pages/en/method.json
+++ b/content/pages/en/method.json
@@ -3,6 +3,23 @@
   "metaDescription": "Clean argan protocols that balance rural stewardship with dermatology-backed recovery.",
   "heroTitle": "Method Kapunka",
   "heroSubtitle": "Sensitive care rooted in Berber tradition and validated with modern dermal science.",
+  "clinicalNotes": [
+    {
+      "title": "Forest & sourcing commitments",
+      "bullets": [
+        "UNESCO biosphere reserve spanning 828k hectares",
+        "Fair-trade cooperatives oversee harvesting and revenue"
+      ]
+    },
+    {
+      "title": "Clarification protocol",
+      "bullets": [
+        "No solvents",
+        "Physical decanting then double filtration",
+        "No chemical refining"
+      ]
+    }
+  ],
   "sections": [
     {
       "type": "facts",

--- a/content/pages/en/story.json
+++ b/content/pages/en/story.json
@@ -1,6 +1,19 @@
 {
   "metaTitle": "Kapunka Story – From hammams to derm clinics",
   "metaDescription": "Follow how Kapunka's argan rituals moved from Moroccan cooperatives to modern dermatology partners.",
+  "tagline": "Less, but better.",
+  "story": [
+    {
+      "heading": "Our Story",
+      "body": "Kapunka was born from a desire for transparent, effective skincare. We started by sourcing the purest, ECOCERT-certified Argan oil from women's cooperatives in Morocco.",
+      "imageRef": ""
+    },
+    {
+      "heading": "Ethical Sourcing",
+      "body": "We are committed to ethical and sustainable practices. Our ingredients are sourced from suppliers who share our values of environmental responsibility and fair trade. Our Argan oil is a prime example, providing economic empowerment to the Berber women who have perfected its traditional extraction method for centuries.",
+      "imageRef": ""
+    }
+  ],
   "sections": [
     {
       "type": "timeline",

--- a/content/pages/es/method.json
+++ b/content/pages/es/method.json
@@ -3,6 +3,23 @@
   "metaDescription": "Protocolos limpios de argán que equilibran el trabajo cooperativo con la recuperación avalada por la dermatología.",
   "heroTitle": "Método Kapunka",
   "heroSubtitle": "Cuidado sensible arraigado en la tradición bereber y validado por la ciencia dérmica moderna.",
+  "clinicalNotes": [
+    {
+      "title": "Compromisos con el bosque y el abastecimiento",
+      "bullets": [
+        "Reserva de la biosfera de la UNESCO con 828 mil hectáreas",
+        "Las cooperativas de comercio justo coordinan la cosecha y los ingresos"
+      ]
+    },
+    {
+      "title": "Protocolo de clarificación",
+      "bullets": [
+        "Sin disolventes",
+        "Decantación física con doble filtrado",
+        "Sin refinado químico"
+      ]
+    }
+  ],
   "sections": [
     {
       "type": "facts",

--- a/content/pages/es/story.json
+++ b/content/pages/es/story.json
@@ -1,6 +1,19 @@
 {
   "metaTitle": "Historia Kapunka – De los hammams a las clínicas dermatológicas",
   "metaDescription": "Sigue cómo los rituales de argán de Kapunka pasaron de las cooperativas marroquíes a los socios de dermatología moderna.",
+  "tagline": "Menos, pero mejor.",
+  "story": [
+    {
+      "heading": "Nuestra Historia",
+      "body": "Kapunka nació del deseo de un cuidado de la piel transparente y eficaz. Empezamos por obtener el aceite de Argán más puro, certificado por ECOCERT, de cooperativas de mujeres en Marruecos.",
+      "imageRef": ""
+    },
+    {
+      "heading": "Abastecimiento Ético",
+      "body": "Estamos comprometidos con prácticas éticas y sostenibles. Nuestros ingredientes provienen de proveedores que comparten nuestros valores de responsabilidad ambiental y comercio justo. Nuestro aceite de Argán es un ejemplo primordial, proporcionando empoderamiento económico a las mujeres bereberes que han perfeccionado su método tradicional de extracción durante siglos.",
+      "imageRef": ""
+    }
+  ],
   "sections": [
     {
       "type": "timeline",

--- a/content/pages/pt/method.json
+++ b/content/pages/pt/method.json
@@ -3,6 +3,23 @@
   "metaDescription": "Protocolos limpos de argan que equilibram o cuidado cooperativo com a recuperação validada pela dermatologia.",
   "heroTitle": "Método Kapunka",
   "heroSubtitle": "Cuidado sensível enraizado na tradição berbere e validado pela ciência dérmica moderna.",
+  "clinicalNotes": [
+    {
+      "title": "Compromissos com a floresta e o abastecimento",
+      "bullets": [
+        "Reserva da biosfera da UNESCO com 828 mil hectares",
+        "Cooperativas de comércio justo coordenam a colheita e a receita"
+      ]
+    },
+    {
+      "title": "Protocolo de clarificação",
+      "bullets": [
+        "Sem solventes",
+        "Decantação física seguida de dupla filtração",
+        "Sem refino químico"
+      ]
+    }
+  ],
   "sections": [
     {
       "type": "facts",

--- a/content/pages/pt/story.json
+++ b/content/pages/pt/story.json
@@ -1,6 +1,19 @@
 {
   "metaTitle": "História Kapunka – Dos hammams às clínicas dermatológicas",
   "metaDescription": "Acompanhe como os rituais de argan Kapunka passaram das cooperativas marroquinas para parceiros de dermatologia moderna.",
+  "tagline": "Menos, mas melhor.",
+  "story": [
+    {
+      "heading": "Nossa História",
+      "body": "A Kapunka nasceu do desejo por cuidados com a pele transparentes e eficazes. Começamos por obter o mais puro óleo de Argan certificado pela ECOCERT de cooperativas de mulheres em Marrocos.",
+      "imageRef": ""
+    },
+    {
+      "heading": "Fornecimento Ético",
+      "body": "Estamos comprometidos com práticas éticas e sustentáveis. Nossos ingredientes são provenientes de fornecedores que compartilham nossos valores de responsabilidade ambiental e comércio justo. Nosso óleo de Argan é um excelente exemplo, proporcionando empoderamento econômico para as mulheres berberes que aperfeiçoaram seu método tradicional de extração por séculos.",
+      "imageRef": ""
+    }
+  ],
   "sections": [
     {
       "type": "timeline",


### PR DESCRIPTION
## Summary
- expose intro tagline and story block list for the About/Story pages across locales
- add clinical notes list support to Method pages and seed localized content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d95b1e74d48320aaff6e0930c01f62