### PR TITLE
Add localized media copy sections for contact page

### DIFF
--- a/content/pages/en/contact.json
+++ b/content/pages/en/contact.json
@@ -1,0 +1,13 @@
+{
+  "metaTitle": "Contact Kapunka — We're here for you",
+  "metaDescription": "Reach out to Kapunka for tailored routines, training, or wholesale support.",
+  "sections": [
+    {
+      "type": "mediaCopy",
+      "title": "We're ready to listen",
+      "body": "Clinics, partners, and individuals—tell us what you need and we’ll guide you to the right routine, training, or wholesale option.",
+      "imageRef": "/content/uploads/argan-fields.jpg",
+      "layout": "textLeftImageRight"
+    }
+  ]
+}

--- a/content/pages/es/contact.json
+++ b/content/pages/es/contact.json
@@ -1,0 +1,13 @@
+{
+  "metaTitle": "Contacta a Kapunka — Estamos aquí para ti",
+  "metaDescription": "Escríbenos para recibir rutinas, formación u opciones mayoristas a tu medida.",
+  "sections": [
+    {
+      "type": "mediaCopy",
+      "title": "Estamos aquí para escucharte",
+      "body": "Clínicas, aliados y personas—cuéntanos qué necesitas y te guiamos hacia la rutina, la formación u opción mayorista adecuada.",
+      "imageRef": "/content/uploads/argan-fields.jpg",
+      "layout": "textLeftImageRight"
+    }
+  ]
+}

--- a/content/pages/pt/contact.json
+++ b/content/pages/pt/contact.json
@@ -1,0 +1,13 @@
+{
+  "metaTitle": "Fale com a Kapunka — Estamos aqui por você",
+  "metaDescription": "Fale conosco para receber rotinas, treinamentos ou opções de atacado sob medida.",
+  "sections": [
+    {
+      "type": "mediaCopy",
+      "title": "Estamos aqui para ouvir",
+      "body": "Clínicas, parceiros e pessoas queridas—conte o que você precisa e guiamos você até a rotina, o treinamento ou a opção de atacado ideal.",
+      "imageRef": "/content/uploads/argan-fields.jpg",
+      "layout": "textLeftImageRight"
+    }
+  ]
+}

--- a/site/content/en/pages/contact.json
+++ b/site/content/en/pages/contact.json
@@ -1,0 +1,13 @@
+{
+  "metaTitle": "Contact Kapunka — We're here for you",
+  "metaDescription": "Reach out to Kapunka for tailored routines, training, or wholesale support.",
+  "sections": [
+    {
+      "type": "mediaCopy",
+      "title": "We're ready to listen",
+      "body": "Clinics, partners, and individuals—tell us what you need and we’ll guide you to the right routine, training, or wholesale option.",
+      "imageRef": "/content/uploads/argan-fields.jpg",
+      "layout": "textLeftImageRight"
+    }
+  ]
+}

--- a/site/content/es/pages/contact.json
+++ b/site/content/es/pages/contact.json
@@ -1,0 +1,13 @@
+{
+  "metaTitle": "Contacta a Kapunka — Estamos aquí para ti",
+  "metaDescription": "Escríbenos para recibir rutinas, formación u opciones mayoristas a tu medida.",
+  "sections": [
+    {
+      "type": "mediaCopy",
+      "title": "Estamos aquí para escucharte",
+      "body": "Clínicas, aliados y personas—cuéntanos qué necesitas y te guiamos hacia la rutina, la formación u opción mayorista adecuada.",
+      "imageRef": "/content/uploads/argan-fields.jpg",
+      "layout": "textLeftImageRight"
+    }
+  ]
+}

--- a/site/content/pt/pages/contact.json
+++ b/site/content/pt/pages/contact.json
@@ -1,0 +1,13 @@
+{
+  "metaTitle": "Fale com a Kapunka — Estamos aqui por você",
+  "metaDescription": "Fale conosco para receber rotinas, treinamentos ou opções de atacado sob medida.",
+  "sections": [
+    {
+      "type": "mediaCopy",
+      "title": "Estamos aqui para ouvir",
+      "body": "Clínicas, parceiros e pessoas queridas—conte o que você precisa e guiamos você até a rotina, o treinamento ou a opção de atacado ideal.",
+      "imageRef": "/content/uploads/argan-fields.jpg",
+      "layout": "textLeftImageRight"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add contact page entries for en/es/pt with a single mediaCopy section and localized metadata
- mirror the new contact page content under site/content for Netlify Visual Editor parity

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68da5c620df88320b35bc26c5c58556e