### PR TITLE
feat: add locale links to cms preview header

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -21,6 +21,171 @@
           return;
         }
 
+        var defaultLocale = 'en';
+        var supportedLocales = ['en', 'pt', 'es'];
+        var localeLinksContainerId = 'cms-preview-locale-links';
+        var latestEntryLocale = null;
+        var refreshScheduled = false;
+
+        function getLocaleFromPath(path) {
+          if (typeof path !== 'string') {
+            return null;
+          }
+          var match = path.match(/\/(en|pt|es)\//);
+          return match ? match[1] : null;
+        }
+
+        function parseHashInfo() {
+          var hash = window.location.hash || '';
+          if (!hash) {
+            return null;
+          }
+
+          var questionIndex = hash.indexOf('?');
+          var base = questionIndex === -1 ? hash : hash.slice(0, questionIndex);
+          var queryString = questionIndex === -1 ? '' : hash.slice(questionIndex + 1);
+          var params = new window.URLSearchParams(queryString);
+          var segments = base.replace(/^#\/?/, '').split('/').filter(Boolean);
+
+          if (segments.length < 4 || segments[0] !== 'collections' || segments[2] !== 'entries') {
+            return {
+              view: 'other',
+              base: base,
+              params: params,
+              collection: segments[1] || '',
+              locale: params.get('locale') || null
+            };
+          }
+
+          return {
+            view: 'entry',
+            base: base,
+            params: params,
+            collection: segments[1] || '',
+            slug: segments[3] || '',
+            locale: params.get('locale') || null
+          };
+        }
+
+        function buildLocaleHash(base, params, locale) {
+          var cloned = new window.URLSearchParams(params.toString());
+          cloned.set('locale', locale);
+          var search = cloned.toString();
+          return search ? base + '?' + search : base;
+        }
+
+        function findPreviewHeader() {
+          var selectors = [
+            '[data-testid="preview-pane-top-bar"]',
+            '[class*="PreviewPaneTopBar"]',
+            '[class*="PreviewPaneHeader"]',
+            '[class*="PreviewPane"] [class*="TopBar"]'
+          ];
+
+          for (var i = 0; i < selectors.length; i += 1) {
+            var node = document.querySelector(selectors[i]);
+            if (node) {
+              return node;
+            }
+          }
+
+          return null;
+        }
+
+        function ensureLocaleContainer(header) {
+          if (!header) {
+            return null;
+          }
+
+          var container = header.querySelector('#' + localeLinksContainerId);
+
+          if (!container) {
+            container = document.createElement('div');
+            container.id = localeLinksContainerId;
+            container.style.display = 'flex';
+            container.style.alignItems = 'center';
+            container.style.fontSize = '11px';
+            container.style.letterSpacing = '0.08em';
+            container.style.textTransform = 'uppercase';
+            container.style.gap = '6px';
+            container.style.marginLeft = 'auto';
+            container.style.color = '#486581';
+            container.style.userSelect = 'none';
+            header.appendChild(container);
+          }
+
+          return container;
+        }
+
+        function renderLocaleLinks() {
+          var header = findPreviewHeader();
+          if (!header) {
+            return;
+          }
+
+          var container = ensureLocaleContainer(header);
+          if (!container) {
+            return;
+          }
+
+          var info = parseHashInfo();
+          if (!info || info.view !== 'entry' || info.collection !== 'pages') {
+            container.style.display = 'none';
+            return;
+          }
+
+          var activeLocale = info.locale || latestEntryLocale || defaultLocale;
+          container.style.display = 'flex';
+          container.innerHTML = '';
+
+          for (var i = 0; i < supportedLocales.length; i += 1) {
+            var locale = supportedLocales[i];
+            var link = document.createElement('a');
+            link.href = buildLocaleHash(info.base, info.params, locale);
+            link.textContent = locale.toUpperCase();
+            link.style.color = '#243b53';
+            link.style.opacity = locale === activeLocale ? '1' : '0.6';
+            link.style.textDecoration = 'none';
+            link.style.cursor = locale === activeLocale ? 'default' : 'pointer';
+
+            container.appendChild(link);
+
+            if (i < supportedLocales.length - 1) {
+              var separator = document.createElement('span');
+              separator.textContent = '|';
+              separator.style.opacity = '0.35';
+              container.appendChild(separator);
+            }
+          }
+        }
+
+        function scheduleLocaleRender() {
+          if (refreshScheduled) {
+            return;
+          }
+
+          refreshScheduled = true;
+          window.requestAnimationFrame(function () {
+            refreshScheduled = false;
+            renderLocaleLinks();
+          });
+        }
+
+        function noteEntryLocale(entry) {
+          if (!entry || typeof entry.get !== 'function') {
+            return;
+          }
+
+          var path = entry.get('path');
+          var localeFromPath = getLocaleFromPath(path);
+          if (localeFromPath) {
+            latestEntryLocale = localeFromPath;
+          }
+        }
+
+        window.addEventListener('hashchange', scheduleLocaleRender);
+        scheduleLocaleRender();
+
         var containerStyle = {
           fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
           padding: '24px',
@@ -167,6 +332,9 @@
               createElement('div', { style: sectionTitleStyle }, titleText || 'Untitled section')
             );
           });
+
+          noteEntryLocale(entry);
+          scheduleLocaleRender();
 
           return createElement(
             'div',


### PR DESCRIPTION
## Summary
- add a preview-pane locale switcher that links to the current page in EN, PT, and ES
- infer the active locale from the entry path or URL hash and update links as the entry changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d9bf7c5a548320ba6be23a613cf612