### PR TITLE
Update pages collection section schema

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,91 +1,88 @@
 # ===== Shared Section Templates (anchors) =====
 shared_sections: &shared_sections
-  - label: "Hero"
-    name: "hero"
-    widget: "object"
-    fields:
-      - { label: "Headline", name: "headline", widget: "string", i18n: true }
-      - { label: "Subheadline", name: "subheadline", widget: "text", i18n: true, required: false }
-      - label: "Hero Text Position"
-        name: "position"
-        widget: "select"
-        hint: "Controls alignment on desktop & mobile."
-        options: ["top-left","top-center","top-right","middle-left","middle-center","middle-right","bottom-left","bottom-center","bottom-right"]
-        required: false
-      - label: "Background Image"
-        name: "image"
-        widget: "image"
-        required: false
-      - { label: "Overlay", name: "overlay", widget: "boolean", default: true }
-      - { label: "Primary CTA", name: "ctaPrimary", widget: "string", i18n: true, required: false }
-      - { label: "Secondary CTA", name: "ctaSecondary", widget: "string", i18n: true, required: false }
-  - label: "Media + Copy"
+  - &section_mediaCopy
+    label: "Media + Copy"
     name: "mediaCopy"
     widget: "object"
     fields:
+      - { name: "type", widget: "hidden", default: "mediaCopy" }
       - { label: "Title", name: "title", widget: "string", i18n: true }
-      - { label: "Body", name: "body", widget: "text", i18n: true }
-      - { label: "Image", name: "image", widget: "image" }
-      - { label: "Layout", name: "layout", widget: "select", options: ["image-left","image-right"] }
-      - { label: "Columns (1–3)", name: "columns", widget: "number", min: 1, max: 3, default: 1 }
-  - label: "Feature Grid"
+      - { label: "Body", name: "body", widget: "markdown", i18n: true }
+      - { label: "Image", name: "image", widget: "image", required: false }
+      - { label: "Media Alignment", name: "mediaAlign", widget: "select", options: ["left", "right"], default: "left" }
+      - { label: "Background", name: "background", widget: "select", options: ["none", "muted"], default: "none" }
+      - { label: "CTA Label", name: "ctaLabel", widget: "string", i18n: true, required: false }
+      - { label: "CTA Href", name: "ctaHref", widget: "string", required: false }
+  - &section_featureGrid
+    label: "Feature Grid"
     name: "featureGrid"
     widget: "object"
     fields:
+      - { name: "type", widget: "hidden", default: "featureGrid" }
       - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
-      - label: "Items"
-        name: "items"
+      - label: "Features"
+        name: "features"
         widget: "list"
         fields:
-          - { label: "Label", name: "label", widget: "string", i18n: true }
-          - { label: "Description", name: "description", widget: "text", i18n: true, required: false }
-          - { label: "Icon/Image", name: "icon", widget: "image", required: false }
-      - { label: "Columns (2–4)", name: "columns", widget: "number", min: 2, max: 4, default: 4 }
-  - label: "Product Grid"
+          - { label: "Title", name: "title", widget: "string", i18n: true }
+          - { label: "Description", name: "text", widget: "markdown", i18n: true }
+  - &section_productGrid
+    label: "Product Grid"
     name: "productGrid"
     widget: "object"
     fields:
+      - { name: "type", widget: "hidden", default: "productGrid" }
       - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
-      - label: "Products (keys or SKUs)"
-        name: "products"
-        widget: "list"
-        field: { label: "Product ID", name: "id", widget: "string" }
-      - { label: "Columns (2–4)", name: "columns", widget: "number", min: 2, max: 4, default: 3 }
-  - label: "Testimonials"
+      - { label: "Products", name: "productsRef", widget: "relation", collection: "Products", search_fields: ["title"], value_field: "slug", multiple: true, required: false }
+      - { label: "Note", name: "note", widget: "text", i18n: true, required: false }
+  - &section_testimonials
+    label: "Testimonials"
     name: "testimonials"
     widget: "object"
     fields:
-      - label: "Quotes"
-        name: "quotes"
-        widget: "list"
-        fields:
-          - { label: "Quote", name: "text", widget: "text", i18n: true }
-          - { label: "Author", name: "author", widget: "string", i18n: true }
-          - { label: "Role", name: "role", widget: "string", i18n: true, required: false }
-  - label: "FAQ"
-    name: "faq"
-    widget: "object"
-    fields:
+      - { name: "type", widget: "hidden", default: "testimonials" }
       - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
       - label: "Items"
         name: "items"
         widget: "list"
         fields:
-          - { label: "Q", name: "q", widget: "string", i18n: true }
-          - { label: "A", name: "a", widget: "text", i18n: true }
-  - label: "Banner"
+          - { label: "Quote", name: "quote", widget: "markdown", i18n: true }
+          - { label: "Author", name: "author", widget: "string", required: false }
+          - { label: "Role", name: "role", widget: "string", required: false }
+  - &section_faq
+    label: "FAQ"
+    name: "faq"
+    widget: "object"
+    fields:
+      - { name: "type", widget: "hidden", default: "faq" }
+      - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
+      - label: "Items"
+        name: "items"
+        widget: "list"
+        fields:
+          - { label: "Question", name: "q", widget: "string", i18n: true }
+          - { label: "Answer", name: "a", widget: "markdown", i18n: true }
+  - &section_banner
+    label: "Banner"
     name: "banner"
     widget: "object"
     fields:
-      - { label: "Text", name: "text", widget: "string", i18n: true }
-      - { label: "CTA Label", name: "cta", widget: "string", i18n: true, required: false }
-      - { label: "CTA URL", name: "url", widget: "string", required: false }
-  - label: "Video"
+      - { name: "type", widget: "hidden", default: "banner" }
+      - { label: "Eyebrow", name: "eyebrow", widget: "string", i18n: true, required: false }
+      - { label: "Title", name: "title", widget: "string", i18n: true }
+      - { label: "Subheadline", name: "sub", widget: "text", i18n: true, required: false }
+      - { label: "CTA Label", name: "ctaLabel", widget: "string", i18n: true, required: false }
+      - { label: "CTA Href", name: "ctaHref", widget: "string", required: false }
+      - { label: "Style", name: "style", widget: "select", options: ["muted", "inset"], default: "muted" }
+  - &section_video
+    label: "Video"
     name: "video"
     widget: "object"
     fields:
+      - { name: "type", widget: "hidden", default: "video" }
       - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
-      - { label: "Embed URL", name: "url", widget: "string" }
+      - { label: "URL", name: "url", widget: "string" }
+      - { label: "Poster", name: "poster", widget: "image", required: false }
 
 # SINGLE SOURCE OF TRUTH for Decap CMS (production /admin). Do not edit site/admin/config.yml.
 backend:
@@ -330,134 +327,52 @@ collections:
                 name: heroImageRightRef
                 widget: image
                 required: false
-          - label: Sections
+          - label: "Sections — Use root hero OR a hero section (root takes precedence)."
             name: sections
             widget: list
             i18n: true
             collapsed: true
             summary: "{{fields.title}} — {{fields.type}}"
             types:
-              - name: mediaCopy
-                label: Media + Copy
+              - label: "Hero Section"
+                name: hero
+                widget: object
                 fields:
-                  - { name: type, widget: hidden, default: "mediaCopy" }
-                  - { name: title, widget: string, i18n: true }
-                  - { name: body, widget: markdown, i18n: true }
-                  - { name: image, widget: image, required: false }
-                  - { name: mediaAlign, widget: select, options: [left, right], default: "left" }
-                  - { name: background, widget: select, options: [none, muted], default: "none" }
-                  - { name: ctaLabel, widget: string, i18n: true, required: false }
-                  - { name: ctaHref, widget: string, required: false }
-              - name: featureGrid
-                label: Feature Grid
-                fields:
-                  - { name: type, widget: hidden, default: "featureGrid" }
-                  - { name: title, widget: string, i18n: true, required: false }
-                  - label: Features
-                    name: features
-                    widget: list
+                  - { name: type, widget: hidden, default: "hero" }
+                  - { label: "Headline", name: "headline", widget: "string", i18n: true }
+                  - { label: "Subheadline", name: "subheadline", widget: "text", i18n: true, required: false }
+                  - label: "CTAs"
+                    name: "ctas"
+                    widget: "object"
+                    required: false
                     fields:
-                      - { name: title, widget: string, i18n: true }
-                      - { name: text, widget: text, i18n: true }
-              - name: productGrid
-                label: Product Grid
-                fields:
-                  - { name: type, widget: hidden, default: "productGrid" }
-                  - { name: title, widget: string, i18n: true, required: false }
-                  - { name: productsRef, widget: relation, collection: "Products", search_fields: ["title"], value_field: "slug", multiple: true, required: false }
-                  - { name: note, widget: text, i18n: true, required: false }
-              - name: testimonials
-                label: Testimonials
-                fields:
-                  - { name: type, widget: hidden, default: "testimonials" }
-                  - { name: title, widget: string, i18n: true, required: false }
-                  - label: Items
-                    name: items
-                    widget: list
+                      - { label: "Primary CTA Label", name: "primaryLabel", widget: "string", i18n: true, required: false }
+                      - { label: "Primary CTA Href", name: "primaryHref", widget: "string", required: false }
+                      - { label: "Secondary CTA Label", name: "secondaryLabel", widget: "string", i18n: true, required: false }
+                      - { label: "Secondary CTA Href", name: "secondaryHref", widget: "string", required: false }
+                  - label: "Alignment"
+                    name: "alignment"
+                    widget: "object"
+                    required: false
                     fields:
-                      - { name: quote, widget: text, i18n: true }
-                      - { name: author, widget: string }
-                      - { name: role, widget: string, required: false }
-              - name: faq
-                label: FAQ
-                fields:
-                  - { name: type, widget: hidden, default: "faq" }
-                  - { name: title, widget: string, i18n: true, required: false }
-                  - label: Items
-                    name: items
-                    widget: list
+                      - { label: "Horizontal", name: "horizontal", widget: "select", options: ["left", "center", "right"], default: "center" }
+                      - { label: "Vertical", name: "vertical", widget: "select", options: ["top", "center", "bottom"], default: "center" }
+                      - { label: "Layout Hint", name: "layout", widget: "select", options: ["bgImage", "split"], default: "bgImage", required: false }
+                      - { label: "Overlay", name: "overlay", widget: "number", min: 0, max: 90, value_type: "int", default: 40, required: false }
+                  - label: "Images"
+                    name: "images"
+                    widget: "object"
+                    required: false
                     fields:
-                      - { name: q, widget: string, i18n: true }
-                      - { name: a, widget: markdown, i18n: true }
-              - name: banner
-                label: Banner
-                fields:
-                  - { name: type, widget: hidden, default: "banner" }
-                  - { name: eyebrow, widget: string, i18n: true, required: false }
-                  - { name: title, widget: string, i18n: true }
-                  - { name: sub, widget: text, i18n: true, required: false }
-                  - { name: ctaLabel, widget: string, i18n: true, required: false }
-                  - { name: ctaHref, widget: string, required: false }
-                  - { name: style, widget: select, options: [muted, inset], default: "muted" }
-              - name: video
-                label: Video
-                fields:
-                  - { name: type, widget: hidden, default: "video" }
-                  - { name: title, widget: string, i18n: true, required: false }
-                  - { name: url, widget: string }
-                  - { name: poster, widget: image, required: false }
-          - name: heroPrimaryCta
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
-          - name: heroCtaPrimary
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
-          - name: ctaPrimary
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
-          - name: heroSecondaryCta
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
-          - name: heroCtaSecondary
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
-          - name: ctaSecondary
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
-          - name: heroImageLeft
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
-          - name: heroImageRight
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
-          - name: heroImageLeftRef
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
-          - name: heroImageRightRef
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
-          - name: heroOverlay
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
-          - name: heroLayoutHint
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
-          - name: heroTextPosition
-            widget: hidden
-            required: false
-            comment: "Legacy fallback. Do not edit."
+                      - { label: "Image Left", name: "left", widget: "image", required: false }
+                      - { label: "Image Right", name: "right", widget: "image", required: false }
+              - *section_mediaCopy
+              - *section_featureGrid
+              - *section_productGrid
+              - *section_testimonials
+              - *section_faq
+              - *section_banner
+              - *section_video
       - name: shop
         label: Shop Page
         file: content/pages/shop.json
@@ -467,12 +382,30 @@ collections:
         description: "Edit sections from top to bottom. Drag to reorder. Use Hero, Media+Copy, Feature Grid, Product Grid, Testimonials, FAQ, Banner, Video."
         i18n: true
         fields: &page_fields
-          - { label: Meta Title, name: metaTitle, widget: string, required: false }
-          - { label: Meta Description, name: metaDescription, widget: text, required: false }
+          - label: "Meta Title"
+            name: "metaTitle"
+            widget: "string"
+            i18n: true
+            required: false
+          - label: "Meta Description"
+            name: "metaDescription"
+            widget: "text"
+            i18n: true
+            required: false
           - label: "Sections"
             name: "sections"
             widget: "list"
-            types: *shared_sections
+            i18n: true
+            collapsed: true
+            summary: "{{fields.title}} — {{fields.type}}"
+            types:
+              - *section_mediaCopy
+              - *section_featureGrid
+              - *section_productGrid
+              - *section_testimonials
+              - *section_faq
+              - *section_banner
+              - *section_video
       - name: learn
         label: Learn Page
         file: content/pages/learn.json


### PR DESCRIPTION
## Summary
- update shared section definitions to standardize media, feature, product, testimonial, FAQ, banner, and video blocks
- simplify pages collection entries to only expose meta fields and localized sections, adding hero support to Home Page sections

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d9d811233c8320adb49c880a9cdace