### PR TITLE
feat: support cms content on about and method pages

### DIFF
--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -33,6 +33,67 @@ const isTimelineSection = (value: unknown): value is TimelineSectionContent => {
   return section.entries.every(isTimelineEntry);
 };
 
+const isImageTextHalfSection = (value: unknown): value is PageSection => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const section = value as Record<string, unknown>;
+
+  return (
+    section.type === 'imageTextHalf'
+    && (section.image === undefined || typeof section.image === 'string')
+    && (section.title === undefined || typeof section.title === 'string')
+    && (section.text === undefined || typeof section.text === 'string')
+  );
+};
+
+const isImageGridItem = (value: unknown): value is { image?: string; title?: string; subtitle?: string } => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const item = value as Record<string, unknown>;
+
+  return (
+    (item.image === undefined || typeof item.image === 'string')
+    && (item.title === undefined || typeof item.title === 'string')
+    && (item.subtitle === undefined || typeof item.subtitle === 'string')
+  );
+};
+
+const isImageGridSection = (value: unknown): value is PageSection => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const section = value as Record<string, unknown>;
+
+  return section.type === 'imageGrid' && Array.isArray(section.items) && section.items.every(isImageGridItem);
+};
+
+const isPageSection = (value: unknown): value is PageSection => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const section = value as Record<string, unknown>;
+
+  if (section.type === 'timeline') {
+    return isTimelineSection(section);
+  }
+
+  if (section.type === 'imageTextHalf') {
+    return isImageTextHalfSection(section);
+  }
+
+  if (section.type === 'imageGrid') {
+    return isImageGridSection(section);
+  }
+
+  return false;
+};
+
 const isPageContent = (value: unknown): value is PageContent => {
   if (!value || typeof value !== 'object') {
     return false;
@@ -43,20 +104,124 @@ const isPageContent = (value: unknown): value is PageContent => {
     return false;
   }
 
-  return content.sections.every(isTimelineSection);
+  return content.sections.every(isPageSection);
+};
+
+interface AboutStoryBlock {
+  heading?: string;
+  body?: string;
+  imageRef?: string | null;
+  imageUrl?: string | null;
+  imageAlt?: string | null;
+}
+
+interface AboutPageContent {
+  metaTitle?: string;
+  metaDescription?: string;
+  heroTitle?: string;
+  heroSubtitle?: string;
+  story?: AboutStoryBlock[];
+  sections?: PageSection[];
+}
+
+const isAboutStoryBlock = (value: unknown): value is AboutStoryBlock => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const block = value as Record<string, unknown>;
+
+  return (
+    (block.heading === undefined || typeof block.heading === 'string')
+    && (block.body === undefined || typeof block.body === 'string')
+    && (block.imageRef === undefined || block.imageRef === null || typeof block.imageRef === 'string')
+    && (block.imageUrl === undefined || block.imageUrl === null || typeof block.imageUrl === 'string')
+    && (block.imageAlt === undefined || block.imageAlt === null || typeof block.imageAlt === 'string')
+  );
+};
+
+const isAboutPageContent = (value: unknown): value is AboutPageContent => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const content = value as Record<string, unknown>;
+
+  if (content.story !== undefined) {
+    if (!Array.isArray(content.story) || !content.story.every(isAboutStoryBlock)) {
+      return false;
+    }
+  }
+
+  if (content.sections !== undefined) {
+    if (!Array.isArray(content.sections) || !content.sections.every(isPageSection)) {
+      return false;
+    }
+  }
+
+  return (
+    (content.metaTitle === undefined || typeof content.metaTitle === 'string')
+    && (content.metaDescription === undefined || typeof content.metaDescription === 'string')
+    && (content.heroTitle === undefined || typeof content.heroTitle === 'string')
+    && (content.heroSubtitle === undefined || typeof content.heroSubtitle === 'string')
+  );
 };
 
 const About: React.FC = () => {
     const { t, language } = useLanguage();
     const { settings } = useSiteSettings();
-    const aboutFieldPath = `translations.${language}.about`;
+    const translationsAboutFieldPath = `translations.${language}.about`;
+    const aboutFieldPath = `pages.about_${language}`;
     const defaultStoryImage = 'https://images.unsplash.com/photo-1598555769781-8714b14a293f?q=80&w=1974&auto=format&fit=crop';
     const defaultSourcingImage = 'https://images.unsplash.com/photo-1616893904984-7a57a3b35338?q=80&w=1964&auto=format&fit=crop';
     const storyImage = settings.about?.storyImage || defaultStoryImage;
     const sourcingImage = settings.about?.sourcingImage || defaultSourcingImage;
     const storyAlt = settings.about?.storyAlt || 'Brand story';
     const sourcingAlt = settings.about?.sourcingAlt || t('about.sourcingImageAlt');
+    const [aboutContent, setAboutContent] = useState<AboutPageContent | null>(null);
     const [storyContent, setStoryContent] = useState<PageContent | null>(null);
+
+    useEffect(() => {
+        let isMounted = true;
+        setAboutContent(null);
+
+        const loadAboutContent = async () => {
+            const localesToTry = [language, 'en'].filter((locale, index, arr) => arr.indexOf(locale) === index);
+
+            for (const locale of localesToTry) {
+                try {
+                    const response = await fetch(`/content/pages/${locale}/about.json`);
+                    if (!response.ok) {
+                        continue;
+                    }
+
+                    const data = (await response.json()) as unknown;
+                    if (!isMounted) {
+                        return;
+                    }
+
+                    if (isAboutPageContent(data)) {
+                        setAboutContent(data);
+                        return;
+                    }
+                } catch (error) {
+                    if (locale === localesToTry[localesToTry.length - 1]) {
+                        console.error('Failed to load about page content', error);
+                    }
+                }
+            }
+
+            if (isMounted) {
+                setAboutContent(null);
+            }
+        };
+
+        void loadAboutContent();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [language]);
 
     useEffect(() => {
         let isMounted = true;
@@ -100,10 +265,32 @@ const About: React.FC = () => {
         };
     }, [language]);
 
-    const timelineFieldPath = `pages.story_${language}.sections`;
-    const storySections = storyContent?.sections ?? [];
-    const computedTitle = storyContent?.metaTitle ?? `${t('about.title')} | Kapunka Skincare`;
-    const computedDescription = storyContent?.metaDescription ?? t('about.metaDescription');
+    const aboutStoryBlocks = aboutContent?.story?.filter((block) => {
+        if (!block) {
+            return false;
+        }
+
+        const hasText = Boolean(block.heading && block.heading.trim()) || Boolean(block.body && block.body.trim());
+        const hasImage = Boolean(block.imageUrl && block.imageUrl.trim()) || Boolean(block.imageRef && block.imageRef.trim());
+        return hasText || hasImage;
+    }) ?? [];
+
+    const rawAboutSections = aboutContent?.sections;
+    const sectionsFromAbout = Array.isArray(rawAboutSections) ? rawAboutSections : [];
+    const fallbackSections = storyContent?.sections ?? [];
+    const sectionsToRender = sectionsFromAbout.length > 0 ? sectionsFromAbout : fallbackSections;
+    const sectionsFieldPath = sectionsFromAbout.length > 0
+        ? `${aboutFieldPath}.sections`
+        : `pages.story_${language}.sections`;
+
+    const metaTitleBase = aboutContent?.metaTitle
+        ?? storyContent?.metaTitle
+        ?? t('about.title');
+    const computedDescription = aboutContent?.metaDescription
+        ?? storyContent?.metaDescription
+        ?? t('about.metaDescription');
+    const computedTitle = metaTitleBase.includes('Kapunka') ? metaTitleBase : `${metaTitleBase} | Kapunka Skincare`;
+
   return (
     <div>
         <Helmet>
@@ -117,7 +304,7 @@ const About: React.FC = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
             className="text-4xl sm:text-5xl font-semibold tracking-tight"
-            data-nlv-field-path={`${aboutFieldPath}.headerTitle`}
+            data-nlv-field-path={`${translationsAboutFieldPath}.headerTitle`}
           >
             {t('about.headerTitle')}
           </motion.h1>
@@ -126,7 +313,7 @@ const About: React.FC = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.1 }}
             className="mt-4 text-lg text-stone-600 max-w-3xl mx-auto"
-            data-nlv-field-path={`${aboutFieldPath}.headerSubtitle`}
+            data-nlv-field-path={`${translationsAboutFieldPath}.headerSubtitle`}
           >
             {t('about.headerSubtitle')}
           </motion.p>
@@ -135,87 +322,173 @@ const About: React.FC = () => {
 
       <div className="py-16 sm:py-24">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid md:grid-cols-2 gap-12 items-center">
-            <motion.div
-                initial={{ opacity: 0, x: -30 }}
-                whileInView={{ opacity: 1, x: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.6 }}
-            >
-              <h2
-                className="text-3xl font-semibold mb-6"
-                data-nlv-field-path={`${aboutFieldPath}.storyTitle`}
-              >
-                {t('about.storyTitle')}
-              </h2>
-              <div className="text-stone-600 leading-relaxed space-y-4">
-                <p data-nlv-field-path={`${aboutFieldPath}.storyText1`}>
-                  {t('about.storyText1')}
-                </p>
-                <p data-nlv-field-path={`${aboutFieldPath}.storyText2`}>
-                  {t('about.storyText2')}
-                </p>
-              </div>
-            </motion.div>
-            <motion.div
-                initial={{ opacity: 0, x: 30 }}
-                whileInView={{ opacity: 1, x: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.6 }}
-            >
-              <img
-                src={storyImage}
-                alt={storyAlt}
-                className="rounded-lg shadow-lg"
-                data-nlv-field-path="site.about.storyImage"
-              />
-            </motion.div>
-          </div>
+          {aboutStoryBlocks.length > 0 ? (
+            <>
+              <div className="space-y-16">
+                {aboutStoryBlocks.map((block, index) => {
+                    const imageUrl = block.imageUrl ?? block.imageRef ?? undefined;
+                    const hasImage = Boolean(imageUrl);
+                    const imageFirst = hasImage && index % 2 === 0;
+                    const storyBlockFieldPath = `${aboutFieldPath}.story.${index}`;
+                    const textOrderClass = hasImage ? (imageFirst ? 'md:order-2' : 'md:order-1') : '';
+                    const imageOrderClass = hasImage ? (imageFirst ? 'md:order-1' : 'md:order-2') : '';
+                    const bodyParagraphs = block.body
+                        ? block.body.split(/\n\s*\n/).filter(Boolean)
+                        : [];
+                    const imageFieldPath = block.imageRef ? `${storyBlockFieldPath}.imageRef` : `${storyBlockFieldPath}.imageUrl`;
 
-          {storySections.length > 0 && (
-            <div className="mt-20 sm:mt-28">
-              <SectionRenderer sections={storySections} fieldPath={timelineFieldPath} />
-            </div>
+                    const textContent = (
+                        <motion.div
+                            initial={{ opacity: 0, x: imageFirst ? 30 : -30 }}
+                            whileInView={{ opacity: 1, x: 0 }}
+                            viewport={{ once: true }}
+                            transition={{ duration: 0.6 }}
+                            className={textOrderClass}
+                        >
+                            {block.heading ? (
+                                <h2
+                                    className="text-3xl font-semibold mb-6"
+                                    data-nlv-field-path={`${storyBlockFieldPath}.heading`}
+                                >
+                                    {block.heading}
+                                </h2>
+                            ) : null}
+                            {block.body ? (
+                                <div
+                                    className="text-stone-600 leading-relaxed space-y-4"
+                                    data-nlv-field-path={`${storyBlockFieldPath}.body`}
+                                >
+                                    {bodyParagraphs.length > 0
+                                        ? bodyParagraphs.map((paragraph, paragraphIndex) => (
+                                            <p key={`${index}-${paragraphIndex}`}>{paragraph}</p>
+                                        ))
+                                        : <p>{block.body}</p>}
+                                </div>
+                            ) : null}
+                        </motion.div>
+                    );
+
+                    const imageContent = hasImage ? (
+                        <motion.div
+                            initial={{ opacity: 0, x: imageFirst ? -30 : 30 }}
+                            whileInView={{ opacity: 1, x: 0 }}
+                            viewport={{ once: true }}
+                            transition={{ duration: 0.6 }}
+                            className={imageOrderClass}
+                            data-nlv-field-path={imageFieldPath}
+                        >
+                            <img
+                                src={imageUrl}
+                                alt={block.imageAlt ?? block.heading ?? 'Story visual'}
+                                className="rounded-lg shadow-lg"
+                            />
+                        </motion.div>
+                    ) : null;
+
+                    return (
+                        <div
+                            key={`${block.heading ?? 'story'}-${index}`}
+                            className={`grid gap-12 ${hasImage ? 'md:grid-cols-2 items-center' : ''}`}
+                        >
+                            {hasImage && imageFirst ? imageContent : textContent}
+                            {hasImage && imageFirst ? textContent : null}
+                            {hasImage && !imageFirst ? imageContent : null}
+                        </div>
+                    );
+                })}
+              </div>
+
+              {sectionsToRender.length > 0 && (
+                <div className="mt-20 sm:mt-28">
+                  <SectionRenderer sections={sectionsToRender} fieldPath={sectionsFieldPath} />
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              <div className="grid md:grid-cols-2 gap-12 items-center">
+                <motion.div
+                    initial={{ opacity: 0, x: -30 }}
+                    whileInView={{ opacity: 1, x: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ duration: 0.6 }}
+                >
+                  <h2
+                    className="text-3xl font-semibold mb-6"
+                    data-nlv-field-path={`${translationsAboutFieldPath}.storyTitle`}
+                  >
+                    {t('about.storyTitle')}
+                  </h2>
+                  <div className="text-stone-600 leading-relaxed space-y-4">
+                    <p data-nlv-field-path={`${translationsAboutFieldPath}.storyText1`}>
+                      {t('about.storyText1')}
+                    </p>
+                    <p data-nlv-field-path={`${translationsAboutFieldPath}.storyText2`}>
+                      {t('about.storyText2')}
+                    </p>
+                  </div>
+                </motion.div>
+                <motion.div
+                    initial={{ opacity: 0, x: 30 }}
+                    whileInView={{ opacity: 1, x: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ duration: 0.6 }}
+                >
+                  <img
+                    src={storyImage}
+                    alt={storyAlt}
+                    className="rounded-lg shadow-lg"
+                    data-nlv-field-path="site.about.storyImage"
+                  />
+                </motion.div>
+              </div>
+
+              {sectionsToRender.length > 0 && (
+                <div className="mt-20 sm:mt-28">
+                  <SectionRenderer sections={sectionsToRender} fieldPath={sectionsFieldPath} />
+                </div>
+              )}
+
+              <div className="grid md:grid-cols-2 gap-12 items-center mt-20 sm:mt-28">
+                <motion.div
+                    initial={{ opacity: 0, x: -30 }}
+                    whileInView={{ opacity: 1, x: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ duration: 0.6 }}
+                    className="md:order-2"
+                >
+                  <h2
+                    className="text-3xl font-semibold mb-6"
+                    data-nlv-field-path={`${translationsAboutFieldPath}.sourcingTitle`}
+                  >
+                    {t('about.sourcingTitle')}
+                  </h2>
+                  <div className="text-stone-600 leading-relaxed space-y-4">
+                    <p data-nlv-field-path={`${translationsAboutFieldPath}.sourcingText1`}>
+                      {t('about.sourcingText1')}
+                    </p>
+                    <p data-nlv-field-path={`${translationsAboutFieldPath}.sourcingText2`}>
+                      {t('about.sourcingText2')}
+                    </p>
+                  </div>
+                </motion.div>
+                <motion.div
+                    initial={{ opacity: 0, x: 30 }}
+                    whileInView={{ opacity: 1, x: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ duration: 0.6 }}
+                    className="md:order-1"
+                >
+                  <img
+                    src={sourcingImage}
+                    alt={sourcingAlt}
+                    className="rounded-lg shadow-lg"
+                    data-nlv-field-path="site.about.sourcingImage"
+                  />
+                </motion.div>
+              </div>
+            </>
           )}
-
-          <div className="grid md:grid-cols-2 gap-12 items-center mt-20 sm:mt-28">
-            <motion.div
-                initial={{ opacity: 0, x: -30 }}
-                whileInView={{ opacity: 1, x: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.6 }}
-                className="md:order-2"
-            >
-              <h2
-                className="text-3xl font-semibold mb-6"
-                data-nlv-field-path={`${aboutFieldPath}.sourcingTitle`}
-              >
-                {t('about.sourcingTitle')}
-              </h2>
-              <div className="text-stone-600 leading-relaxed space-y-4">
-                <p data-nlv-field-path={`${aboutFieldPath}.sourcingText1`}>
-                  {t('about.sourcingText1')}
-                </p>
-                <p data-nlv-field-path={`${aboutFieldPath}.sourcingText2`}>
-                  {t('about.sourcingText2')}
-                </p>
-              </div>
-            </motion.div>
-            <motion.div
-                initial={{ opacity: 0, x: 30 }}
-                whileInView={{ opacity: 1, x: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.6 }}
-                className="md:order-1"
-            >
-              <img
-                src={sourcingImage}
-                alt={sourcingAlt}
-                className="rounded-lg shadow-lg"
-                data-nlv-field-path="site.about.sourcingImage"
-              />
-            </motion.div>
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- load localized About CMS content with optional story blocks and sections while preserving existing fallbacks
- surface optional Method clinical notes in a responsive two-column layout driven by CMS data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d95c9f793883209b4b23df0b8dfbdc