### PR TITLE
Fix indentation for community carousel slide duration field

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -113,12 +113,12 @@ shared_sections: &shared_sections
             widget: "string"
             i18n: true
             required: false
-           - label: "Slide Duration (ms)"
-             name: "slideDuration"
-             widget: "number"
-             value_type: "int"
-             required: false
-             hint: "Leave blank to use the default 8000ms timing."
+          - label: "Slide Duration (ms)"
+            name: "slideDuration"
+            widget: "number"
+            value_type: "int"
+            required: false
+            hint: "Leave blank to use the default 8000ms timing."
   - &section_faq
     label: "FAQ"
     name: "faq"


### PR DESCRIPTION
## Summary
- correct the indentation for the slide duration field in the community carousel list to restore valid YAML

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68da822efba88320a48bc113d6fc1092