### PR TITLE
Expose missing hero fields for Pages collection

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -282,6 +282,28 @@ collections:
                 name: ctaSecondaryHref
                 widget: string
                 required: false
+              - label: Primary Label
+                name: primaryLabel
+                widget: string
+                i18n: true
+                required: false
+                hint: "Displayed label for the main hero button."
+              - label: Primary Href
+                name: primaryHref
+                widget: string
+                required: false
+                hint: "Destination URL for the main hero button."
+              - label: Secondary Label
+                name: secondaryLabel
+                widget: string
+                i18n: true
+                required: false
+                hint: "Displayed label for the secondary hero button."
+              - label: Secondary Href
+                name: secondaryHref
+                widget: string
+                required: false
+                hint: "Destination URL for the secondary hero button."
           - label: Hero Alignment
             name: heroAlignment
             widget: object
@@ -314,6 +336,29 @@ collections:
                 widget: select
                 options: [bgImage, split]
                 default: bgImage
+              - label: Text Position
+                name: textPosition
+                widget: select
+                options: [overlay, below]
+                default: overlay
+                required: false
+                hint: "Controls whether copy overlays the image or sits below it."
+              - label: Overlay Strength
+                name: overlay
+                widget: number
+                min: 0
+                max: 90
+                value_type: int
+                default: 40
+                required: false
+                hint: "Adjusts the dark overlay strength on hero imagery."
+              - label: Layout Hint
+                name: layoutHint
+                widget: select
+                options: [bgImage, split]
+                default: bgImage
+                required: false
+                hint: "Suggests whether the hero renders as a background image or split layout."
           - label: Hero Images
             name: heroImages
             widget: object
@@ -327,6 +372,16 @@ collections:
                 name: heroImageRightRef
                 widget: image
                 required: false
+              - label: Hero Image Left
+                name: heroImageLeft
+                widget: image
+                required: false
+                hint: "Upload the left-side hero image."
+              - label: Hero Image Right
+                name: heroImageRight
+                widget: image
+                required: false
+                hint: "Upload the right-side hero image."
           - label: "Sections — Use root hero OR a hero section (root takes precedence)."
             name: sections
             widget: list


### PR DESCRIPTION
## Summary
- expose the Pages collection hero CTA, alignment, and image fields required by the brief
- add concise guidance hints for the new optional fields

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68da4b3fdc708320bcc6f1ed21f16f5d