### PR TITLE
content: sync home hero and sections from cms preview

### DIFF
--- a/content/pages/en/home.json
+++ b/content/pages/en/home.json
@@ -1,10 +1,50 @@
 {
   "metaTitle": "KAPUNKA — Argan care",
   "metaDescription": "Sensitive, post-procedure, and everyday skin rituals with Moroccan argan.",
-  "heroHeadline": "A gentle restart for sensitive skin",
-  "heroSubheadline": "Single-origin Moroccan argan, trusted in clinical practice.",
-  "heroAlignment": { "heroAlignX": "center", "heroAlignY": "middle", "heroLayoutHint": "image-full", "heroOverlay": 48 },
-  "heroImages": { "heroImageLeft": "/content/uploads/placeholder-hero.jpg" },
-  "heroCtas": { "ctaPrimary": "Shop argan rituals", "ctaSecondary": "Clinics partnership" },
-  "sections": []
+  "heroHeadline": "Local CMS Hero Headline",
+  "heroSubheadline": "Single-origin Moroccan argan care, published from the local CMS preview.",
+  "heroAlignment": {
+    "heroAlignX": "center",
+    "heroAlignY": "middle",
+    "heroLayoutHint": "image-full",
+    "heroOverlay": 48,
+    "heroTextPosition": "below"
+  },
+  "heroImages": {
+    "heroImageLeft": "/content/uploads/274937ac-6e5d-4dca-8dd5-d08b8004a4d9.jpg"
+  },
+  "heroCtas": {
+    "ctaPrimary": "Shop argan rituals",
+    "ctaSecondary": "Clinics partnership"
+  },
+  "sections": [
+    {
+      "type": "hero",
+      "headline": "Local CMS Hero Headline",
+      "subheadline": "Single-origin Moroccan argan care, published from the local CMS preview.",
+      "ctaPrimary": "Shop argan rituals",
+      "ctaSecondary": "Clinics partnership",
+      "image": "/content/uploads/274937ac-6e5d-4dca-8dd5-d08b8004a4d9.jpg",
+      "overlay": 48,
+      "position": "middle-center"
+    },
+    {
+      "type": "mediaCopy",
+      "title": "Media spotlight from CMS",
+      "body": "This media and copy block was published from the local CMS preview.",
+      "image": "/content/uploads/2cb41747-352c-4a0b-affc-bbbcbf90b362-1-.jpg",
+      "mediaAlign": "left",
+      "background": "none"
+    },
+    {
+      "type": "featureGrid",
+      "title": "Feature highlights from CMS",
+      "features": [
+        {
+          "title": "Softer skin in days",
+          "text": "Nutrient-dense argan and botanicals deliver visible results quickly."
+        }
+      ]
+    }
+  ]
 }

--- a/content/pages/es/home.json
+++ b/content/pages/es/home.json
@@ -1,10 +1,50 @@
 {
   "metaTitle": "KAPUNKA — Argan care",
   "metaDescription": "Sensitive, post-procedure, and everyday skin rituals with Moroccan argan.",
-  "heroHeadline": "Un reinicio suave para piel sensible",
-  "heroSubheadline": "Argán marroquí de origen único, confiable en clínicas.",
-  "heroAlignment": { "heroAlignX": "center", "heroAlignY": "middle", "heroLayoutHint": "image-full", "heroOverlay": 48 },
-  "heroImages": { "heroImageLeft": "/content/uploads/placeholder-hero.jpg" },
-  "heroCtas": { "ctaPrimary": "Comprar rituales de argán", "ctaSecondary": "Alianza para clínicas" },
-  "sections": []
+  "heroHeadline": "Titular destacado desde el CMS local",
+  "heroSubheadline": "Cuidado de argán marroquí de origen único, publicado desde la vista previa del CMS local.",
+  "heroAlignment": {
+    "heroAlignX": "center",
+    "heroAlignY": "middle",
+    "heroLayoutHint": "image-full",
+    "heroOverlay": 48,
+    "heroTextPosition": "below"
+  },
+  "heroImages": {
+    "heroImageLeft": "/content/uploads/274937ac-6e5d-4dca-8dd5-d08b8004a4d9.jpg"
+  },
+  "heroCtas": {
+    "ctaPrimary": "Comprar rituales de argán",
+    "ctaSecondary": "Alianza para clínicas"
+  },
+  "sections": [
+    {
+      "type": "hero",
+      "headline": "Titular destacado desde el CMS local",
+      "subheadline": "Cuidado de argán marroquí de origen único, publicado desde la vista previa del CMS local.",
+      "ctaPrimary": "Comprar rituales de argán",
+      "ctaSecondary": "Alianza para clínicas",
+      "image": "/content/uploads/274937ac-6e5d-4dca-8dd5-d08b8004a4d9.jpg",
+      "overlay": 48,
+      "position": "middle-center"
+    },
+    {
+      "type": "mediaCopy",
+      "title": "Foco mediático desde el CMS",
+      "body": "Este bloque de medios y texto se publicó desde la vista previa del CMS local.",
+      "image": "/content/uploads/2cb41747-352c-4a0b-affc-bbbcbf90b362-1-.jpg",
+      "mediaAlign": "left",
+      "background": "none"
+    },
+    {
+      "type": "featureGrid",
+      "title": "Aspectos destacados desde el CMS",
+      "features": [
+        {
+          "title": "Piel más suave en pocos días",
+          "text": "Argán rico en nutrientes y botánicos aportan resultados visibles rápidamente."
+        }
+      ]
+    }
+  ]
 }

--- a/content/pages/pt/home.json
+++ b/content/pages/pt/home.json
@@ -1,10 +1,50 @@
 {
   "metaTitle": "KAPUNKA — Argan care",
   "metaDescription": "Sensitive, post-procedure, and everyday skin rituals with Moroccan argan.",
-  "heroHeadline": "Um recomeço suave para peles sensíveis",
-  "heroSubheadline": "Argan marroquino de origem única, confiável em clínicas.",
-  "heroAlignment": { "heroAlignX": "center", "heroAlignY": "middle", "heroLayoutHint": "image-full", "heroOverlay": 48 },
-  "heroImages": { "heroImageLeft": "/content/uploads/placeholder-hero.jpg" },
-  "heroCtas": { "ctaPrimary": "Comprar rituais de argan", "ctaSecondary": "Parceria com clínicas" },
-  "sections": []
+  "heroHeadline": "Destaque do herói pelo CMS local",
+  "heroSubheadline": "Cuidados marroquinos de argan de origem única, publicados a partir da pré-visualização do CMS local.",
+  "heroAlignment": {
+    "heroAlignX": "center",
+    "heroAlignY": "middle",
+    "heroLayoutHint": "image-full",
+    "heroOverlay": 48,
+    "heroTextPosition": "below"
+  },
+  "heroImages": {
+    "heroImageLeft": "/content/uploads/274937ac-6e5d-4dca-8dd5-d08b8004a4d9.jpg"
+  },
+  "heroCtas": {
+    "ctaPrimary": "Comprar rituais de argan",
+    "ctaSecondary": "Parceria com clínicas"
+  },
+  "sections": [
+    {
+      "type": "hero",
+      "headline": "Destaque do herói pelo CMS local",
+      "subheadline": "Cuidados marroquinos de argan de origem única, publicados a partir da pré-visualização do CMS local.",
+      "ctaPrimary": "Comprar rituais de argan",
+      "ctaSecondary": "Parceria com clínicas",
+      "image": "/content/uploads/274937ac-6e5d-4dca-8dd5-d08b8004a4d9.jpg",
+      "overlay": 48,
+      "position": "middle-center"
+    },
+    {
+      "type": "mediaCopy",
+      "title": "Destaque de mídia do CMS",
+      "body": "Este bloco de mídia e texto foi publicado a partir da pré-visualização do CMS local.",
+      "image": "/content/uploads/2cb41747-352c-4a0b-affc-bbbcbf90b362-1-.jpg",
+      "mediaAlign": "left",
+      "background": "none"
+    },
+    {
+      "type": "featureGrid",
+      "title": "Destaques do CMS",
+      "features": [
+        {
+          "title": "Pele mais macia em poucos dias",
+          "text": "Argan rico em nutrientes e botânicos entregam resultados visíveis rapidamente."
+        }
+      ]
+    }
+  ]
 }

--- a/site/content/en/pages/home.json
+++ b/site/content/en/pages/home.json
@@ -1,25 +1,26 @@
 {
-  "metaTitle": "Kapunka — Moroccan argan care for sensitive & post-procedure skin",
-  "metaDescription": "Single-origin Moroccan argan oils, floral waters, and traditional treatments designed for sensitive and post-procedure skin. Clinically trusted, heritage sourced.",
+  "metaTitle": "KAPUNKA — Argan care",
+  "metaDescription": "Sensitive, post-procedure, and everyday skin rituals with Moroccan argan.",
   "meta": {
-    "metaTitle": "Kapunka — Moroccan argan care for sensitive & post-procedure skin",
-    "metaDescription": "Single-origin Moroccan argan oils, floral waters, and traditional treatments designed for sensitive and post-procedure skin. Clinically trusted, heritage sourced."
+    "metaTitle": "KAPUNKA — Argan care",
+    "metaDescription": "Sensitive, post-procedure, and everyday skin rituals with Moroccan argan."
   },
-  "heroHeadline": "Care that listens when skin is tender.",
-  "heroSubheadline": "Kapunka 2.0 blends Moroccan argan rituals with clinical empathy so reactive and post-procedure skin can breathe easier.",
+  "heroHeadline": "Local CMS Hero Headline",
+  "heroSubheadline": "Single-origin Moroccan argan care, published from the local CMS preview.",
   "heroAlignment": {
     "heroAlignX": "center",
     "heroAlignY": "middle",
-    "heroLayoutHint": "text-over-media",
-    "heroOverlay": true
+    "heroLayoutHint": "image-full",
+    "heroOverlay": 48,
+    "heroTextPosition": "below"
   },
   "heroImages": {
-    "heroImageLeft": "",
+    "heroImageLeft": "/content/uploads/274937ac-6e5d-4dca-8dd5-d08b8004a4d9.jpg",
     "heroImageRight": ""
   },
   "heroCtas": {
-    "ctaPrimary": "Shop Kapunka 2.0 rituals",
-    "ctaSecondary": "Partner with our clinic team"
+    "ctaPrimary": "Shop argan rituals",
+    "ctaSecondary": "Clinics partnership"
   },
   "brandIntro": {
     "title": "Born from gratitude",
@@ -124,39 +125,30 @@
   },
   "sections": [
     {
-      "type": "imageTextHalf",
-      "title": "Heritage sourcing, clinic-grade standards",
-      "text": "We bottle single-origin argan oil within hours of pressing to lock in antioxidants. Every lot is microbiologically tested and traceable from kernel to bottle for spa and medical safety.",
-      "image": ""
+      "type": "hero",
+      "headline": "Local CMS Hero Headline",
+      "subheadline": "Single-origin Moroccan argan care, published from the local CMS preview.",
+      "ctaPrimary": "Shop argan rituals",
+      "ctaSecondary": "Clinics partnership",
+      "image": "/content/uploads/274937ac-6e5d-4dca-8dd5-d08b8004a4d9.jpg",
+      "overlay": 48,
+      "position": "middle-center"
     },
     {
-      "type": "imageTextHalf",
-      "title": "From hammam rituals to modern recovery",
-      "text": "Pair our black soap cleanse, rose water mist, and argan concentrate for a three-step routine that calms inflammation, supports barrier repair, and leaves no heavy film.",
-      "image": ""
+      "type": "mediaCopy",
+      "title": "Media spotlight from CMS",
+      "body": "This media and copy block was published from the local CMS preview.",
+      "image": "/content/uploads/2cb41747-352c-4a0b-affc-bbbcbf90b362-1-.jpg",
+      "mediaAlign": "left",
+      "background": "none"
     },
     {
-      "type": "imageGrid",
-      "items": [
+      "type": "featureGrid",
+      "title": "Feature highlights from CMS",
+      "features": [
         {
-          "image": "",
-          "title": "Clinic-ready batching",
-          "subtitle": "Sterile filling, safety dossiers, and bilingual protocols for teams."
-        },
-        {
-          "image": "",
-          "title": "Holistic sensorial care",
-          "subtitle": "Light aromatics from native botanicals without synthetic fragrance."
-        },
-        {
-          "image": "",
-          "title": "Flexible retail stories",
-          "subtitle": "Merchandising kits and QR education for every treatment room."
-        },
-        {
-          "image": "",
-          "title": "Sustainable partnership",
-          "subtitle": "Revenue reinvested into Moroccan women’s cooperatives and reforestation."
+          "title": "Softer skin in days",
+          "text": "Nutrient-dense argan and botanicals deliver visible results quickly."
         }
       ]
     }

--- a/site/content/es/pages/home.json
+++ b/site/content/es/pages/home.json
@@ -1,25 +1,26 @@
 {
-  "metaTitle": "Kapunka — Cuidado con argán para piel sensible y post-procedimiento",
-  "metaDescription": "Aceites de argán de origen único, aguas florales y tratamientos tradicionales para piel sensible y post-procedimiento. Confianza clínica, origen con herencia.",
+  "metaTitle": "KAPUNKA — Argan care",
+  "metaDescription": "Sensitive, post-procedure, and everyday skin rituals with Moroccan argan.",
   "meta": {
-    "metaTitle": "Kapunka — Cuidado con argán para piel sensible y post-procedimiento",
-    "metaDescription": "Aceites de argán de origen único, aguas florales y tratamientos tradicionales para piel sensible y post-procedimiento. Confianza clínica, origen con herencia."
+    "metaTitle": "KAPUNKA — Argan care",
+    "metaDescription": "Sensitive, post-procedure, and everyday skin rituals with Moroccan argan."
   },
-  "heroHeadline": "Cuidado que escucha cuando la piel duele.",
-  "heroSubheadline": "Kapunka 2.0 une rituales marroquíes de argán con empatía clínica para que la piel reactiva y post-procedimiento respire tranquila.",
+  "heroHeadline": "Titular destacado desde el CMS local",
+  "heroSubheadline": "Cuidado de argán marroquí de origen único, publicado desde la vista previa del CMS local.",
   "heroAlignment": {
     "heroAlignX": "center",
     "heroAlignY": "middle",
-    "heroLayoutHint": "text-over-media",
-    "heroOverlay": true
+    "heroLayoutHint": "image-full",
+    "heroOverlay": 48,
+    "heroTextPosition": "below"
   },
   "heroImages": {
-    "heroImageLeft": "",
+    "heroImageLeft": "/content/uploads/274937ac-6e5d-4dca-8dd5-d08b8004a4d9.jpg",
     "heroImageRight": ""
   },
   "heroCtas": {
-    "ctaPrimary": "Comprar rituales Kapunka 2.0",
-    "ctaSecondary": "Habla con nuestro equipo clínico"
+    "ctaPrimary": "Comprar rituales de argán",
+    "ctaSecondary": "Alianza para clínicas"
   },
   "brandIntro": {
     "title": "Nacido del agradecimiento",
@@ -124,39 +125,30 @@
   },
   "sections": [
     {
-      "type": "imageTextHalf",
-      "title": "Origen con herencia, estándares clínicos",
-      "text": "Envasamos el aceite de argán de origen único pocas horas después del prensado para conservar los antioxidantes. Cada lote se analiza microbiológicamente y es trazable de la semilla al frasco para la seguridad de spas y clínicas.",
-      "image": ""
+      "type": "hero",
+      "headline": "Titular destacado desde el CMS local",
+      "subheadline": "Cuidado de argán marroquí de origen único, publicado desde la vista previa del CMS local.",
+      "ctaPrimary": "Comprar rituales de argán",
+      "ctaSecondary": "Alianza para clínicas",
+      "image": "/content/uploads/274937ac-6e5d-4dca-8dd5-d08b8004a4d9.jpg",
+      "overlay": 48,
+      "position": "middle-center"
     },
     {
-      "type": "imageTextHalf",
-      "title": "Del hammam a la recuperación moderna",
-      "text": "Combina nuestro jabón negro limpiador, la bruma de agua de rosas y el concentrado de argán en un ritual de tres pasos que calma la inflamación, refuerza la barrera y no deja película pesada.",
-      "image": ""
+      "type": "mediaCopy",
+      "title": "Foco mediático desde el CMS",
+      "body": "Este bloque de medios y texto se publicó desde la vista previa del CMS local.",
+      "image": "/content/uploads/2cb41747-352c-4a0b-affc-bbbcbf90b362-1-.jpg",
+      "mediaAlign": "left",
+      "background": "none"
     },
     {
-      "type": "imageGrid",
-      "items": [
+      "type": "featureGrid",
+      "title": "Aspectos destacados desde el CMS",
+      "features": [
         {
-          "image": "",
-          "title": "Producción lista para clínicas",
-          "subtitle": "Envasado estéril, dossiers de seguridad y protocolos bilingües para los equipos."
-        },
-        {
-          "image": "",
-          "title": "Cuidado sensorial holístico",
-          "subtitle": "Aromas ligeros de botánicos nativos sin fragancias sintéticas."
-        },
-        {
-          "image": "",
-          "title": "Historias flexibles en retail",
-          "subtitle": "Kits de merchandising y educación con QR para cada sala de tratamiento."
-        },
-        {
-          "image": "",
-          "title": "Alianza sostenible",
-          "subtitle": "Ingresos reinvertidos en cooperativas marroquíes lideradas por mujeres y reforestación."
+          "title": "Piel más suave en pocos días",
+          "text": "Argán rico en nutrientes y botánicos aportan resultados visibles rápidamente."
         }
       ]
     }

--- a/site/content/pt/pages/home.json
+++ b/site/content/pt/pages/home.json
@@ -1,25 +1,26 @@
 {
-  "metaTitle": "Kapunka — Cuidado com argão para pele sensível e pós-procedimento",
-  "metaDescription": "Óleos de argão de origem única, águas florais e tratamentos tradicionais para pele sensível e pós-procedimento. Confiança clínica, origem com herança.",
+  "metaTitle": "KAPUNKA — Argan care",
+  "metaDescription": "Sensitive, post-procedure, and everyday skin rituals with Moroccan argan.",
   "meta": {
-    "metaTitle": "Kapunka — Cuidado com argão para pele sensível e pós-procedimento",
-    "metaDescription": "Óleos de argão de origem única, águas florais e tratamentos tradicionais para pele sensível e pós-procedimento. Confiança clínica, origem com herança."
+    "metaTitle": "KAPUNKA — Argan care",
+    "metaDescription": "Sensitive, post-procedure, and everyday skin rituals with Moroccan argan."
   },
-  "heroHeadline": "Cuidado que escuta quando a pele está sensível.",
-  "heroSubheadline": "A Kapunka 2.0 une rituais marroquinos de argão e empatia clínica para que a pele reativa e pós-procedimento respire com calma.",
+  "heroHeadline": "Destaque do herói pelo CMS local",
+  "heroSubheadline": "Cuidados marroquinos de argan de origem única, publicados a partir da pré-visualização do CMS local.",
   "heroAlignment": {
     "heroAlignX": "center",
     "heroAlignY": "middle",
-    "heroLayoutHint": "text-over-media",
-    "heroOverlay": true
+    "heroLayoutHint": "image-full",
+    "heroOverlay": 48,
+    "heroTextPosition": "below"
   },
   "heroImages": {
-    "heroImageLeft": "",
+    "heroImageLeft": "/content/uploads/274937ac-6e5d-4dca-8dd5-d08b8004a4d9.jpg",
     "heroImageRight": ""
   },
   "heroCtas": {
-    "ctaPrimary": "Comprar rituais Kapunka 2.0",
-    "ctaSecondary": "Falar com a nossa equipa clínica"
+    "ctaPrimary": "Comprar rituais de argan",
+    "ctaSecondary": "Parceria com clínicas"
   },
   "brandIntro": {
     "title": "Nascido da gratidão",
@@ -124,39 +125,30 @@
   },
   "sections": [
     {
-      "type": "imageTextHalf",
-      "title": "Origem com herança, padrão de clínica",
-      "text": "Envasamos óleo de argan de origem única poucas horas após a prensagem para preservar antioxidantes. Cada lote é testado microbiologicamente e rastreável da semente ao frasco para segurança em spas e clínicas.",
-      "image": ""
+      "type": "hero",
+      "headline": "Destaque do herói pelo CMS local",
+      "subheadline": "Cuidados marroquinos de argan de origem única, publicados a partir da pré-visualização do CMS local.",
+      "ctaPrimary": "Comprar rituais de argan",
+      "ctaSecondary": "Parceria com clínicas",
+      "image": "/content/uploads/274937ac-6e5d-4dca-8dd5-d08b8004a4d9.jpg",
+      "overlay": 48,
+      "position": "middle-center"
     },
     {
-      "type": "imageTextHalf",
-      "title": "Do hammam moderno à recuperação profissional",
-      "text": "Combine nosso sabão preto de limpeza, névoa de água de rosas e concentrado de argan em um ritual de três etapas que acalma a inflamação, apoia a barreira e não deixa filme pesado.",
-      "image": ""
+      "type": "mediaCopy",
+      "title": "Destaque de mídia do CMS",
+      "body": "Este bloco de mídia e texto foi publicado a partir da pré-visualização do CMS local.",
+      "image": "/content/uploads/2cb41747-352c-4a0b-affc-bbbcbf90b362-1-.jpg",
+      "mediaAlign": "left",
+      "background": "none"
     },
     {
-      "type": "imageGrid",
-      "items": [
+      "type": "featureGrid",
+      "title": "Destaques do CMS",
+      "features": [
         {
-          "image": "",
-          "title": "Produção pronta para clínicas",
-          "subtitle": "Envase estéril, dossiês de segurança e protocolos bilíngues para as equipes."
-        },
-        {
-          "image": "",
-          "title": "Cuidado sensorial holístico",
-          "subtitle": "Aromas leves de botânicos nativos sem fragrâncias sintéticas."
-        },
-        {
-          "image": "",
-          "title": "Histórias flexíveis no varejo",
-          "subtitle": "Kits de merchandising e educação por QR code para cada sala de tratamento."
-        },
-        {
-          "image": "",
-          "title": "Parceria sustentável",
-          "subtitle": "Receitas reinvestidas em cooperativas marroquinas lideradas por mulheres e reflorestamento."
+          "title": "Pele mais macia em poucos dias",
+          "text": "Argan rico em nutrientes e botânicos entregam resultados visíveis rapidamente."
         }
       ]
     }


### PR DESCRIPTION
## Summary
- update the English, Spanish, and Portuguese home content with the new hero headline, hero section, and CMS-driven media/feature blocks
- mirror the same hero and section data in the site/content copies used by the Visual Editor

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_b_68d9dca50c108320a7becdb684932f9b