### PR TITLE
Content: Refresh Kapunka home hero copy

### DIFF
--- a/content/pages/en/home.json
+++ b/content/pages/en/home.json
@@ -6,7 +6,6 @@
     "clinicsCtaHref": "#/for-clinics",
     "clinicsImage": ""
   },
-  "ctaSecondary": "Clinics partnership",
   "meta": {
     "metaTitle": "Kapunka Skincare | Moroccan Argan Rituals for Clinics & Sensitive Skin",
     "metaDescription": "Kapunka formulates Moroccan argan oils, mists, and hammam treatments trusted by aesthetic clinics for post-procedure recovery, barrier repair, and daily rituals."
@@ -21,8 +20,22 @@
     "image": ""
   },
   "newsletterPitch": "Get monthly updates on clinic protocols, ingredient sourcing, and new product drops tailored for sensitive skin pros.",
-  "heroPrimaryCta": "Shop argan rituals",
-  "heroImageLeft": "",
+  "heroHeadline": "Care that listens when skin is tender.",
+  "heroSubheadline": "Kapunka 2.0 blends Moroccan argan rituals with clinical empathy so reactive and post-procedure skin can breathe easier.",
+  "heroAlignment": {
+    "heroAlignX": "center",
+    "heroAlignY": "middle",
+    "heroLayoutHint": "text-over-media",
+    "heroOverlay": true
+  },
+  "heroImages": {
+    "heroImageLeft": "",
+    "heroImageRight": ""
+  },
+  "heroCtas": {
+    "ctaPrimary": "Shop Kapunka 2.0 rituals",
+    "ctaSecondary": "Partner with our clinic team"
+  },
   "galleryRows": [
     {
       "layout": "thirds",
@@ -60,8 +73,6 @@
       ]
     }
   ],
-  "heroLayoutHint": "image-full",
-  "heroAlignX": "left",
   "sections": [
     {
       "type": "imageTextHalf",
@@ -101,9 +112,6 @@
       ]
     }
   ],
-  "heroAlignY": "middle",
-  "heroHeadline": "Be grateful to your skin.",
-  "ctaPrimary": "Shop rituals",
   "metaTitle": "",
   "testimonials": [
     {
@@ -117,8 +125,6 @@
       "role": "Founder, Lumina Aesthetics"
     }
   ],
-  "heroSecondaryCta": "Clinics partnership",
-  "heroOverlay": "rgba(0,0,0,0.48)",
   "metaDescription": "Kapunka formulates Moroccan argan oils, mists, and hammam treatments trusted by aesthetic clinics for post-procedure recovery, barrier repair, and daily rituals.",
   "methodMini": {
     "title": "Our Method: Cleanse · Replenish · Protect",
@@ -130,8 +136,6 @@
     "ctaLabel": "See the Kapunka method",
     "ctaHref": "#/method"
   },
-  "heroSubheadline": "Gentle argan rituals from Morocco, made for sensitive and post-procedure skin. Welcome to Kapunka 2.0—care that feels human.",
-  "heroImageRight": "",
   "bestsellersIntro": "Meet the three-step ritual clinics retail most—cleanse, replenish, and seal with nutrient-dense argan care.",
   "brandMini": {
     "title": "Why Kapunka",

--- a/content/pages/es/home.json
+++ b/content/pages/es/home.json
@@ -5,18 +5,22 @@
     "metaTitle": "Kapunka Skincare | Rituales de argán marroquí para clínicas y piel sensible",
     "metaDescription": "Kapunka formula aceites de argán, brumas y tratamientos de hammam marroquíes en los que confían las clínicas estéticas para la recuperación post-procedimiento, la reparación de la barrera y los rituales diarios."
   },
-  "heroHeadline": "Agradece a tu piel.",
-  "heroSubheadline": "Rituales suaves de argán de Marruecos, creados para piel sensible y post-procedimiento. Bienvenido a Kapunka 2.0—cuidado con calidez humana.",
-  "heroPrimaryCta": "Comprar rituales de argán",
-  "ctaPrimary": "Ver rituales",
-  "ctaSecondary": "Alianza con clínicas",
-  "heroAlignX": "center",
-  "heroAlignY": "middle",
-  "heroSecondaryCta": "Alianza para clínicas",
-  "heroOverlay": "rgba(0,0,0,0.48)",
-  "heroImageLeft": "",
-  "heroImageRight": "",
-  "heroLayoutHint": "image-full",
+  "heroHeadline": "Cuidado que escucha cuando la piel duele.",
+  "heroSubheadline": "Kapunka 2.0 une rituales marroquíes de argán con empatía clínica para que la piel reactiva y post-procedimiento respire tranquila.",
+  "heroAlignment": {
+    "heroAlignX": "center",
+    "heroAlignY": "middle",
+    "heroLayoutHint": "text-over-media",
+    "heroOverlay": true
+  },
+  "heroImages": {
+    "heroImageLeft": "",
+    "heroImageRight": ""
+  },
+  "heroCtas": {
+    "ctaPrimary": "Comprar rituales Kapunka 2.0",
+    "ctaSecondary": "Habla con nuestro equipo clínico"
+  },
   "brandIntro": {
     "title": "Nacido del agradecimiento",
     "text": "Kapunka significa “gracias”. Hacemos cuidado de argán puro con respeto clínico—rutinas simples que calman la piel y apoyan la recuperación. Nuestro aceite procede de cooperativas en Marruecos y se clarifica sin disolventes."

--- a/content/pages/pt/home.json
+++ b/content/pages/pt/home.json
@@ -5,18 +5,22 @@
     "metaTitle": "Kapunka Skincare | Rituais de argan marroquino para clínicas e pele sensível",
     "metaDescription": "A Kapunka formula óleos de argan, névoas e tratamentos de hammam marroquinos confiados por clínicas estéticas para recuperação pós-procedimento, reparo da barreira e rituais diários."
   },
-  "heroHeadline": "Agradece à tua pele.",
-  "heroSubheadline": "Rituais suaves de argão de Marrocos, pensados para pele sensível e pós-procedimento. Bem-vindo à Kapunka 2.0—cuidado com toque humano.",
-  "heroPrimaryCta": "Comprar rituais de argan",
-  "ctaPrimary": "Ver rituais",
-  "ctaSecondary": "Parceria com clínicas",
-  "heroAlignX": "center",
-  "heroAlignY": "middle",
-  "heroSecondaryCta": "Parceria para clínicas",
-  "heroOverlay": "rgba(0,0,0,0.48)",
-  "heroImageLeft": "",
-  "heroImageRight": "",
-  "heroLayoutHint": "image-full",
+  "heroHeadline": "Cuidado que escuta quando a pele está sensível.",
+  "heroSubheadline": "A Kapunka 2.0 une rituais marroquinos de argão e empatia clínica para que a pele reativa e pós-procedimento respire com calma.",
+  "heroAlignment": {
+    "heroAlignX": "center",
+    "heroAlignY": "middle",
+    "heroLayoutHint": "text-over-media",
+    "heroOverlay": true
+  },
+  "heroImages": {
+    "heroImageLeft": "",
+    "heroImageRight": ""
+  },
+  "heroCtas": {
+    "ctaPrimary": "Comprar rituais Kapunka 2.0",
+    "ctaSecondary": "Falar com a nossa equipa clínica"
+  },
   "brandIntro": {
     "title": "Nascido da gratidão",
     "text": "Kapunka significa “obrigado”. Criamos cuidados de argão puros com rigor clínico—rotinas simples que acalmam a pele e apoiam a recuperação. O nosso óleo é obtido de cooperativas em Marrocos e clarificado sem solventes."

--- a/site/content/en/pages/home.json
+++ b/site/content/en/pages/home.json
@@ -5,18 +5,22 @@
     "metaTitle": "Kapunka — Moroccan argan care for sensitive & post-procedure skin",
     "metaDescription": "Single-origin Moroccan argan oils, floral waters, and traditional treatments designed for sensitive and post-procedure skin. Clinically trusted, heritage sourced."
   },
-  "heroHeadline": "Pure argan care. Born from gratitude, trusted by experts.",
-  "heroSubheadline": "Single-origin Moroccan argan and simple, science-aware routines for sensitive, post-procedure, and everyday skin.",
-  "heroPrimaryCta": "Shop rituals",
-  "heroSecondaryCta": "For Clinics",
-  "ctaPrimary": "Shop rituals",
-  "ctaSecondary": "For Clinics",
-  "heroAlignX": "left",
-  "heroAlignY": "bottom",
-  "heroOverlay": "rgba(0,0,0,0.48)",
-  "heroImageLeft": "",
-  "heroImageRight": "",
-  "heroLayoutHint": "image-right",
+  "heroHeadline": "Care that listens when skin is tender.",
+  "heroSubheadline": "Kapunka 2.0 blends Moroccan argan rituals with clinical empathy so reactive and post-procedure skin can breathe easier.",
+  "heroAlignment": {
+    "heroAlignX": "center",
+    "heroAlignY": "middle",
+    "heroLayoutHint": "text-over-media",
+    "heroOverlay": true
+  },
+  "heroImages": {
+    "heroImageLeft": "",
+    "heroImageRight": ""
+  },
+  "heroCtas": {
+    "ctaPrimary": "Shop Kapunka 2.0 rituals",
+    "ctaSecondary": "Partner with our clinic team"
+  },
   "brandIntro": {
     "title": "Born from gratitude",
     "text": "Kapunka means “thank you.” We make pure argan care with clinical respect—simple routines that comfort skin and support healing. Our oil is cooperatively sourced in Morocco and clarified without solvents."

--- a/site/content/es/pages/home.json
+++ b/site/content/es/pages/home.json
@@ -5,18 +5,22 @@
     "metaTitle": "Kapunka — Cuidado con argán para piel sensible y post-procedimiento",
     "metaDescription": "Aceites de argán de origen único, aguas florales y tratamientos tradicionales para piel sensible y post-procedimiento. Confianza clínica, origen con herencia."
   },
-  "heroHeadline": "Cuidado con argán puro. Nacido de la gratitud, confiado por especialistas.",
-  "heroSubheadline": "Argán marroquí de origen único y rutinas sencillas, con base científica, para piel sensible, post-procedimiento y diaria.",
-  "heroPrimaryCta": "Ver rituales",
-  "heroSecondaryCta": "Para Clínicas",
-  "ctaPrimary": "Ver rituales",
-  "ctaSecondary": "Para Clínicas",
-  "heroAlignX": "left",
-  "heroAlignY": "bottom",
-  "heroOverlay": "rgba(0,0,0,0.48)",
-  "heroImageLeft": "",
-  "heroImageRight": "",
-  "heroLayoutHint": "image-right",
+  "heroHeadline": "Cuidado que escucha cuando la piel duele.",
+  "heroSubheadline": "Kapunka 2.0 une rituales marroquíes de argán con empatía clínica para que la piel reactiva y post-procedimiento respire tranquila.",
+  "heroAlignment": {
+    "heroAlignX": "center",
+    "heroAlignY": "middle",
+    "heroLayoutHint": "text-over-media",
+    "heroOverlay": true
+  },
+  "heroImages": {
+    "heroImageLeft": "",
+    "heroImageRight": ""
+  },
+  "heroCtas": {
+    "ctaPrimary": "Comprar rituales Kapunka 2.0",
+    "ctaSecondary": "Habla con nuestro equipo clínico"
+  },
   "brandIntro": {
     "title": "Nacido del agradecimiento",
     "text": "Kapunka significa “gracias”. Hacemos cuidado de argán puro con respeto clínico—rutinas simples que calman la piel y apoyan la recuperación. Nuestro aceite procede de cooperativas en Marruecos y se clarifica sin disolventes."

--- a/site/content/pt/pages/home.json
+++ b/site/content/pt/pages/home.json
@@ -5,18 +5,22 @@
     "metaTitle": "Kapunka — Cuidado com argão para pele sensível e pós-procedimento",
     "metaDescription": "Óleos de argão de origem única, águas florais e tratamentos tradicionais para pele sensível e pós-procedimento. Confiança clínica, origem com herança."
   },
-  "heroHeadline": "Cuidado com argão puro. Nascido da gratidão, confiado por especialistas.",
-  "heroSubheadline": "Argão marroquino de origem única e rotinas simples, com base científica, para pele sensível, pós-procedimento e do dia a dia.",
-  "heroPrimaryCta": "Ver rituais",
-  "heroSecondaryCta": "Para Clínicas",
-  "ctaPrimary": "Ver rituais",
-  "ctaSecondary": "Para Clínicas",
-  "heroAlignX": "left",
-  "heroAlignY": "bottom",
-  "heroOverlay": "rgba(0,0,0,0.48)",
-  "heroImageLeft": "",
-  "heroImageRight": "",
-  "heroLayoutHint": "image-right",
+  "heroHeadline": "Cuidado que escuta quando a pele está sensível.",
+  "heroSubheadline": "A Kapunka 2.0 une rituais marroquinos de argão e empatia clínica para que a pele reativa e pós-procedimento respire com calma.",
+  "heroAlignment": {
+    "heroAlignX": "center",
+    "heroAlignY": "middle",
+    "heroLayoutHint": "text-over-media",
+    "heroOverlay": true
+  },
+  "heroImages": {
+    "heroImageLeft": "",
+    "heroImageRight": ""
+  },
+  "heroCtas": {
+    "ctaPrimary": "Comprar rituais Kapunka 2.0",
+    "ctaSecondary": "Falar com a nossa equipa clínica"
+  },
   "brandIntro": {
     "title": "Nascido da gratidão",
     "text": "Kapunka significa “obrigado”. Criamos cuidados de argão puros com rigor clínico—rotinas simples que acalmam a pele e apoiam a recuperação. O nosso óleo é obtido de cooperativas em Marrocos e clarificado sem solventes."


### PR DESCRIPTION
## Summary
- update English, Portuguese, and Spanish home hero headline, subheadline, and CTAs with new Kapunka 2.0 messaging
- configure the new hero alignment group to center text over media with overlay enabled while keeping existing imagery references intact
- mirror the updated hero copy and alignment structure in the Netlify Visual Editor content under site/content

## Testing
- npm run build *(fails: missing dependency "zod" referenced by pages/Home.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68d973f641d48320bd09e5dc4ba1c073