### PR TITLE
Fix CMS hero overlay hint quoting

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -485,7 +485,7 @@ collections:
                   - { label: "Bottom center", value: "bottom-center" }
                   - { label: "Bottom right", value: "bottom-right" }
                 default: middle-center
-                hint: "Pins overlay text to a corner or edge when ""Text Display"" is set to overlay."
+                hint: 'Pins overlay text to a corner or edge when "Text Display" is set to overlay.'
               - label: Overlay Strength
                 name: heroOverlay
                 widget: select


### PR DESCRIPTION
## Summary
- adjust the hero overlay anchor hint to use single quotes so the Decap YAML remains valid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68da84986dfc8320a449974ed2f274f4