### PR TITLE
fix: remove invalid sections model references from Stackbit config

### DIFF
--- a/stackbit.config.js
+++ b/stackbit.config.js
@@ -1925,7 +1925,6 @@ const customModels = [
         name: 'sections',
         type: 'list',
         label: 'Sections',
-        models: sectionModelNames,
         items: {
           type: 'model',
           models: sectionModelNames,
@@ -1945,7 +1944,6 @@ const customModels = [
         name: 'sections',
         type: 'list',
         label: 'Sections',
-        models: sectionModelNames,
         items: {
           type: 'model',
           models: sectionModelNames,
@@ -1965,7 +1963,6 @@ const customModels = [
         name: 'sections',
         type: 'list',
         label: 'Sections',
-        models: sectionModelNames,
         items: {
           type: 'model',
           models: sectionModelNames,
@@ -1985,7 +1982,6 @@ const customModels = [
         name: 'sections',
         type: 'list',
         label: 'Sections',
-        models: sectionModelNames,
         items: {
           type: 'model',
           models: sectionModelNames,
@@ -2005,7 +2001,6 @@ const customModels = [
         name: 'sections',
         type: 'list',
         label: 'Sections',
-        models: sectionModelNames,
         items: {
           type: 'model',
           models: sectionModelNames,
@@ -2025,7 +2020,6 @@ const customModels = [
         name: 'sections',
         type: 'list',
         label: 'Sections',
-        models: sectionModelNames,
         items: {
           type: 'model',
           models: sectionModelNames,
@@ -2045,7 +2039,6 @@ const customModels = [
         name: 'sections',
         type: 'list',
         label: 'Sections',
-        models: sectionModelNames,
         items: {
           type: 'model',
           models: sectionModelNames,
@@ -2065,7 +2058,6 @@ const customModels = [
         name: 'sections',
         type: 'list',
         label: 'Sections',
-        models: sectionModelNames,
         items: {
           type: 'model',
           models: sectionModelNames,
@@ -2085,7 +2077,6 @@ const customModels = [
         name: 'sections',
         type: 'list',
         label: 'Sections',
-        models: sectionModelNames,
         items: {
           type: 'model',
           models: sectionModelNames,
@@ -2105,7 +2096,6 @@ const customModels = [
         name: 'sections',
         type: 'list',
         label: 'Sections',
-        models: sectionModelNames,
         items: {
           type: 'model',
           models: sectionModelNames,
@@ -2125,7 +2115,6 @@ const customModels = [
         name: 'sections',
         type: 'list',
         label: 'Sections',
-        models: sectionModelNames,
         items: {
           type: 'model',
           models: sectionModelNames,


### PR DESCRIPTION
## Summary
- remove unsupported `models` property from all section list fields so Stackbit/Netlify Visual Editor accepts the schema

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dd087afc288320a083cc8386ebbabf