### PR TITLE
CMS: shared section templates + sections list on all pages

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,3 +1,91 @@
+# ===== Shared Section Templates (anchors) =====
+shared_sections: &shared_sections
+  - label: "Hero"
+    name: "hero"
+    widget: "object"
+    fields:
+      - { label: "Headline", name: "headline", widget: "string", i18n: true }
+      - { label: "Subheadline", name: "subheadline", widget: "text", i18n: true, required: false }
+      - label: "Text Position"
+        name: "position"
+        widget: "select"
+        options: ["top-left","top-center","top-right","middle-left","middle-center","middle-right","bottom-left","bottom-center","bottom-right"]
+        required: false
+      - label: "Background Image"
+        name: "image"
+        widget: "image"
+        required: false
+      - { label: "Overlay", name: "overlay", widget: "boolean", default: true }
+      - { label: "Primary CTA", name: "ctaPrimary", widget: "string", i18n: true, required: false }
+      - { label: "Secondary CTA", name: "ctaSecondary", widget: "string", i18n: true, required: false }
+  - label: "Media + Copy"
+    name: "mediaCopy"
+    widget: "object"
+    fields:
+      - { label: "Title", name: "title", widget: "string", i18n: true }
+      - { label: "Body", name: "body", widget: "text", i18n: true }
+      - { label: "Image", name: "image", widget: "image" }
+      - { label: "Layout", name: "layout", widget: "select", options: ["image-left","image-right"] }
+      - { label: "Columns (1–3)", name: "columns", widget: "number", min: 1, max: 3, default: 1 }
+  - label: "Feature Grid"
+    name: "featureGrid"
+    widget: "object"
+    fields:
+      - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
+      - label: "Items"
+        name: "items"
+        widget: "list"
+        fields:
+          - { label: "Label", name: "label", widget: "string", i18n: true }
+          - { label: "Description", name: "description", widget: "text", i18n: true, required: false }
+          - { label: "Icon/Image", name: "icon", widget: "image", required: false }
+      - { label: "Columns (2–4)", name: "columns", widget: "number", min: 2, max: 4, default: 4 }
+  - label: "Product Grid"
+    name: "productGrid"
+    widget: "object"
+    fields:
+      - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
+      - label: "Products (keys or SKUs)"
+        name: "products"
+        widget: "list"
+        field: { label: "Product ID", name: "id", widget: "string" }
+      - { label: "Columns (2–4)", name: "columns", widget: "number", min: 2, max: 4, default: 3 }
+  - label: "Testimonials"
+    name: "testimonials"
+    widget: "object"
+    fields:
+      - label: "Quotes"
+        name: "quotes"
+        widget: "list"
+        fields:
+          - { label: "Quote", name: "text", widget: "text", i18n: true }
+          - { label: "Author", name: "author", widget: "string", i18n: true }
+          - { label: "Role", name: "role", widget: "string", i18n: true, required: false }
+  - label: "FAQ"
+    name: "faq"
+    widget: "object"
+    fields:
+      - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
+      - label: "Items"
+        name: "items"
+        widget: "list"
+        fields:
+          - { label: "Q", name: "q", widget: "string", i18n: true }
+          - { label: "A", name: "a", widget: "text", i18n: true }
+  - label: "Banner"
+    name: "banner"
+    widget: "object"
+    fields:
+      - { label: "Text", name: "text", widget: "string", i18n: true }
+      - { label: "CTA Label", name: "cta", widget: "string", i18n: true, required: false }
+      - { label: "CTA URL", name: "url", widget: "string", required: false }
+  - label: "Video"
+    name: "video"
+    widget: "object"
+    fields:
+      - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
+      - { label: "Embed URL", name: "url", widget: "string" }
+
 # SINGLE SOURCE OF TRUTH for Decap CMS (production /admin). Do not edit site/admin/config.yml.
 backend:
   name: git-gateway
@@ -202,51 +290,7 @@ collections:
           - label: "Sections"
             name: "sections"
             widget: "list"
-            types:
-              - label: "Value Pillars"
-                name: "pillars"
-                widget: "object"
-                summary: "Pillars: {{fields.title}}"
-                fields:
-                  - { label: "Title", name: "title", widget: "string", i18n: true }
-                  - label: "Items"
-                    name: "items"
-                    widget: "list"
-                    fields:
-                      - { label: "Label", name: "label", widget: "string", i18n: true }
-                      - { label: "Description", name: "description", widget: "text", required: false, i18n: true }
-                      - { label: "Icon/Image", name: "icon", widget: "image", required: false }
-              - label: "Image + Copy"
-                name: "mediaCopy"
-                widget: "object"
-                summary: "Media+Copy: {{fields.title}} ({{fields.layout}})"
-                fields:
-                  - { label: "Title", name: "title", widget: "string", i18n: true }
-                  - { label: "Body", name: "body", widget: "text", i18n: true }
-                  - { label: "Image", name: "image", widget: "image" }
-                  - {
-                      label: "Image from Media Set (alt to upload)",
-                      name: "imageRef",
-                      widget: "relation",
-                      collection: "mediaSets",
-                      searchFields: ["title", "images.caption"],
-                      valueField: "images.*.src",
-                      displayFields: ["title"],
-                      required: false
-                    }
-                  - { label: "Layout", name: "layout", widget: "select", options: ["image-left", "image-right"], default: "image-right" }
-              - label: "Testimonials"
-                name: "testimonials"
-                widget: "object"
-                summary: "Testimonials"
-                fields:
-                  - label: "Quotes"
-                    name: "quotes"
-                    widget: "list"
-                    fields:
-                      - { label: "Quote", name: "text", widget: "text", i18n: true }
-                      - { label: "Author", name: "author", widget: "string", i18n: true }
-                      - { label: "Role", name: "role", widget: "string", required: false, i18n: true }
+            types: *shared_sections
           # keep existing fields after this unchanged
           - { label: Primary CTA Label, name: heroPrimaryCta, widget: string, required: false }
           - { label: Secondary CTA Label, name: heroSecondaryCta, widget: string, required: false }
@@ -436,74 +480,10 @@ collections:
         fields:
           - { label: Meta Title, name: metaTitle, widget: string, required: false }
           - { label: Meta Description, name: metaDescription, widget: text, required: false }
-          - &standard_sections_field
-            label: Sections
-            name: sections
-            widget: list
-            required: false
-            types:
-              - label: Timeline
-                name: timeline
-                widget: object
-                fields:
-                  - { label: Title, name: title, widget: string, required: false }
-                  - label: Entries
-                    name: entries
-                    widget: list
-                    summary: "{{fields.year}} — {{fields.title}}"
-                    fields:
-                      - { label: Year, name: year, widget: string, required: false }
-                      - { label: Title, name: title, widget: text, required: false }
-                      - { label: Description, name: description, widget: markdown, required: false }
-                      - { label: Image, name: image, widget: image, choose_url: true, required: false }
-              - label: Image + Copy
-                name: imageTextHalf
-                widget: object
-                fields:
-                  - { label: Title, name: title, widget: string, required: false }
-                  - { label: Body, name: text, widget: text, required: false }
-                  - { label: Image, name: image, widget: image, choose_url: true, required: false }
-              - label: Image Grid
-                name: imageGrid
-                widget: object
-                fields:
-                  - label: Items
-                    name: items
-                    widget: list
-                    summary: "{{fields.title}}"
-                    fields:
-                      - { label: Image, name: image, widget: image, choose_url: true, required: false }
-                      - { label: Title, name: title, widget: string, required: false }
-                      - { label: Subtitle, name: subtitle, widget: string, required: false }
-              - label: Video Gallery
-                name: videoGallery
-                widget: object
-                fields:
-                  - { label: Title, name: title, widget: string, required: false }
-                  - { label: Description, name: description, widget: text, required: false }
-                  - label: Videos
-                    name: entries
-                    widget: list
-                    summary: "{{fields.title}}"
-                    fields:
-                      - { label: Title, name: title, widget: string, required: false }
-                      - { label: Description, name: description, widget: text, required: false }
-                      - { label: Video URL, name: videoUrl, widget: string, required: false }
-                      - { label: Thumbnail, name: thumbnail, widget: image, choose_url: true, required: false }
-              - label: Training List
-                name: trainingList
-                widget: object
-                fields:
-                  - { label: Title, name: title, widget: string, required: false }
-                  - { label: Description, name: description, widget: text, required: false }
-                  - label: Trainings
-                    name: entries
-                    widget: list
-                    summary: "{{fields.courseTitle}}"
-                    fields:
-                      - { label: Course Title, name: courseTitle, widget: string, required: false }
-                      - { label: Course Summary, name: courseSummary, widget: text, required: false }
-                      - { label: Link URL, name: linkUrl, widget: string, required: false }
+          - label: "Sections"
+            name: "sections"
+            widget: "list"
+            types: *shared_sections
       - name: learn
         label: Learn Page
         file: content/pages/learn.json
@@ -512,7 +492,10 @@ collections:
         fields:
           - { label: Meta Title, name: metaTitle, widget: string, required: false }
           - { label: Meta Description, name: metaDescription, widget: text, required: false }
-          - *standard_sections_field
+          - label: "Sections"
+            name: "sections"
+            widget: "list"
+            types: *shared_sections
       - name: method
         label: Method Page
         file: content/pages/method.json
@@ -533,39 +516,10 @@ collections:
                 name: bullets
                 widget: list
                 field: { label: Item, name: item, widget: string }
-          - label: Sections
-            name: sections
-            widget: list
-            types:
-              - label: Fact Block
-                name: facts
-                widget: object
-                fields:
-                  - { label: Title, name: title, widget: string }
-                  - { label: Text, name: text, widget: text }
-              - label: Bullet List
-                name: bullets
-                widget: object
-                fields:
-                  - { label: Title, name: title, widget: string }
-                  - label: Items
-                    name: items
-                    widget: list
-                    field: { label: Item, name: item, widget: string }
-              - label: Specialties Accordion
-                name: specialties
-                widget: object
-                fields:
-                  - label: Specialties
-                    name: items
-                    widget: list
-                    summary: "{{fields.title}}"
-                    fields:
-                      - { label: Title, name: title, widget: string }
-                      - label: Bullets
-                        name: bullets
-                        widget: list
-                        field: { label: Bullet, name: bullet, widget: string }
+          - label: "Sections"
+            name: "sections"
+            widget: "list"
+            types: *shared_sections
       - name: clinics
         label: For Clinics Page
         file: content/pages/clinics.json
@@ -574,7 +528,10 @@ collections:
         fields:
           - { label: Meta Title, name: metaTitle, widget: string, required: false }
           - { label: Meta Description, name: metaDescription, widget: text, required: false }
-          - *standard_sections_field
+          - label: "Sections"
+            name: "sections"
+            widget: "list"
+            types: *shared_sections
       - name: about
         label: About Page
         file: content/pages/about.json
@@ -599,24 +556,10 @@ collections:
                 value_field: image
                 display_fields: ["title"]
                 required: false
-          - label: Sections
-            name: sections
-            widget: list
-            types:
-              - label: Timeline
-                name: timeline
-                widget: object
-                fields:
-                  - { label: Title, name: title, widget: string, required: false }
-                  - label: Entries
-                    name: entries
-                    widget: list
-                    summary: "{{fields.year}} — {{fields.title}}"
-                    fields:
-                      - { label: Year, name: year, widget: string }
-                      - { label: Title, name: title, widget: text }
-                      - { label: Description, name: description, widget: markdown }
-                      - { label: Image, name: image, widget: image, choose_url: true, required: false }
+          - label: "Sections"
+            name: "sections"
+            widget: "list"
+            types: *shared_sections
       - name: contact
         label: Contact Page
         file: content/pages/contact.json
@@ -625,7 +568,10 @@ collections:
         fields:
           - { label: Meta Title, name: metaTitle, widget: string, required: false }
           - { label: Meta Description, name: metaDescription, widget: text, required: false }
-          - *standard_sections_field
+          - label: "Sections"
+            name: "sections"
+            widget: "list"
+            types: *shared_sections
   - name: translations
     label: Translations
     files:


### PR DESCRIPTION
## Summary
- define shared section templates anchor in Decap CMS config
- reuse the shared section list for the Home, Shop, Learn, Method, Clinics, About, and Contact page collections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d9a950dc588320951a0b62232081b0