### PR TITLE
Add Media Sets collection to Decap CMS

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -140,6 +140,21 @@ collections:
         fields:
           - { label: "x (0..1)", name: "x", widget: "number", value_type: "float", min: 0, max: 1, required: false }
           - { label: "y (0..1)", name: "y", widget: "number", value_type: "float", min: 0, max: 1, required: false }
+  - name: "mediaSets"
+    label: "Media Sets"
+    folder: "content/media-sets"
+    create: true
+    slug: "{{slug}}"
+    i18n: false
+    fields:
+      - { label: "Title", name: "title", widget: "string" }
+      - label: "Images"
+        name: "images"
+        widget: "list"
+        summary: "{{fields.caption | default('Image')}}"
+        fields:
+          - { label: "Image", name: "src", widget: "image" }
+          - { label: "Caption (optional)", name: "caption", widget: "string", required: false }
   - name: pages
     label: Pages
     group: "1. Pages"

--- a/content/media-sets/.gitkeep
+++ b/content/media-sets/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory is tracked by Git.


### PR DESCRIPTION
## Summary
- add a Media Sets folder collection to the Decap configuration for managing grouped images
- scaffold the `content/media-sets` directory so new entries can be tracked in version control

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d96902d75483209a797deaec003f48