### PR TITLE
Clarify hero text position hint

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -6,9 +6,10 @@ shared_sections: &shared_sections
     fields:
       - { label: "Headline", name: "headline", widget: "string", i18n: true }
       - { label: "Subheadline", name: "subheadline", widget: "text", i18n: true, required: false }
-      - label: "Text Position"
+      - label: "Hero Text Position"
         name: "position"
         widget: "select"
+        hint: "Controls alignment on desktop & mobile."
         options: ["top-left","top-center","top-right","middle-left","middle-center","middle-right","bottom-left","bottom-center","bottom-right"]
         required: false
       - label: "Background Image"


### PR DESCRIPTION
## Summary
- rename the hero text alignment field label in the shared hero section schema
- add guidance hint describing how the hero text position affects alignment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d9cb0ee1f083209a3e8e379eafdc71