### PR TITLE
Align Decap sections with live page structure

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -6,13 +6,12 @@ shared_sections: &shared_sections
     widget: "object"
     fields:
       - { name: "type", widget: "hidden", default: "mediaCopy" }
-      - { label: "Title", name: "title", widget: "string", i18n: true }
-      - { label: "Body", name: "body", widget: "markdown", i18n: true }
-      - { label: "Image", name: "image", widget: "image", required: false }
-      - { label: "Media Alignment", name: "mediaAlign", widget: "select", options: ["left", "right"], default: "left" }
-      - { label: "Background", name: "background", widget: "select", options: ["none", "muted"], default: "none" }
-      - { label: "CTA Label", name: "ctaLabel", widget: "string", i18n: true, required: false }
-      - { label: "CTA Href", name: "ctaHref", widget: "string", required: false }
+      - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
+      - { label: "Body", name: "body", widget: "markdown", i18n: true, required: false }
+      - { label: "Image Upload", name: "image", widget: "image", choose_url: true, required: false }
+      - { label: "Image Path (optional)", name: "imageRef", widget: "string", required: false, hint: "Use when referencing an existing asset path such as /content/uploads/example.jpg." }
+      - { label: "Layout", name: "layout", widget: "select", options: ["image-right", "image-left"], default: "image-right" }
+      - { label: "Columns", name: "columns", widget: "number", value_type: "int", min: 1, max: 3, required: false, hint: "Leave blank for the default two-column layout." }
   - &section_featureGrid
     label: "Feature Grid"
     name: "featureGrid"
@@ -20,12 +19,14 @@ shared_sections: &shared_sections
     fields:
       - { name: "type", widget: "hidden", default: "featureGrid" }
       - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
-      - label: "Features"
-        name: "features"
+      - { label: "Columns", name: "columns", widget: "number", value_type: "int", min: 1, max: 4, required: false }
+      - label: "Items"
+        name: "items"
         widget: "list"
+        summary: "{{fields.label}}"
         fields:
-          - { label: "Title", name: "title", widget: "string", i18n: true }
-          - { label: "Description", name: "text", widget: "markdown", i18n: true }
+          - { label: "Label", name: "label", widget: "string", i18n: true, required: false }
+          - { label: "Description", name: "description", widget: "markdown", i18n: true, required: false }
   - &section_productGrid
     label: "Product Grid"
     name: "productGrid"
@@ -33,8 +34,24 @@ shared_sections: &shared_sections
     fields:
       - { name: "type", widget: "hidden", default: "productGrid" }
       - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
-      - { label: "Products", name: "productsRef", widget: "relation", collection: "Products", search_fields: ["title"], value_field: "slug", multiple: true, required: false }
-      - { label: "Note", name: "note", widget: "text", i18n: true, required: false }
+      - { label: "Columns", name: "columns", widget: "number", value_type: "int", min: 1, max: 4, required: false }
+      - label: "Products"
+        name: "products"
+        widget: "list"
+        summary: "{{fields.id}}"
+        field:
+          label: "Product"
+          name: "id"
+          widget: "relation"
+          collection: "products"
+          file: "catalog"
+          search_fields:
+            - "items.*.name.en"
+            - "items.*.name.pt"
+            - "items.*.name.es"
+          display_fields:
+            - "items.*.name.en"
+          value_field: "items.*.id"
   - &section_testimonials
     label: "Testimonials"
     name: "testimonials"
@@ -42,11 +59,11 @@ shared_sections: &shared_sections
     fields:
       - { name: "type", widget: "hidden", default: "testimonials" }
       - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
-      - label: "Items"
-        name: "items"
+      - label: "Quotes"
+        name: "quotes"
         widget: "list"
         fields:
-          - { label: "Quote", name: "quote", widget: "markdown", i18n: true }
+          - { label: "Quote", name: "text", widget: "markdown", i18n: true, required: false }
           - { label: "Author", name: "author", widget: "string", required: false }
           - { label: "Role", name: "role", widget: "string", required: false }
   - &section_faq
@@ -68,21 +85,92 @@ shared_sections: &shared_sections
     widget: "object"
     fields:
       - { name: "type", widget: "hidden", default: "banner" }
-      - { label: "Eyebrow", name: "eyebrow", widget: "string", i18n: true, required: false }
-      - { label: "Title", name: "title", widget: "string", i18n: true }
-      - { label: "Subheadline", name: "sub", widget: "text", i18n: true, required: false }
-      - { label: "CTA Label", name: "ctaLabel", widget: "string", i18n: true, required: false }
-      - { label: "CTA Href", name: "ctaHref", widget: "string", required: false }
-      - { label: "Style", name: "style", widget: "select", options: ["muted", "inset"], default: "muted" }
-  - &section_video
-    label: "Video"
-    name: "video"
+      - { label: "Text", name: "text", widget: "string", i18n: true, required: false }
+      - { label: "CTA Label", name: "cta", widget: "string", i18n: true, required: false }
+      - { label: "CTA URL", name: "url", widget: "string", required: false }
+      - { label: "Style", name: "style", widget: "select", options: ["muted", "inset"], required: false }
+  - &section_videoGallery
+    label: "Video Gallery"
+    name: "videoGallery"
     widget: "object"
     fields:
-      - { name: "type", widget: "hidden", default: "video" }
+      - { name: "type", widget: "hidden", default: "videoGallery" }
       - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
-      - { label: "URL", name: "url", widget: "string" }
-      - { label: "Poster", name: "poster", widget: "image", required: false }
+      - { label: "Description", name: "description", widget: "text", i18n: true, required: false }
+      - label: "Entries"
+        name: "entries"
+        widget: "list"
+        fields:
+          - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
+          - { label: "Description", name: "description", widget: "text", i18n: true, required: false }
+          - { label: "Video URL", name: "videoUrl", widget: "string", required: false }
+          - { label: "Thumbnail", name: "thumbnail", widget: "image", choose_url: true, required: false }
+  - &section_trainingList
+    label: "Training List"
+    name: "trainingList"
+    widget: "object"
+    fields:
+      - { name: "type", widget: "hidden", default: "trainingList" }
+      - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
+      - { label: "Description", name: "description", widget: "text", i18n: true, required: false }
+      - label: "Entries"
+        name: "entries"
+        widget: "list"
+        fields:
+          - { label: "Course Title", name: "courseTitle", widget: "string", i18n: true, required: false }
+          - { label: "Summary", name: "courseSummary", widget: "text", i18n: true, required: false }
+          - { label: "Link URL", name: "linkUrl", widget: "string", required: false }
+  - &section_timeline
+    label: "Timeline"
+    name: "timeline"
+    widget: "object"
+    fields:
+      - { name: "type", widget: "hidden", default: "timeline" }
+      - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
+      - label: "Entries"
+        name: "entries"
+        widget: "list"
+        fields:
+          - { label: "Year", name: "year", widget: "string" }
+          - { label: "Title", name: "title", widget: "string", i18n: true }
+          - { label: "Description", name: "description", widget: "markdown", i18n: true }
+          - { label: "Image", name: "image", widget: "image", choose_url: true, required: false }
+  - &section_facts
+    label: "Facts"
+    name: "facts"
+    widget: "object"
+    fields:
+      - { name: "type", widget: "hidden", default: "facts" }
+      - { label: "Title", name: "title", widget: "string", i18n: true }
+      - { label: "Body", name: "text", widget: "text", i18n: true }
+  - &section_bullets
+    label: "Bulleted List"
+    name: "bullets"
+    widget: "object"
+    fields:
+      - { name: "type", widget: "hidden", default: "bullets" }
+      - { label: "Title", name: "title", widget: "string", i18n: true }
+      - label: "Items"
+        name: "items"
+        widget: "list"
+        field: { label: "Item", name: "item", widget: "string", i18n: true }
+  - &section_specialties
+    label: "Specialties"
+    name: "specialties"
+    widget: "object"
+    fields:
+      - { name: "type", widget: "hidden", default: "specialties" }
+      - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
+      - label: "Specialties"
+        name: "items"
+        widget: "list"
+        summary: "{{fields.title}}"
+        fields:
+          - { label: "Specialty Title", name: "title", widget: "string", i18n: true }
+          - label: "Bullets"
+            name: "bullets"
+            widget: "list"
+            field: { label: "Bullet", name: "bullet", widget: "string", i18n: true }
 
 # SINGLE SOURCE OF TRUTH for Decap CMS (production /admin). Do not edit site/admin/config.yml.
 backend:
@@ -380,7 +468,9 @@ collections:
               - *section_testimonials
               - *section_faq
               - *section_banner
-              - *section_video
+              - *section_videoGallery
+              - *section_trainingList
+              - *section_timeline
       - name: shop
         label: Shop Page
         file: content/pages/shop.json
@@ -413,7 +503,9 @@ collections:
               - *section_testimonials
               - *section_faq
               - *section_banner
-              - *section_video
+              - *section_videoGallery
+              - *section_trainingList
+              - *section_timeline
       - name: learn
         label: Learn Page
         file: content/pages/learn.json
@@ -429,9 +521,33 @@ collections:
         format: json
         editor:
           preview: true
-        description: "Edit sections from top to bottom. Drag to reorder. Use Hero, Media+Copy, Feature Grid, Product Grid, Testimonials, FAQ, Banner, Video."
+        description: "Edit hero copy, clinical notes, and structured sections in order."
         i18n: true
-        fields: *page_fields
+        fields:
+          - { label: "Meta Title", name: "metaTitle", widget: "string", i18n: true, required: false }
+          - { label: "Meta Description", name: "metaDescription", widget: "text", i18n: true, required: false }
+          - { label: "Hero Title", name: "heroTitle", widget: "string", i18n: true, required: false }
+          - { label: "Hero Subtitle", name: "heroSubtitle", widget: "text", i18n: true, required: false }
+          - label: "Clinical Notes"
+            name: "clinicalNotes"
+            widget: "list"
+            collapsed: true
+            summary: "{{fields.title}}"
+            fields:
+              - { label: "Title", name: "title", widget: "string", i18n: true }
+              - label: "Bullets"
+                name: "bullets"
+                widget: "list"
+                field: { label: "Bullet", name: "bullet", widget: "string", i18n: true }
+          - label: "Sections"
+            name: "sections"
+            widget: "list"
+            collapsed: true
+            summary: "{{fields.title}} — {{fields.type}}"
+            types:
+              - *section_facts
+              - *section_bullets
+              - *section_specialties
       - name: clinics
         label: For Clinics Page
         file: content/pages/clinics.json

--- a/content/pages/en/about.json
+++ b/content/pages/en/about.json
@@ -7,14 +7,14 @@
       "title": "Where Kapunka comes from",
       "body": "Kapunka began with a simple idea: the way we touch changes how we heal. Years beside clinicians shaped a method that is careful, precise, and kind.",
       "imageRef": "/content/uploads/founder-portrait.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "The name",
       "body": "‘Kapunka’ was first heard by our founder in a school in Ubud. The word—thank you—became a promise: make care that gives back. Be thankful to your skin.",
       "imageRef": "/content/uploads/ubud-moment.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     }
   ]
 }

--- a/content/pages/en/clinics.json
+++ b/content/pages/en/clinics.json
@@ -7,16 +7,25 @@
       "title": "From operating room to everyday routine",
       "body": "Trusted by dermatology and aesthetic teams for scar care and recovery. Low-residue, fragrance-considerate options and printable protocols.",
       "imageRef": "/content/uploads/clinic-tray.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "featureGrid",
       "title": "",
       "columns": 3,
       "items": [
-        { "label": "Protocols", "description": "Simple steps for pre-op, post-op, and home care." },
-        { "label": "Education", "description": "Short onboarding and in-service training." },
-        { "label": "Wholesale", "description": "Starter kits and steady replenishment." }
+        {
+          "label": "Protocols",
+          "description": "Simple steps for pre-op, post-op, and home care."
+        },
+        {
+          "label": "Education",
+          "description": "Short onboarding and in-service training."
+        },
+        {
+          "label": "Wholesale",
+          "description": "Starter kits and steady replenishment."
+        }
       ]
     },
     {

--- a/content/pages/en/contact.json
+++ b/content/pages/en/contact.json
@@ -7,7 +7,7 @@
       "title": "We're ready to listen",
       "body": "Clinics, partners, and individuals—tell us what you need and we’ll guide you to the right routine, training, or wholesale option.",
       "imageRef": "/content/uploads/argan-fields.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     }
   ]
 }

--- a/content/pages/en/home.json
+++ b/content/pages/en/home.json
@@ -4,8 +4,14 @@
   "heroHeadline": "Be thankful to your skin.",
   "heroSubheadline": "Gentle argan rituals from Morocco, made for sensitive and post-procedure skin. Welcome to Kapunka 2.0: calm care that feels human.",
   "heroCtas": {
-    "ctaPrimary": { "label": "Shop argan rituals", "href": "/shop" },
-    "ctaSecondary": { "label": "Clinics partnership", "href": "/clinics" }
+    "ctaPrimary": {
+      "label": "Shop argan rituals",
+      "href": "/shop"
+    },
+    "ctaSecondary": {
+      "label": "Clinics partnership",
+      "href": "/clinics"
+    }
   },
   "heroAlignment": {
     "heroAlignX": "center",
@@ -23,47 +29,65 @@
       "title": "Born from gratitude",
       "body": "“Kapunka” means “thank you.” We make argan care with clinical respect—simple routines that comfort, shield, and support healing. Our roots are in Morocco; our method grew in real clinics.",
       "imageRef": "/content/uploads/roots-olive-tree.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "Preferred by dermatologists, medspas, and holistic clinics",
       "body": "Our treatments are gentle, low-residue, and knowledge-led, with skin acceptance, barrier stability, and aroma balance. Dedicated training and wholesale support keep your team confident.",
       "imageRef": "/content/uploads/clinic-hands.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "Heritage sourcing, clinic-grade standards",
       "body": "We source single-origin argan and trace the steps from cooperatives to lab certifications. Every lot is meticulously quality-tested to maintain human care at scale.",
       "imageRef": "/content/uploads/argan-coop.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "From hammam rituals to modern recovery",
       "body": "Pure oil, floral mists, and clean washes. Old wisdom connected to the lives we live today: routines that calm discomfort, repair the barrier, and leave no heavy film.",
       "imageRef": "/content/uploads/hammam-light.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "featureGrid",
       "title": "",
       "columns": 4,
       "items": [
-        { "label": "Clinic-ready batching", "description": "Skin-friendly, clean, cold-pressed." },
-        { "label": "Holistic sensorial care", "description": "Low-residue textures and gentle aromas for sensitive skin." },
-        { "label": "Flexible retail stories", "description": "Starter sets and education for consistent home routines." },
-        { "label": "Sustainable partnerships", "description": "Fair relationships across Morocco’s cooperatives." }
+        {
+          "label": "Clinic-ready batching",
+          "description": "Skin-friendly, clean, cold-pressed."
+        },
+        {
+          "label": "Holistic sensorial care",
+          "description": "Low-residue textures and gentle aromas for sensitive skin."
+        },
+        {
+          "label": "Flexible retail stories",
+          "description": "Starter sets and education for consistent home routines."
+        },
+        {
+          "label": "Sustainable partnerships",
+          "description": "Fair relationships across Morocco’s cooperatives."
+        }
       ]
     },
     {
       "type": "productGrid",
       "title": "Our Bestsellers",
       "products": [
-        { "id": "pure-argan-100" },
-        { "id": "scar-care" },
-        { "id": "ritual-pack" }
+        {
+          "id": "pure-argan-100"
+        },
+        {
+          "id": "scar-care"
+        },
+        {
+          "id": "ritual-pack"
+        }
       ],
       "columns": 3
     },
@@ -71,8 +95,16 @@
       "type": "testimonials",
       "title": "What Professionals Say",
       "quotes": [
-        { "text": "After laser treatments, I recommend Kapunka pure argan for faster barrier repair. My patients notice less tightness and redness.", "author": "Dr. Isabella Rossi", "role": "Dermatologist" },
-        { "text": "Finally, a cleanser that respects sensitive skin while effectively removing makeup.", "author": "Chloe Davis", "role": "Esthetician" }
+        {
+          "text": "After laser treatments, I recommend Kapunka pure argan for faster barrier repair. My patients notice less tightness and redness.",
+          "author": "Dr. Isabella Rossi",
+          "role": "Dermatologist"
+        },
+        {
+          "text": "Finally, a cleanser that respects sensitive skin while effectively removing makeup.",
+          "author": "Chloe Davis",
+          "role": "Esthetician"
+        }
       ]
     }
   ]

--- a/content/pages/es/about.json
+++ b/content/pages/es/about.json
@@ -7,14 +7,14 @@
       "title": "De dónde viene Kapunka",
       "body": "Kapunka nació de una idea sencilla: la forma en que tocamos transforma cómo sanamos. Años junto a profesionales clínicos dieron forma a un método atento, preciso y amable.",
       "imageRef": "/content/uploads/founder-portrait.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "El nombre",
       "body": "Nuestra fundadora escuchó por primera vez ‘Kapunka’ en una escuela de Ubud. La palabra —gracias— se convirtió en una promesa: crear un cuidado que devuelva. Agradece a tu piel.",
       "imageRef": "/content/uploads/ubud-moment.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     }
   ]
 }

--- a/content/pages/es/clinics.json
+++ b/content/pages/es/clinics.json
@@ -7,16 +7,25 @@
       "title": "Del quirófano a la rutina diaria",
       "body": "Equipos de dermatología y estética confían en nosotros para el cuidado de cicatrices y la recuperación. Opciones de bajo residuo, consideradas con la fragancia y protocolos imprimibles.",
       "imageRef": "/content/uploads/clinic-tray.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "featureGrid",
       "title": "",
       "columns": 3,
       "items": [
-        { "label": "Protocolos", "description": "Pasos sencillos para preoperatorio, postoperatorio y cuidado en casa." },
-        { "label": "Formación", "description": "Onboarding breve y capacitaciones en servicio." },
-        { "label": "Mayoristas", "description": "Kits iniciales y reposición constante." }
+        {
+          "label": "Protocolos",
+          "description": "Pasos sencillos para preoperatorio, postoperatorio y cuidado en casa."
+        },
+        {
+          "label": "Formación",
+          "description": "Onboarding breve y capacitaciones en servicio."
+        },
+        {
+          "label": "Mayoristas",
+          "description": "Kits iniciales y reposición constante."
+        }
       ]
     },
     {

--- a/content/pages/es/contact.json
+++ b/content/pages/es/contact.json
@@ -7,7 +7,7 @@
       "title": "Estamos aquí para escucharte",
       "body": "Clínicas, aliados y personas—cuéntanos qué necesitas y te guiamos hacia la rutina, la formación u opción mayorista adecuada.",
       "imageRef": "/content/uploads/argan-fields.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     }
   ]
 }

--- a/content/pages/es/home.json
+++ b/content/pages/es/home.json
@@ -4,8 +4,14 @@
   "heroHeadline": "Sé agradecido con tu piel.",
   "heroSubheadline": "Rituales suaves de argán desde Marruecos para piel sensible y post-procedimiento. Kapunka 2.0: un cuidado sereno y humano.",
   "heroCtas": {
-    "ctaPrimary": { "label": "Ver rituales", "href": "/shop" },
-    "ctaSecondary": { "label": "Alianzas con clínicas", "href": "/clinics" }
+    "ctaPrimary": {
+      "label": "Ver rituales",
+      "href": "/shop"
+    },
+    "ctaSecondary": {
+      "label": "Alianzas con clínicas",
+      "href": "/clinics"
+    }
   },
   "heroAlignment": {
     "heroAlignX": "center",
@@ -14,54 +20,74 @@
     "heroOverlay": "medium",
     "heroLayoutHint": "bg"
   },
-  "heroImages": { "heroImageLeft": "/content/uploads/hero-dark-water.jpg" },
+  "heroImages": {
+    "heroImageLeft": "/content/uploads/hero-dark-water.jpg"
+  },
   "sections": [
     {
       "type": "mediaCopy",
       "title": "Nacido de la gratitud",
       "body": "“Kapunka” significa “gracias”. Elaboramos cuidados de argán con respeto clínico: rutinas sencillas que reconfortan, protegen y apoyan la recuperación. Nuestras raíces están en Marruecos; nuestro método creció en clínicas reales.",
       "imageRef": "/content/uploads/roots-olive-tree.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "Preferido por dermatólogos, medspas y clínicas holísticas",
       "body": "Nuestros tratamientos son suaves, de bajo residuo y guiados por el conocimiento, con aceptación de la piel, estabilidad de la barrera y equilibrio aromático. La formación dedicada y el soporte mayorista mantienen a tu equipo con confianza.",
       "imageRef": "/content/uploads/clinic-hands.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "Abastecimiento patrimonial, estándares de grado clínico",
       "body": "Obtenemos argán de origen único y seguimos cada paso desde las cooperativas hasta las certificaciones de laboratorio. Cada lote se somete a pruebas meticulosas para mantener un cuidado humano a escala.",
       "imageRef": "/content/uploads/argan-coop.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "De los rituales de hammam a la recuperación moderna",
       "body": "Aceite puro, brumas florales y limpiadores suaves. Sabiduría ancestral conectada con la vida de hoy: rutinas que calman el malestar, reparan la barrera y no dejan una película pesada.",
       "imageRef": "/content/uploads/hammam-light.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "featureGrid",
       "title": "",
       "columns": 4,
       "items": [
-        { "label": "Lotes listos para clínica", "description": "Amables con la piel, puros y prensados en frío." },
-        { "label": "Cuidado sensorial holístico", "description": "Texturas de bajo residuo y aromas suaves para piel sensible." },
-        { "label": "Historias minoristas flexibles", "description": "Sets iniciales y formación para rutinas constantes en casa." },
-        { "label": "Alianzas sostenibles", "description": "Relaciones justas con las cooperativas de Marruecos." }
+        {
+          "label": "Lotes listos para clínica",
+          "description": "Amables con la piel, puros y prensados en frío."
+        },
+        {
+          "label": "Cuidado sensorial holístico",
+          "description": "Texturas de bajo residuo y aromas suaves para piel sensible."
+        },
+        {
+          "label": "Historias minoristas flexibles",
+          "description": "Sets iniciales y formación para rutinas constantes en casa."
+        },
+        {
+          "label": "Alianzas sostenibles",
+          "description": "Relaciones justas con las cooperativas de Marruecos."
+        }
       ]
     },
     {
       "type": "productGrid",
       "title": "Nuestros más vendidos",
       "products": [
-        { "id": "pure-argan-100" },
-        { "id": "scar-care" },
-        { "id": "ritual-pack" }
+        {
+          "id": "pure-argan-100"
+        },
+        {
+          "id": "scar-care"
+        },
+        {
+          "id": "ritual-pack"
+        }
       ],
       "columns": 3
     },
@@ -69,8 +95,16 @@
       "type": "testimonials",
       "title": "Lo que dicen los profesionales",
       "quotes": [
-        { "text": "Después de los tratamientos con láser, recomiendo el argán puro de Kapunka para acelerar la reparación de la barrera. Mis pacientes notan menos tirantez y enrojecimiento.", "author": "Dra. Isabella Rossi", "role": "Dermatóloga" },
-        { "text": "Por fin, un limpiador que respeta la piel sensible y aun así elimina el maquillaje de forma eficaz.", "author": "Chloe Davis", "role": "Esteticista" }
+        {
+          "text": "Después de los tratamientos con láser, recomiendo el argán puro de Kapunka para acelerar la reparación de la barrera. Mis pacientes notan menos tirantez y enrojecimiento.",
+          "author": "Dra. Isabella Rossi",
+          "role": "Dermatóloga"
+        },
+        {
+          "text": "Por fin, un limpiador que respeta la piel sensible y aun así elimina el maquillaje de forma eficaz.",
+          "author": "Chloe Davis",
+          "role": "Esteticista"
+        }
       ]
     }
   ]

--- a/content/pages/es/learn.json
+++ b/content/pages/es/learn.json
@@ -7,21 +7,27 @@
       "title": "El Método Kapunka",
       "body": "Un enfoque que combina neurociencia, tacto preciso y cuidado dérmico. No es solo masaje: un protocolo para preoperatorio, tratamiento, recuperación, dolor crónico y cuidado en casa.",
       "imageRef": "/content/uploads/method-hands.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "Formación Profesional (ISMET)",
       "body": "Curso híbrido: 150 h online + 8 h de taller práctico. Objetivos: reducir estrés, dolor y ansiedad; apoyar la cicatrización; convertir la vulnerabilidad en confianza; aplicar el Método paso a paso. Certificación al completar.",
       "imageRef": "/content/uploads/training-class.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "faq",
       "title": "¿Qué la hace diferente?",
       "items": [
-        { "q": "¿En qué se diferencia de un masaje relajante?", "a": "Va más allá de la relajación global. Está protocolizada para fases clínicas, trabaja el sistema nervioso y la piel, usa argán Kapunka con propiedades antiinflamatorias y reparadoras, y suma acompañamiento humano." },
-        { "q": "¿Se solapa con técnicas de masaje cicatricial o linfáticas?", "a": "Son valiosas. Kapunka añade una visión más amplia: emoción y sistema nervioso, soporte dermocosmético y protocolos que mejoran toda la experiencia del paciente, no solo el estado mecánico del tejido." }
+        {
+          "q": "¿En qué se diferencia de un masaje relajante?",
+          "a": "Va más allá de la relajación global. Está protocolizada para fases clínicas, trabaja el sistema nervioso y la piel, usa argán Kapunka con propiedades antiinflamatorias y reparadoras, y suma acompañamiento humano."
+        },
+        {
+          "q": "¿Se solapa con técnicas de masaje cicatricial o linfáticas?",
+          "a": "Son valiosas. Kapunka añade una visión más amplia: emoción y sistema nervioso, soporte dermocosmético y protocolos que mejoran toda la experiencia del paciente, no solo el estado mecánico del tejido."
+        }
       ]
     },
     {

--- a/content/pages/pt/about.json
+++ b/content/pages/pt/about.json
@@ -7,14 +7,14 @@
       "title": "De onde vem a Kapunka",
       "body": "A Kapunka começou com uma ideia simples: a forma como tocamos muda a maneira como curamos. Anos ao lado de equipes clínicas moldaram um método cuidadoso, preciso e gentil.",
       "imageRef": "/content/uploads/founder-portrait.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "O nome",
       "body": "Nossa fundadora ouviu ‘Kapunka’ pela primeira vez em uma escola em Ubud. A palavra — obrigado — tornou-se uma promessa: criar um cuidado que retribua. Seja grato à sua pele.",
       "imageRef": "/content/uploads/ubud-moment.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     }
   ]
 }

--- a/content/pages/pt/clinics.json
+++ b/content/pages/pt/clinics.json
@@ -7,16 +7,25 @@
       "title": "Do centro cirúrgico à rotina diária",
       "body": "Equipes de dermatologia e estética confiam em nós para cuidados com cicatrizes e recuperação. Opções de baixo resíduo, atentas à fragrância e protocolos imprimíveis.",
       "imageRef": "/content/uploads/clinic-tray.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "featureGrid",
       "title": "",
       "columns": 3,
       "items": [
-        { "label": "Protocolos", "description": "Etapas simples para pré-operatório, pós-operatório e cuidado em casa." },
-        { "label": "Educação", "description": "Integração rápida e treinamentos em serviço." },
-        { "label": "Atacado", "description": "Kits iniciais e reposição constante." }
+        {
+          "label": "Protocolos",
+          "description": "Etapas simples para pré-operatório, pós-operatório e cuidado em casa."
+        },
+        {
+          "label": "Educação",
+          "description": "Integração rápida e treinamentos em serviço."
+        },
+        {
+          "label": "Atacado",
+          "description": "Kits iniciais e reposição constante."
+        }
       ]
     },
     {

--- a/content/pages/pt/contact.json
+++ b/content/pages/pt/contact.json
@@ -7,7 +7,7 @@
       "title": "Estamos aqui para ouvir",
       "body": "Clínicas, parceiros e pessoas queridas—conte o que você precisa e guiamos você até a rotina, o treinamento ou a opção de atacado ideal.",
       "imageRef": "/content/uploads/argan-fields.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     }
   ]
 }

--- a/content/pages/pt/home.json
+++ b/content/pages/pt/home.json
@@ -4,8 +4,14 @@
   "heroHeadline": "Agradece à tua pele.",
   "heroSubheadline": "Rituais suaves de argão de Marrocos para pele sensível e pós-procedimento. Kapunka 2.0: cuidado calmo, humano.",
   "heroCtas": {
-    "ctaPrimary": { "label": "Comprar rituais", "href": "/shop" },
-    "ctaSecondary": { "label": "Parceria para clínicas", "href": "/clinics" }
+    "ctaPrimary": {
+      "label": "Comprar rituais",
+      "href": "/shop"
+    },
+    "ctaSecondary": {
+      "label": "Parceria para clínicas",
+      "href": "/clinics"
+    }
   },
   "heroAlignment": {
     "heroAlignX": "center",
@@ -14,54 +20,74 @@
     "heroOverlay": "medium",
     "heroLayoutHint": "bg"
   },
-  "heroImages": { "heroImageLeft": "/content/uploads/hero-dark-water.jpg" },
+  "heroImages": {
+    "heroImageLeft": "/content/uploads/hero-dark-water.jpg"
+  },
   "sections": [
     {
       "type": "mediaCopy",
       "title": "Nascida da gratidão",
       "body": "“Kapunka” significa “obrigado”. Criamos cuidados com argão com respeito clínico — rotinas simples que confortam, protegem e apoiam a recuperação. As nossas raízes estão em Marrocos; o nosso método cresceu em clínicas reais.",
       "imageRef": "/content/uploads/roots-olive-tree.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "Preferida por dermatologistas, medspas e clínicas holísticas",
       "body": "Os nossos tratamentos são suaves, de baixa deposição e guiados pelo conhecimento, com aceitação da pele, estabilidade da barreira e equilíbrio aromático. Formação dedicada e apoio de venda por grosso mantêm a tua equipa confiante.",
       "imageRef": "/content/uploads/clinic-hands.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "Origem ancestral, padrões de nível clínico",
       "body": "Selecionamos argão de origem única e rastreamos os passos das cooperativas às certificações laboratoriais. Cada lote é meticulosamente testado para manter um cuidado humano em escala.",
       "imageRef": "/content/uploads/argan-coop.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "Dos rituais de hammam à recuperação moderna",
       "body": "Óleo puro, névoas florais e lavagens limpas. Sabedoria antiga ligada à vida que vivemos hoje: rotinas que acalmam o desconforto, reparam a barreira e não deixam uma película pesada.",
       "imageRef": "/content/uploads/hammam-light.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "featureGrid",
       "title": "",
       "columns": 4,
       "items": [
-        { "label": "Lotes prontos para clínica", "description": "Amigável para a pele, puro e prensado a frio." },
-        { "label": "Cuidado sensorial holístico", "description": "Texturas de baixa deposição e aromas suaves para pele sensível." },
-        { "label": "Histórias de retalho flexíveis", "description": "Conjuntos iniciais e formação para rotinas consistentes em casa." },
-        { "label": "Parcerias sustentáveis", "description": "Relações justas com as cooperativas de Marrocos." }
+        {
+          "label": "Lotes prontos para clínica",
+          "description": "Amigável para a pele, puro e prensado a frio."
+        },
+        {
+          "label": "Cuidado sensorial holístico",
+          "description": "Texturas de baixa deposição e aromas suaves para pele sensível."
+        },
+        {
+          "label": "Histórias de retalho flexíveis",
+          "description": "Conjuntos iniciais e formação para rotinas consistentes em casa."
+        },
+        {
+          "label": "Parcerias sustentáveis",
+          "description": "Relações justas com as cooperativas de Marrocos."
+        }
       ]
     },
     {
       "type": "productGrid",
       "title": "Os nossos mais vendidos",
       "products": [
-        { "id": "pure-argan-100" },
-        { "id": "scar-care" },
-        { "id": "ritual-pack" }
+        {
+          "id": "pure-argan-100"
+        },
+        {
+          "id": "scar-care"
+        },
+        {
+          "id": "ritual-pack"
+        }
       ],
       "columns": 3
     },
@@ -69,8 +95,16 @@
       "type": "testimonials",
       "title": "O que dizem os profissionais",
       "quotes": [
-        { "text": "Após tratamentos a laser, recomendo o argão puro da Kapunka para uma reparação mais rápida da barreira. As minhas pacientes notam menos repuxamento e vermelhidão.", "author": "Dra. Isabella Rossi", "role": "Dermatologista" },
-        { "text": "Finalmente, um cleanser que respeita a pele sensível enquanto remove a maquilhagem de forma eficaz.", "author": "Chloe Davis", "role": "Esteticista" }
+        {
+          "text": "Após tratamentos a laser, recomendo o argão puro da Kapunka para uma reparação mais rápida da barreira. As minhas pacientes notam menos repuxamento e vermelhidão.",
+          "author": "Dra. Isabella Rossi",
+          "role": "Dermatologista"
+        },
+        {
+          "text": "Finalmente, um cleanser que respeita a pele sensível enquanto remove a maquilhagem de forma eficaz.",
+          "author": "Chloe Davis",
+          "role": "Esteticista"
+        }
       ]
     }
   ]

--- a/content/pages/pt/learn.json
+++ b/content/pages/pt/learn.json
@@ -7,21 +7,27 @@
       "title": "O Método Kapunka",
       "body": "Uma abordagem que combina neurociência, toque preciso e cuidado dérmico. Não é apenas massagem: um protocolo para pré-operatório, tratamento, recuperação, dor crônica e autocuidado em casa.",
       "imageRef": "/content/uploads/method-hands.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "Formação Profissional (ISMET)",
       "body": "Curso híbrido: 150 h online + 8 h de workshop prático. Objetivos: reduzir stress, dor e ansiedade; apoiar a cicatrização; transformar vulnerabilidade em confiança; aplicar o Método passo a passo. Certificação ao concluir.",
       "imageRef": "/content/uploads/training-class.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "faq",
       "title": "O que a torna diferente?",
       "items": [
-        { "q": "Em que ela difere de uma massagem relaxante?", "a": "Vai além do relaxamento global. É protocolizada para fases clínicas, atua no sistema nervoso e na pele, usa argan Kapunka com propriedades anti-inflamatórias e reparadoras e acrescenta acompanhamento humano." },
-        { "q": "Ela se sobrepõe a técnicas de massagem para cicatrizes ou linfáticas?", "a": "Elas são valiosas. Kapunka acrescenta uma visão mais ampla: emoção e sistema nervoso, suporte dermocosmético e protocolos que melhoram toda a experiência do paciente, não apenas o estado mecânico do tecido." }
+        {
+          "q": "Em que ela difere de uma massagem relaxante?",
+          "a": "Vai além do relaxamento global. É protocolizada para fases clínicas, atua no sistema nervoso e na pele, usa argan Kapunka com propriedades anti-inflamatórias e reparadoras e acrescenta acompanhamento humano."
+        },
+        {
+          "q": "Ela se sobrepõe a técnicas de massagem para cicatrizes ou linfáticas?",
+          "a": "Elas são valiosas. Kapunka acrescenta uma visão mais ampla: emoção e sistema nervoso, suporte dermocosmético e protocolos que melhoram toda a experiência do paciente, não apenas o estado mecânico do tecido."
+        }
       ]
     },
     {

--- a/site/content/en/pages/about.json
+++ b/site/content/en/pages/about.json
@@ -7,14 +7,14 @@
       "title": "Where Kapunka comes from",
       "body": "Kapunka began with a simple idea: the way we touch changes how we heal. Years beside clinicians shaped a method that is careful, precise, and kind.",
       "imageRef": "/content/uploads/founder-portrait.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "The name",
       "body": "‘Kapunka’ was first heard by our founder in a school in Ubud. The word—thank you—became a promise: make care that gives back. Be thankful to your skin.",
       "imageRef": "/content/uploads/ubud-moment.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     }
   ]
 }

--- a/site/content/en/pages/clinics.json
+++ b/site/content/en/pages/clinics.json
@@ -7,16 +7,25 @@
       "title": "From operating room to everyday routine",
       "body": "Trusted by dermatology and aesthetic teams for scar care and recovery. Low-residue, fragrance-considerate options and printable protocols.",
       "imageRef": "/content/uploads/clinic-tray.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "featureGrid",
       "title": "",
       "columns": 3,
       "items": [
-        { "label": "Protocols", "description": "Simple steps for pre-op, post-op, and home care." },
-        { "label": "Education", "description": "Short onboarding and in-service training." },
-        { "label": "Wholesale", "description": "Starter kits and steady replenishment." }
+        {
+          "label": "Protocols",
+          "description": "Simple steps for pre-op, post-op, and home care."
+        },
+        {
+          "label": "Education",
+          "description": "Short onboarding and in-service training."
+        },
+        {
+          "label": "Wholesale",
+          "description": "Starter kits and steady replenishment."
+        }
       ]
     },
     {

--- a/site/content/en/pages/contact.json
+++ b/site/content/en/pages/contact.json
@@ -7,7 +7,7 @@
       "title": "We're ready to listen",
       "body": "Clinics, partners, and individuals—tell us what you need and we’ll guide you to the right routine, training, or wholesale option.",
       "imageRef": "/content/uploads/argan-fields.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     }
   ]
 }

--- a/site/content/es/pages/about.json
+++ b/site/content/es/pages/about.json
@@ -7,14 +7,14 @@
       "title": "De dónde viene Kapunka",
       "body": "Kapunka nació de una idea sencilla: la forma en que tocamos transforma cómo sanamos. Años junto a profesionales clínicos dieron forma a un método atento, preciso y amable.",
       "imageRef": "/content/uploads/founder-portrait.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "El nombre",
       "body": "Nuestra fundadora escuchó por primera vez ‘Kapunka’ en una escuela de Ubud. La palabra —gracias— se convirtió en una promesa: crear un cuidado que devuelva. Agradece a tu piel.",
       "imageRef": "/content/uploads/ubud-moment.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     }
   ]
 }

--- a/site/content/es/pages/clinics.json
+++ b/site/content/es/pages/clinics.json
@@ -7,16 +7,25 @@
       "title": "Del quirófano a la rutina diaria",
       "body": "Equipos de dermatología y estética confían en nosotros para el cuidado de cicatrices y la recuperación. Opciones de bajo residuo, consideradas con la fragancia y protocolos imprimibles.",
       "imageRef": "/content/uploads/clinic-tray.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "featureGrid",
       "title": "",
       "columns": 3,
       "items": [
-        { "label": "Protocolos", "description": "Pasos sencillos para preoperatorio, postoperatorio y cuidado en casa." },
-        { "label": "Formación", "description": "Onboarding breve y capacitaciones en servicio." },
-        { "label": "Mayoristas", "description": "Kits iniciales y reposición constante." }
+        {
+          "label": "Protocolos",
+          "description": "Pasos sencillos para preoperatorio, postoperatorio y cuidado en casa."
+        },
+        {
+          "label": "Formación",
+          "description": "Onboarding breve y capacitaciones en servicio."
+        },
+        {
+          "label": "Mayoristas",
+          "description": "Kits iniciales y reposición constante."
+        }
       ]
     },
     {

--- a/site/content/es/pages/contact.json
+++ b/site/content/es/pages/contact.json
@@ -7,7 +7,7 @@
       "title": "Estamos aquí para escucharte",
       "body": "Clínicas, aliados y personas—cuéntanos qué necesitas y te guiamos hacia la rutina, la formación u opción mayorista adecuada.",
       "imageRef": "/content/uploads/argan-fields.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     }
   ]
 }

--- a/site/content/es/pages/learn.json
+++ b/site/content/es/pages/learn.json
@@ -7,21 +7,27 @@
       "title": "El Método Kapunka",
       "body": "Un enfoque que combina neurociencia, tacto preciso y cuidado dérmico. No es solo masaje: un protocolo para preoperatorio, tratamiento, recuperación, dolor crónico y cuidado en casa.",
       "imageRef": "/content/uploads/method-hands.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "Formación Profesional (ISMET)",
       "body": "Curso híbrido: 150 h online + 8 h de taller práctico. Objetivos: reducir estrés, dolor y ansiedad; apoyar la cicatrización; convertir la vulnerabilidad en confianza; aplicar el Método paso a paso. Certificación al completar.",
       "imageRef": "/content/uploads/training-class.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "faq",
       "title": "¿Qué la hace diferente?",
       "items": [
-        { "q": "¿En qué se diferencia de un masaje relajante?", "a": "Va más allá de la relajación global. Está protocolizada para fases clínicas, trabaja el sistema nervioso y la piel, usa argán Kapunka con propiedades antiinflamatorias y reparadoras, y suma acompañamiento humano." },
-        { "q": "¿Se solapa con técnicas de masaje cicatricial o linfáticas?", "a": "Son valiosas. Kapunka añade una visión más amplia: emoción y sistema nervioso, soporte dermocosmético y protocolos que mejoran toda la experiencia del paciente, no solo el estado mecánico del tejido." }
+        {
+          "q": "¿En qué se diferencia de un masaje relajante?",
+          "a": "Va más allá de la relajación global. Está protocolizada para fases clínicas, trabaja el sistema nervioso y la piel, usa argán Kapunka con propiedades antiinflamatorias y reparadoras, y suma acompañamiento humano."
+        },
+        {
+          "q": "¿Se solapa con técnicas de masaje cicatricial o linfáticas?",
+          "a": "Son valiosas. Kapunka añade una visión más amplia: emoción y sistema nervioso, soporte dermocosmético y protocolos que mejoran toda la experiencia del paciente, no solo el estado mecánico del tejido."
+        }
       ]
     },
     {

--- a/site/content/pt/pages/about.json
+++ b/site/content/pt/pages/about.json
@@ -7,14 +7,14 @@
       "title": "De onde vem a Kapunka",
       "body": "A Kapunka começou com uma ideia simples: a forma como tocamos muda a maneira como curamos. Anos ao lado de equipes clínicas moldaram um método cuidadoso, preciso e gentil.",
       "imageRef": "/content/uploads/founder-portrait.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "O nome",
       "body": "Nossa fundadora ouviu ‘Kapunka’ pela primeira vez em uma escola em Ubud. A palavra — obrigado — tornou-se uma promessa: criar um cuidado que retribua. Seja grato à sua pele.",
       "imageRef": "/content/uploads/ubud-moment.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     }
   ]
 }

--- a/site/content/pt/pages/clinics.json
+++ b/site/content/pt/pages/clinics.json
@@ -7,16 +7,25 @@
       "title": "Do centro cirúrgico à rotina diária",
       "body": "Equipes de dermatologia e estética confiam em nós para cuidados com cicatrizes e recuperação. Opções de baixo resíduo, atentas à fragrância e protocolos imprimíveis.",
       "imageRef": "/content/uploads/clinic-tray.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "featureGrid",
       "title": "",
       "columns": 3,
       "items": [
-        { "label": "Protocolos", "description": "Etapas simples para pré-operatório, pós-operatório e cuidado em casa." },
-        { "label": "Educação", "description": "Integração rápida e treinamentos em serviço." },
-        { "label": "Atacado", "description": "Kits iniciais e reposição constante." }
+        {
+          "label": "Protocolos",
+          "description": "Etapas simples para pré-operatório, pós-operatório e cuidado em casa."
+        },
+        {
+          "label": "Educação",
+          "description": "Integração rápida e treinamentos em serviço."
+        },
+        {
+          "label": "Atacado",
+          "description": "Kits iniciais e reposição constante."
+        }
       ]
     },
     {

--- a/site/content/pt/pages/contact.json
+++ b/site/content/pt/pages/contact.json
@@ -7,7 +7,7 @@
       "title": "Estamos aqui para ouvir",
       "body": "Clínicas, parceiros e pessoas queridas—conte o que você precisa e guiamos você até a rotina, o treinamento ou a opção de atacado ideal.",
       "imageRef": "/content/uploads/argan-fields.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     }
   ]
 }

--- a/site/content/pt/pages/learn.json
+++ b/site/content/pt/pages/learn.json
@@ -7,21 +7,27 @@
       "title": "O Método Kapunka",
       "body": "Uma abordagem que combina neurociência, toque preciso e cuidado dérmico. Não é apenas massagem: um protocolo para pré-operatório, tratamento, recuperação, dor crônica e autocuidado em casa.",
       "imageRef": "/content/uploads/method-hands.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "mediaCopy",
       "title": "Formação Profissional (ISMET)",
       "body": "Curso híbrido: 150 h online + 8 h de workshop prático. Objetivos: reduzir stress, dor e ansiedade; apoiar a cicatrização; transformar vulnerabilidade em confiança; aplicar o Método passo a passo. Certificação ao concluir.",
       "imageRef": "/content/uploads/training-class.jpg",
-      "layout": "textLeftImageRight"
+      "layout": "image-right"
     },
     {
       "type": "faq",
       "title": "O que a torna diferente?",
       "items": [
-        { "q": "Em que ela difere de uma massagem relaxante?", "a": "Vai além do relaxamento global. É protocolizada para fases clínicas, atua no sistema nervoso e na pele, usa argan Kapunka com propriedades anti-inflamatórias e reparadoras e acrescenta acompanhamento humano." },
-        { "q": "Ela se sobrepõe a técnicas de massagem para cicatrizes ou linfáticas?", "a": "Elas são valiosas. Kapunka acrescenta uma visão mais ampla: emoção e sistema nervoso, suporte dermocosmético e protocolos que melhoram toda a experiência do paciente, não apenas o estado mecânico do tecido." }
+        {
+          "q": "Em que ela difere de uma massagem relaxante?",
+          "a": "Vai além do relaxamento global. É protocolizada para fases clínicas, atua no sistema nervoso e na pele, usa argan Kapunka com propriedades anti-inflamatórias e reparadoras e acrescenta acompanhamento humano."
+        },
+        {
+          "q": "Ela se sobrepõe a técnicas de massagem para cicatrizes ou linfáticas?",
+          "a": "Elas são valiosas. Kapunka acrescenta uma visão mais ampla: emoção e sistema nervoso, suporte dermocosmético e protocolos que melhoram toda a experiência do paciente, não apenas o estado mecânico do tecido."
+        }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- sync the Decap section templates with the live site data, including media, product, testimonial, timeline, and training blocks
- expose method-page hero and clinical note fields alongside facts, bullet, and specialty sections for easier editing
- normalize localized page JSON (and Visual Editor mirrors) to use the new media layout options

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68da643079048320ae5d560bfd996814