### PR TITLE
Fix Visual Editor annotations for navigation and footer

### DIFF
--- a/site/content/site.json
+++ b/site/content/site.json
@@ -1,0 +1,61 @@
+{
+  "type": "SiteConfig",
+  "contact": {
+    "email": "info@kapunka.com",
+    "phone": "+1 (234) 567-890",
+    "whatsapp": "https://wa.me/1234567890"
+  },
+  "brand": {
+    "name": "KAPUNKA"
+  },
+  "clinics": {
+    "ctaLink": "https://kapunka.com/#/contact"
+  },
+  "about": {
+    "storyImage": "/content/uploads/monica-argan-.jpg",
+    "sourcingImage": "/content/uploads/argan-production.jpg",
+    "storyAlt": "Brand story",
+    "sourcingAlt": "Sourcing argan oil"
+  },
+  "featureFlags": {
+    "videos": false,
+    "training": false
+  },
+  "footer": {
+    "legalName": "Kapunka Skincare",
+    "socialLinks": [
+      {
+        "id": "facebook",
+        "label": "Facebook",
+        "url": "https://www.facebook.com/kapunkargan",
+        "icon": "facebook"
+      },
+      {
+        "id": "instagram",
+        "label": "Instagram",
+        "url": "https://www.instagram.com/kapunkarganoil/",
+        "icon": "instagram"
+      }
+    ]
+  },
+  "seo": {
+    "defaultTitle": {
+      "en": "Kapunka Skincare",
+      "pt": "Kapunka Skincare",
+      "es": "Kapunka Skincare"
+    },
+    "defaultDescription": {
+      "en": "Premium skincare for a healthy skin barrier. Clean, minimal, and elegant products.",
+      "pt": "Premium skincare for a healthy skin barrier. Clean, minimal, and elegant products.",
+      "es": "Premium skincare for a healthy skin barrier. Clean, minimal, and elegant products."
+    }
+  },
+  "home": {
+    "heroImage": "/content/uploads/pexels-reyna-2825461.jpg",
+    "featuredProductIds": [
+      "pure-argan-oil",
+      "kapunka-cicatrices",
+      "pack-kapunka"
+    ]
+  }
+}

--- a/site/content/translations/about.json
+++ b/site/content/translations/about.json
@@ -1,0 +1,42 @@
+{
+  "type": "translations_about",
+  "en": {
+    "title": "Our Story",
+    "metaDescription": "Learn about Kapunka Skincare's mission to create effective, minimalist skincare that respects the skin barrier and the environment.",
+    "headerTitle": "Less, but better.",
+    "headerSubtitle": "We believe in the power of simplicity. Our philosophy is rooted in using pure, high-quality ingredients to create formulations that support your skin's long-term health.",
+    "storyTitle": "Our Story",
+    "storyText1": "Kapunka was born from a desire for transparent, effective skincare. We started by sourcing the purest, ECOCERT-certified Argan oil from women's cooperatives in Morocco.",
+    "storyText2": "Our goal is to create products that are not only a pleasure to use but also deliver tangible results, always prioritizing the health of your skin barrier.",
+    "sourcingTitle": "Ethical Sourcing",
+    "sourcingText1": "We are committed to ethical and sustainable practices. Our ingredients are sourced from suppliers who share our values of environmental responsibility and fair trade.",
+    "sourcingText2": "Our Argan oil is a prime example, providing economic empowerment to the Berber women who have perfected its traditional extraction method for centuries.",
+    "sourcingImageAlt": "Field of argan trees"
+  },
+  "pt": {
+    "title": "Nossa História",
+    "metaDescription": "Conheça a missão da Kapunka Skincare de criar cuidados com a pele eficazes e minimalistas que respeitam a barreira cutânea e o meio ambiente.",
+    "headerTitle": "Menos, mas melhor.",
+    "headerSubtitle": "Acreditamos no poder da simplicidade. Nossa filosofia está enraizada no uso de ingredientes puros e de alta qualidade para criar formulações que apoiam a saúde da sua pele a longo prazo.",
+    "storyTitle": "Nossa História",
+    "storyText1": "A Kapunka nasceu do desejo por cuidados com a pele transparentes e eficazes. Começamos por obter o mais puro óleo de Argan certificado pela ECOCERT de cooperativas de mulheres em Marrocos.",
+    "storyText2": "Nosso objetivo é criar produtos que não sejam apenas um prazer de usar, mas que também entreguem resultados tangíveis, priorizando sempre a saúde da sua barreira cutânea.",
+    "sourcingTitle": "Fornecimento Ético",
+    "sourcingText1": "Estamos comprometidos com práticas éticas e sustentáveis. Nossos ingredientes são provenientes de fornecedores que compartilham nossos valores de responsabilidade ambiental e comércio justo.",
+    "sourcingText2": "Nosso óleo de Argan é um excelente exemplo, proporcionando empoderamento econômico para as mulheres berberes que aperfeiçoaram seu método tradicional de extração por séculos.",
+    "sourcingImageAlt": "Campo de árvores de argan"
+  },
+  "es": {
+    "title": "Nuestra Historia",
+    "metaDescription": "Conoce la misión de Kapunka Skincare de crear un cuidado de la piel eficaz y minimalista que respete la barrera cutánea y el medio ambiente.",
+    "headerTitle": "Menos, pero mejor.",
+    "headerSubtitle": "Creemos en el poder de la simplicidad. Nuestra filosofía se basa en el uso de ingredientes puros y de alta calidad para crear formulaciones que apoyen la salud de tu piel a largo plazo.",
+    "storyTitle": "Nuestra Historia",
+    "storyText1": "Kapunka nació del deseo de un cuidado de la piel transparente y eficaz. Empezamos por obtener el aceite de Argán más puro, certificado por ECOCERT, de cooperativas de mujeres en Marruecos.",
+    "storyText2": "Nuestro objetivo es crear productos que no solo sean un placer de usar, sino que también ofrezcan resultados tangibles, priorizando siempre la salud de tu barrera cutánea.",
+    "sourcingTitle": "Abastecimiento Ético",
+    "sourcingText1": "Estamos comprometidos con prácticas éticas y sostenibles. Nuestros ingredientes provienen de proveedores que comparten nuestros valores de responsabilidad ambiental y comercio justo.",
+    "sourcingText2": "Nuestro aceite de Argán es un ejemplo primordial, proporcionando empoderamiento económico a las mujeres bereberes que han perfeccionado su método tradicional de extracción durante siglos.",
+    "sourcingImageAlt": "Campo de árboles de argán"
+  }
+}

--- a/site/content/translations/academy.json
+++ b/site/content/translations/academy.json
@@ -1,0 +1,21 @@
+{
+  "type": "translations_academy",
+  "en": {
+    "headerTitle": "Kapunka Academy",
+    "headerSubtitle": "Professional education for dermatologists and estheticians to master advanced skincare techniques with our products.",
+    "coursesTitle": "Available Courses",
+    "enrollNow": "Enroll Now"
+  },
+  "pt": {
+    "headerTitle": "Academia Kapunka",
+    "headerSubtitle": "Educação profissional para dermatologistas e esteticistas para dominar técnicas avançadas de cuidados com a pele com nossos produtos.",
+    "coursesTitle": "Cursos Disponíveis",
+    "enrollNow": "Inscreva-se Agora"
+  },
+  "es": {
+    "headerTitle": "Academia Kapunka",
+    "headerSubtitle": "Educación profesional para dermatólogos y esteticistas para dominar técnicas avanzadas de cuidado de la piel con nuestros productos.",
+    "coursesTitle": "Cursos Disponibles",
+    "enrollNow": "Inscribirse Ahora"
+  }
+}

--- a/site/content/translations/article.json
+++ b/site/content/translations/article.json
@@ -1,0 +1,24 @@
+{
+  "type": "translations_article",
+  "en": {
+    "featuredProduct": "Featured Product",
+    "faqTitle": "Frequently Asked Questions",
+    "backToLibrary": "Back to Skincare Library",
+    "notFound": "Article not found.",
+    "loading": "Loading article..."
+  },
+  "pt": {
+    "featuredProduct": "Produto em destaque",
+    "faqTitle": "Perguntas frequentes",
+    "backToLibrary": "Voltar à Biblioteca de Skincare",
+    "notFound": "Artigo não encontrado.",
+    "loading": "Carregando artigo..."
+  },
+  "es": {
+    "featuredProduct": "Producto destacado",
+    "faqTitle": "Preguntas frecuentes",
+    "backToLibrary": "Volver a la Biblioteca de Skincare",
+    "notFound": "Artículo no encontrado.",
+    "loading": "Cargando artículo..."
+  }
+}

--- a/site/content/translations/cart.json
+++ b/site/content/translations/cart.json
@@ -1,0 +1,48 @@
+{
+  "type": "translations_cart",
+  "en": {
+    "title": "Your Cart",
+    "subtotal": "Subtotal",
+    "shippingNote": "Shipping and taxes calculated at checkout.",
+    "viewCart": "View Full Cart",
+    "empty": "Your cart is empty.",
+    "continueShopping": "Continue Shopping",
+    "pageTitle": "Shopping Cart",
+    "summary": "Order Summary",
+    "shipping": "Shipping",
+    "shippingCalculated": "Calculated at next step",
+    "total": "Total",
+    "checkout": "Proceed to Checkout",
+    "checkoutRedirect": "You will be redirected to a secure checkout page."
+  },
+  "pt": {
+    "title": "Seu Carrinho",
+    "subtotal": "Subtotal",
+    "shippingNote": "Envio e impostos calculados no checkout.",
+    "viewCart": "Ver Carrinho Completo",
+    "empty": "Seu carrinho está vazio.",
+    "continueShopping": "Continuar Comprando",
+    "pageTitle": "Carrinho de Compras",
+    "summary": "Resumo do Pedido",
+    "shipping": "Envio",
+    "shippingCalculated": "Calculado no próximo passo",
+    "total": "Total",
+    "checkout": "Ir para o Checkout",
+    "checkoutRedirect": "Você será redirecionado para uma página de checkout segura."
+  },
+  "es": {
+    "title": "Tu Carrito",
+    "subtotal": "Subtotal",
+    "shippingNote": "Envío e impuestos calculados en el checkout.",
+    "viewCart": "Ver Carrito Completo",
+    "empty": "Tu carrito está vacío.",
+    "continueShopping": "Seguir Comprando",
+    "pageTitle": "Carrito de Compras",
+    "summary": "Resumen del Pedido",
+    "shipping": "Envío",
+    "shippingCalculated": "Calculado en el siguiente paso",
+    "total": "Total",
+    "checkout": "Proceder al Pago",
+    "checkoutRedirect": "Serás redirigido a una página de pago segura."
+  }
+}

--- a/site/content/translations/clinics.json
+++ b/site/content/translations/clinics.json
@@ -1,0 +1,345 @@
+{
+  "type": "translations_clinics",
+  "en": {
+    "title": "Professional Clinic Partnerships",
+    "metaDescription": "B2B skincare supply for post-treatment skin care. Access dermatologist-approved argan oil, clinical protocols, and training for your clinic.",
+    "headerTitle": "Professional Clinic Partnership Program",
+    "headerSubtitle": "Deliver consistent post-treatment skin care with dermatologist-approved argan oil and minimalist, clinic-tested formulas tailored for recovery and hormonal hydration.",
+    "section1Title": "Evidence-Led Support for Every Treatment Room",
+    "section1Text1": "Our B2B skincare supply combines ECOCERT argan oil, Damask rose water, and barrier-strengthening lipids with educational assets you can personalize. Protocols are reviewed by board-certified dermatologists so your team can offer confident guidance after microneedling, chemical peels, laser, or menopause-related dryness.",
+    "section1Text2": "Partners receive wholesale pricing, onboarding modules, and printable aftercare one-pagers in English, Portuguese, and Spanish. Kapunka simplifies the handoff from procedure to home care, helping you retain patients and build retail revenue.",
+    "protocolSection": {
+      "title": "Protocol Blueprints You Can Personalize",
+      "subtitle": "Downloadable, dermatologist-reviewed routines to guide patients through the most requested treatments.",
+      "cards": [
+        {
+          "title": "Microneedling Aftercare (0–72 hours)",
+          "focus": "Stabilize the barrier, reduce TEWL, and prevent microbial contamination.",
+          "steps": [
+            "Immediately post-treatment: mist Kapunka Damask Rose Water or sterile saline, then press three drops of our dermatologist-approved argan oil over treated zones to seal microchannels.",
+            "First night: instruct patients to avoid makeup and retinoids; reapply argan oil on damp skin every 6–8 hours to keep the lipid matrix saturated.",
+            "Days 2–3: layer a hyaluronic serum under argan oil; resume mineral SPF once erythema resolves."
+          ],
+          "evidence": "Guided by Fabbrocini et al., Journal of Clinical and Aesthetic Dermatology (2014), which documents barrier disruption for up to 48 hours post-microneedling and the benefits of lipid-rich emollients."
+        },
+        {
+          "title": "Medium-Depth Chemical Peel Recovery (Day 0–7)",
+          "focus": "Modulate inflammation, support desquamation, and rebuild the stratum corneum.",
+          "steps": [
+            "Day 0: neutralize the peel per manufacturer instructions; once skin temperature normalizes, mist Damask Rose Water and apply a thin veil of argan oil to buffer tightness.",
+            "Days 1–3: cleanse with pH-balanced milk cleansers; alternate rose water compresses with argan oil occlusion to minimize crusting.",
+            "Days 4–7: introduce ceramide cream over argan oil; reinforce broad-spectrum SPF 50 and avoid exfoliants until peeling completes."
+          ],
+          "evidence": "Informed by Soleymani et al., Journal of Clinical and Aesthetic Dermatology (2018), highlighting lipid replenishment as a key determinant of controlled re-epithelialization."
+        },
+        {
+          "title": "Hydration Support During Menopause",
+          "focus": "Restore lipids, improve elasticity, and calm neurogenic dryness linked to estrogen decline.",
+          "steps": [
+            "Morning: spritz Damask Rose Water, cocktail two drops of argan oil with ceramide moisturizer, and finish with SPF to address increased photosensitivity.",
+            "Evening: apply argan oil to face, neck, and décolletage while skin is damp; follow with light massage to stimulate microcirculation.",
+            "Weekly: suggest scalp massages with argan oil to offset hair density changes and provide hand and forearm treatments during in-clinic visits."
+          ],
+          "evidence": "Aligned with Lephart, Biomedicine & Pharmacotherapy (2016) and Sator et al., Journal of the American Academy of Dermatology (2001), which report improved elasticity and hydration in postmenopausal skin after topical phyto-lipids."
+        }
+      ]
+    },
+    "referencesSection": {
+      "title": "Clinical References & Expert Voices",
+      "studiesTitle": "Peer-reviewed highlights",
+      "studies": [
+        {
+          "title": "Fabbrocini A. et al. Microneedling in dermatology: A review.",
+          "details": "Journal of Clinical and Aesthetic Dermatology, 2014."
+        },
+        {
+          "title": "Soleymani T. et al. A practical approach to chemical peels.",
+          "details": "Journal of Clinical and Aesthetic Dermatology, 2018."
+        },
+        {
+          "title": "Lephart E.D. Skin aging and menopause: Implications for treatment.",
+          "details": "Biomedicine & Pharmacotherapy, 2016."
+        }
+      ],
+      "testimonialsTitle": "Dermatologist testimonials",
+      "testimonials": [
+        {
+          "quote": "\"Kapunka’s dermatologist-approved argan oil delivers the lipid profile I want for post-treatment skin care, and patients appreciate the sustainable sourcing.\"",
+          "name": "Dr. Sofia Mendes",
+          "credentials": "Board-Certified Dermatologist, Lisbon"
+        },
+        {
+          "quote": "\"The minimalist INCI keeps our sensitized patients comfortable after peels, while the brand’s training modules shorten staff onboarding.\"",
+          "name": "Dr. Elena Ruiz",
+          "credentials": "Dermatologic Surgeon, Madrid"
+        }
+      ]
+    },
+    "keywordSection": {
+      "title": "Optimized B2B Skincare Supply",
+      "subtitle": "Include these focus points in your listings and marketing to reach discerning patients.",
+      "keywords": [
+        "post-treatment skin care protocols",
+        "dermatologist-approved argan oil retail sets",
+        "B2B skincare supply for medical spas",
+        "hormonal hydration support kits",
+        "sustainable Moroccan argan oil wholesale"
+      ]
+    },
+    "faqSection": {
+      "title": "Clinic FAQs",
+      "subtitle": "Logistics, training, and application methods tailored for your team.",
+      "items": [
+        {
+          "question": "What is the minimum order quantity (MOQ)?",
+          "answer": "Opening orders start at 24 retail units or 6 professional back-bar units. Mixed product cases qualify for the same wholesale pricing so smaller clinics can curate assortments."
+        },
+        {
+          "question": "Do you provide protocol training?",
+          "answer": "Yes. Partners access a bilingual e-learning portal with microneedling, chemical peel, and menopause hydration modules. Live quarterly webinars review updates and allow Q&A with our medical advisory board."
+        },
+        {
+          "question": "How should clinicians apply the argan oil in treatment rooms?",
+          "answer": "Decant into sterile droppers. After finishing a treatment, mist the skin with rose water and press the oil in gloved hands to avoid friction. For scalp or body services, warm the oil to body temperature before massage."
+        },
+        {
+          "question": "Can Kapunka support white-label or co-branded materials?",
+          "answer": "We offer customizable post-treatment cards and co-branded sleeves after your third order. Our design team adapts assets to your brand within five business days."
+        }
+      ]
+    },
+    "doctorsTitle": "Trusted by Top Professionals",
+    "ctaTitle": "Become a Partner",
+    "ctaSubtitle": "Schedule a call to review wholesale pricing, sampling, and clinic launch support.",
+    "ctaButton": "Contact Us",
+    "partnersTitle": "As Seen In"
+  },
+  "pt": {
+    "title": "Parcerias Profissionais para Clínicas",
+    "metaDescription": "Fornecimento B2B de skincare para cuidados pós-tratamento. Acesse óleo de argan aprovado por dermatologistas, protocolos clínicos e treinamento para a sua clínica.",
+    "headerTitle": "Programa Profissional Kapunka",
+    "headerSubtitle": "Ofereça cuidados pós-tratamento consistentes com óleo de argan aprovado por dermatologistas e fórmulas minimalistas testadas em clínica para recuperação e hidratação hormonal.",
+    "section1Title": "Suporte baseado em evidências para cada sala de tratamento",
+    "section1Text1": "Nosso fornecimento B2B de skincare combina óleo de argan ECOCERT, água de rosas Damascena e lipídios fortalecedores da barreira com materiais educativos que você pode personalizar. Os protocolos são revisados por dermatologistas certificados para que a sua equipa ofereça orientações seguras após microagulhamento, peelings químicos, laser ou ressecamento relacionado à menopausa.",
+    "section1Text2": "Os parceiros recebem preços no atacado, módulos de onboarding e folhetos de pós-tratamento prontos para imprimir em inglês, português e espanhol. A Kapunka simplifica a transição do procedimento para o cuidado em casa, ajudando a reter pacientes e ampliar a receita de varejo.",
+    "protocolSection": {
+      "title": "Modelos de protocolo para personalizar",
+      "subtitle": "Rotinas revisadas por dermatologistas e disponíveis para download, guiando pacientes nos tratamentos mais procurados.",
+      "cards": [
+        {
+          "title": "Pós-tratamento de microagulhamento (0–72 horas)",
+          "focus": "Estabilize a barreira, reduza a TEWL e previna contaminação microbiana.",
+          "steps": [
+            "Imediatamente após o procedimento: borrife Água de Rosas Damascena Kapunka ou soro fisiológico estéril e pressione três gotas do nosso óleo de argan aprovado por dermatologistas sobre as zonas tratadas para selar os microcanais.",
+            "Primeira noite: oriente as pacientes a evitarem maquiagem e retinoides; reaplique o óleo de argan na pele úmida a cada 6–8 horas para manter a matriz lipídica saturada.",
+            "Dias 2–3: estratifique um sérum de ácido hialurônico sob o óleo de argan; retome o protetor solar mineral quando o eritema diminuir."
+          ],
+          "evidence": "Orientado por Fabbrocini et al., Journal of Clinical and Aesthetic Dermatology (2014), que documenta a interrupção da barreira por até 48 horas após o microagulhamento e os benefícios de emolientes ricos em lipídios."
+        },
+        {
+          "title": "Recuperação de peeling químico médio (Dia 0–7)",
+          "focus": "Modere a inflamação, apoie a descamação e reconstrua o estrato córneo.",
+          "steps": [
+            "Dia 0: neutralize o peeling conforme as instruções do fabricante; quando a pele voltar à temperatura normal, borrife Água de Rosas Damascena e aplique um véu fino de óleo de argan para amenizar a sensação de repuxamento.",
+            "Dias 1–3: higienize com limpadores lácteos de pH equilibrado; alterne compressas de água de rosas com oclusão de óleo de argan para minimizar a formação de crostas.",
+            "Dias 4–7: introduza um creme com ceramidas sobre o óleo de argan; reforce o uso de protetor solar FPS 50 de amplo espectro e evite esfoliantes até o término da descamação."
+          ],
+          "evidence": "Baseado em Soleymani et al., Journal of Clinical and Aesthetic Dermatology (2018), que destaca a reposição lipídica como determinante para a reepitelização controlada."
+        },
+        {
+          "title": "Suporte de hidratação durante a menopausa",
+          "focus": "Restaure lipídios, melhore a elasticidade e acalme o ressecamento neurogênico ligado à queda estrogênica.",
+          "steps": [
+            "Manhã: borrife Água de Rosas Damascena, misture duas gotas de óleo de argan ao hidratante com ceramidas e finalize com protetor solar para lidar com a fotossensibilidade aumentada.",
+            "Noite: aplique óleo de argan no rosto, pescoço e colo com a pele úmida; faça uma massagem suave para estimular a microcirculação.",
+            "Semanalmente: sugerir massagens no couro cabeludo com óleo de argan para compensar mudanças na densidade capilar e oferecer tratamentos de mãos e antebraços durante as visitas à clínica."
+          ],
+          "evidence": "Alinhado a Lephart, Biomedicine & Pharmacotherapy (2016) e Sator et al., Journal of the American Academy of Dermatology (2001), que relatam melhora de elasticidade e hidratação na pele pós-menopausa após o uso tópico de fito-lipídios."
+        }
+      ]
+    },
+    "referencesSection": {
+      "title": "Referências clínicas e vozes especialistas",
+      "studiesTitle": "Destaques revisados por pares",
+      "studies": [
+        {
+          "title": "Fabbrocini A. et al. Microneedling in dermatology: A review.",
+          "details": "Journal of Clinical and Aesthetic Dermatology, 2014."
+        },
+        {
+          "title": "Soleymani T. et al. A practical approach to chemical peels.",
+          "details": "Journal of Clinical and Aesthetic Dermatology, 2018."
+        },
+        {
+          "title": "Lephart E.D. Skin aging and menopause: Implications for treatment.",
+          "details": "Biomedicine & Pharmacotherapy, 2016."
+        }
+      ],
+      "testimonialsTitle": "Depoimentos de dermatologistas",
+      "testimonials": [
+        {
+          "quote": "\"O óleo de argan aprovado por dermatologistas da Kapunka oferece o perfil lipídico que desejo para o post-treatment skin care, e as pacientes valorizam a origem sustentável.\"",
+          "name": "Dra. Sofia Mendes",
+          "credentials": "Dermatologista certificada, Lisboa"
+        },
+        {
+          "quote": "\"O INCI minimalista mantém as pacientes sensibilizadas confortáveis após os peelings, enquanto os módulos de treinamento da marca encurtam o onboarding da equipa.\"",
+          "name": "Dra. Elena Ruiz",
+          "credentials": "Cirurgiã dermatológica, Madri"
+        }
+      ]
+    },
+    "keywordSection": {
+      "title": "Fornecimento B2B de skincare otimizado",
+      "subtitle": "Inclua estes focos nas suas listas e campanhas para alcançar pacientes exigentes.",
+      "keywords": [
+        "post-treatment skin care protocols (protocolos de cuidados pós-tratamento)",
+        "dermatologist-approved argan oil retail sets (kits de óleo de argan aprovado por dermatologistas)",
+        "B2B skincare supply for medical spas (fornecimento B2B de skincare para clínicas e spas médicos)",
+        "hormonal hydration support kits (kits de suporte de hidratação hormonal)",
+        "sustainable Moroccan argan oil wholesale (óleo de argan marroquino sustentável no atacado)"
+      ]
+    },
+    "faqSection": {
+      "title": "Perguntas frequentes para clínicas",
+      "subtitle": "Logística, treinamento e métodos de aplicação adaptados à sua equipa.",
+      "items": [
+        {
+          "question": "Qual é a quantidade mínima de pedido (MOQ)?",
+          "answer": "Os pedidos iniciais começam com 24 unidades de varejo ou 6 unidades profissionais de back bar. Caixas com produtos variados mantêm o mesmo preço de atacado para que clínicas menores possam montar assortments personalizados."
+        },
+        {
+          "question": "Vocês oferecem treinamento de protocolos?",
+          "answer": "Sim. Os parceiros acessam uma plataforma de e-learning bilíngue com módulos de microagulhamento, peeling químico e hidratação na menopausa. Webinars trimestrais ao vivo trazem atualizações e um Q&A com o nosso conselho médico."
+        },
+        {
+          "question": "Como os clínicos devem aplicar o óleo de argan na sala de tratamento?",
+          "answer": "Transfira para conta-gotas estéreis. Ao finalizar o procedimento, borrife água de rosas na pele e pressione o óleo com as mãos enluvadas para evitar fricção. Em serviços de couro cabeludo ou corpo, aqueça o óleo à temperatura corporal antes da massagem."
+        },
+        {
+          "question": "A Kapunka oferece materiais em white label ou co-branded?",
+          "answer": "Oferecemos cartões pós-tratamento personalizáveis e sleeves co-branded após o terceiro pedido. A nossa equipa de design adapta os materiais à sua marca em até cinco dias úteis."
+        }
+      ]
+    },
+    "doctorsTitle": "Aprovado pelos melhores profissionais",
+    "ctaTitle": "Torne-se um parceiro",
+    "ctaSubtitle": "Agende uma chamada para conhecer preços de atacado, amostras e suporte de lançamento na clínica.",
+    "ctaButton": "Fale conosco",
+    "partnersTitle": "Como visto em"
+  },
+  "es": {
+    "title": "Alianzas Profesionales para Clínicas",
+    "metaDescription": "Suministro B2B de cuidado de la piel para el post-tratamiento. Accede a aceite de argán aprobado por dermatólogos, protocolos clínicos y capacitación para tu clínica.",
+    "headerTitle": "Programa Profesional Kapunka",
+    "headerSubtitle": "Ofrece un post-treatment skin care coherente con aceite de argán aprobado por dermatólogos y fórmulas minimalistas, probadas en clínica para la recuperación y la hidratación hormonal.",
+    "section1Title": "Soporte basado en evidencia para cada sala de tratamiento",
+    "section1Text1": "Nuestro suministro B2B de skincare combina aceite de argán ECOCERT, agua de rosas de Damasco y lípidos que refuerzan la barrera con materiales educativos personalizables. Los protocolos son revisados por dermatólogos certificados para que tu equipo brinde indicaciones seguras tras microneedling, peelings químicos, láser o sequedad ligada a la menopausia.",
+    "section1Text2": "Los socios reciben precios mayoristas, módulos de onboarding y fichas de cuidados post-tratamiento listas para imprimir en inglés, portugués y español. Kapunka simplifica el traspaso del procedimiento al cuidado en casa, ayudando a fidelizar pacientes y aumentar el ticket minorista.",
+    "protocolSection": {
+      "title": "Planos de protocolo para personalizar",
+      "subtitle": "Rutinas revisadas por dermatólogos y descargables para guiar a los pacientes en los tratamientos más solicitados.",
+      "cards": [
+        {
+          "title": "Cuidados tras microneedling (0–72 horas)",
+          "focus": "Estabiliza la barrera, reduce la TEWL y evita la contaminación microbiana.",
+          "steps": [
+            "Inmediatamente después del tratamiento: pulveriza Agua de Rosas de Damasco Kapunka o suero fisiológico estéril y presiona tres gotas de nuestro aceite de argán aprobado por dermatólogos sobre las zonas tratadas para sellar los microcanales.",
+            "Primera noche: indica a los pacientes que eviten maquillaje y retinoides; reaplica el aceite de argán sobre la piel húmeda cada 6–8 horas para mantener saturada la matriz lipídica.",
+            "Días 2–3: coloca un sérum de ácido hialurónico bajo el aceite de argán; retoma el protector solar mineral cuando el eritema disminuya."
+          ],
+          "evidence": "Basado en Fabbrocini et al., Journal of Clinical and Aesthetic Dermatology (2014), que documenta la alteración de la barrera hasta 48 horas después del microneedling y los beneficios de los emolientes ricos en lípidos."
+        },
+        {
+          "title": "Recuperación de peeling químico medio (Día 0–7)",
+          "focus": "Modera la inflamación, favorece la descamación y reconstruye el estrato córneo.",
+          "steps": [
+            "Día 0: neutraliza el peeling según las instrucciones del fabricante; cuando la piel recupere su temperatura, pulveriza Agua de Rosas de Damasco y aplica un velo fino de aceite de argán para aliviar la tirantez.",
+            "Días 1–3: limpia con leches de pH equilibrado; alterna compresas de agua de rosas con oclusión de aceite de argán para minimizar las costras.",
+            "Días 4–7: incorpora una crema con ceramidas sobre el aceite de argán; refuerza el fotoprotector FPS 50 de amplio espectro y evita exfoliantes hasta finalizar la descamación."
+          ],
+          "evidence": "Respaldado por Soleymani et al., Journal of Clinical and Aesthetic Dermatology (2018), que destaca la reposición lipídica como clave para una reepitelización controlada."
+        },
+        {
+          "title": "Soporte de hidratación durante la menopausia",
+          "focus": "Restituye lípidos, mejora la elasticidad y calma la sequedad neurogénica asociada al descenso de estrógenos.",
+          "steps": [
+            "Mañana: pulveriza Agua de Rosas de Damasco, mezcla dos gotas de aceite de argán con la crema de ceramidas y finaliza con protector solar para abordar la fotosensibilidad aumentada.",
+            "Noche: aplica aceite de argán en rostro, cuello y escote con la piel húmeda; realiza un masaje ligero para estimular la microcirculación.",
+            "Semanalmente: sugiere masajes capilares con aceite de argán para compensar los cambios en la densidad del cabello y ofrece tratamientos de manos y antebrazos durante las visitas a la clínica."
+          ],
+          "evidence": "En línea con Lephart, Biomedicine & Pharmacotherapy (2016) y Sator et al., Journal of the American Academy of Dermatology (2001), que informan mejoras de elasticidad e hidratación en la piel posmenopáusica tras lípidos tópicos."
+        }
+      ]
+    },
+    "referencesSection": {
+      "title": "Referencias clínicas y voces expertas",
+      "studiesTitle": "Destacados revisados por pares",
+      "studies": [
+        {
+          "title": "Fabbrocini A. et al. Microneedling in dermatology: A review.",
+          "details": "Journal of Clinical and Aesthetic Dermatology, 2014."
+        },
+        {
+          "title": "Soleymani T. et al. A practical approach to chemical peels.",
+          "details": "Journal of Clinical and Aesthetic Dermatology, 2018."
+        },
+        {
+          "title": "Lephart E.D. Skin aging and menopause: Implications for treatment.",
+          "details": "Biomedicine & Pharmacotherapy, 2016."
+        }
+      ],
+      "testimonialsTitle": "Testimonios de dermatólogos",
+      "testimonials": [
+        {
+          "quote": "\"El aceite de argán aprobado por dermatólogos de Kapunka aporta el perfil lipídico que necesito para el post-treatment skin care, y las pacientes valoran su origen sostenible.\"",
+          "name": "Dra. Sofia Mendes",
+          "credentials": "Dermatóloga certificada, Lisboa"
+        },
+        {
+          "quote": "\"El INCI minimalista mantiene cómodos a nuestros pacientes sensibilizados tras los peelings, y los módulos formativos de la marca acortan la capacitación del personal.\"",
+          "name": "Dra. Elena Ruiz",
+          "credentials": "Cirujana dermatológica, Madrid"
+        }
+      ]
+    },
+    "keywordSection": {
+      "title": "Suministro B2B de skincare optimizado",
+      "subtitle": "Incluye estos enfoques en tus listados y campañas para llegar a pacientes exigentes.",
+      "keywords": [
+        "post-treatment skin care protocols (protocolos de cuidado post-tratamiento)",
+        "dermatologist-approved argan oil retail sets (sets minoristas de aceite de argán aprobado por dermatólogos)",
+        "B2B skincare supply for medical spas (suministro B2B de skincare para clínicas y spas médicos)",
+        "hormonal hydration support kits (kits de soporte de hidratación hormonal)",
+        "sustainable Moroccan argan oil wholesale (aceite de argán marroquí sostenible al por mayor)"
+      ]
+    },
+    "faqSection": {
+      "title": "Preguntas frecuentes para clínicas",
+      "subtitle": "Logística, formación y métodos de aplicación adaptados a tu equipo.",
+      "items": [
+        {
+          "question": "¿Cuál es la cantidad mínima de pedido (MOQ)?",
+          "answer": "Los pedidos iniciales comienzan con 24 unidades minoristas o 6 unidades profesionales de back bar. Los estuches mixtos califican para el mismo precio mayorista para que las clínicas más pequeñas puedan curar su surtido."
+        },
+        {
+          "question": "¿Ofrecen capacitación en protocolos?",
+          "answer": "Sí. Los socios acceden a un portal e-learning bilingüe con módulos de microneedling, peeling químico e hidratación en la menopausia. Webinars trimestrales en vivo repasan novedades y permiten preguntas a nuestro comité médico."
+        },
+        {
+          "question": "¿Cómo deben aplicar los clínicos el aceite de argán en cabina?",
+          "answer": "Transfiérelo a cuentagotas estériles. Tras finalizar el tratamiento, pulveriza agua de rosas sobre la piel y presiona el aceite con manos enguantadas para evitar fricción. En servicios capilares o corporales, templa el aceite a temperatura corporal antes del masaje."
+        },
+        {
+          "question": "¿Kapunka puede proporcionar materiales white label o co-brandeados?",
+          "answer": "Ofrecemos tarjetas post-tratamiento personalizables y fundas co-brandeadas después de tu tercer pedido. Nuestro equipo de diseño adapta los materiales a tu marca en un máximo de cinco días hábiles."
+        }
+      ]
+    },
+    "doctorsTitle": "Con la confianza de los mejores profesionales",
+    "ctaTitle": "Conviértete en socio",
+    "ctaSubtitle": "Agenda una llamada para revisar precios mayoristas, sampling y soporte de lanzamiento en clínica.",
+    "ctaButton": "Contáctanos",
+    "partnersTitle": "Como visto en"
+  }
+}

--- a/site/content/translations/common.json
+++ b/site/content/translations/common.json
@@ -1,0 +1,39 @@
+{
+  "type": "translations_common",
+  "en": {
+    "loading": "Loading...",
+    "loadingProducts": "Loading products...",
+    "loadingBestsellers": "Loading bestsellers...",
+    "loadingReviews": "Loading reviews...",
+    "loadingCourses": "Loading courses...",
+    "loadingProfessionals": "Loading professionals...",
+    "loadingArticle": "Loading article...",
+    "loadingPolicies": "Loading policy...",
+    "loadingCart": "Loading cart...",
+    "loadingProduct": "Loading product..."
+  },
+  "pt": {
+    "loading": "Carregando...",
+    "loadingProducts": "Carregando produtos...",
+    "loadingBestsellers": "Carregando mais vendidos...",
+    "loadingReviews": "Carregando avaliações...",
+    "loadingCourses": "Carregando cursos...",
+    "loadingProfessionals": "Carregando profissionais...",
+    "loadingArticle": "Carregando artigo...",
+    "loadingPolicies": "Carregando política...",
+    "loadingCart": "Carregando carrinho...",
+    "loadingProduct": "Carregando produto..."
+  },
+  "es": {
+    "loading": "Cargando...",
+    "loadingProducts": "Cargando productos...",
+    "loadingBestsellers": "Cargando más vendidos...",
+    "loadingReviews": "Cargando reseñas...",
+    "loadingCourses": "Cargando cursos...",
+    "loadingProfessionals": "Cargando profesionales...",
+    "loadingArticle": "Cargando artículo...",
+    "loadingPolicies": "Cargando política...",
+    "loadingCart": "Cargando carrito...",
+    "loadingProduct": "Cargando producto..."
+  }
+}

--- a/site/content/translations/contact.json
+++ b/site/content/translations/contact.json
@@ -1,0 +1,66 @@
+{
+  "type": "translations_contact",
+  "en": {
+    "title": "Contact Us",
+    "metaDescription": "Get in touch with the Kapunka Skincare team for questions, partnership inquiries, or customer support.",
+    "headerTitle": "Get in Touch",
+    "headerSubtitle": "We're here to help. Whether you have a question about our products or want to share your skin journey, we'd love to hear from you.",
+    "formTitle": "Send us a message",
+    "form": {
+      "name": "Full Name",
+      "email": "Email Address",
+      "message": "Your Message",
+      "sending": "Sending...",
+      "submit": "Send Message",
+      "success": "Thank you! Your message has been sent.",
+      "error": "Sorry, something went wrong. Please try again."
+    },
+    "infoTitle": "Other ways to connect",
+    "emailTitle": "Email",
+    "phoneTitle": "Phone",
+    "whatsappTitle": "WhatsApp",
+    "whatsappAction": "Chat with us"
+  },
+  "pt": {
+    "title": "Fale Conosco",
+    "metaDescription": "Entre em contato com a equipe da Kapunka Skincare para perguntas, parcerias ou suporte ao cliente.",
+    "headerTitle": "Entre em Contato",
+    "headerSubtitle": "Estamos aqui para ajudar. Se você tem uma pergunta sobre nossos produtos ou quer compartilhar sua jornada com a pele, adoraríamos ouvir de você.",
+    "formTitle": "Envie-nos uma mensagem",
+    "form": {
+      "name": "Nome Completo",
+      "email": "Endereço de E-mail",
+      "message": "Sua Mensagem",
+      "sending": "Enviando...",
+      "submit": "Enviar Mensagem",
+      "success": "Obrigado! Sua mensagem foi enviada.",
+      "error": "Desculpe, algo deu errado. Por favor, tente novamente."
+    },
+    "infoTitle": "Outras formas de conectar",
+    "emailTitle": "E-mail",
+    "phoneTitle": "Telefone",
+    "whatsappTitle": "WhatsApp",
+    "whatsappAction": "Converse conosco"
+  },
+  "es": {
+    "title": "Contáctanos",
+    "metaDescription": "Ponte en contacto con el equipo de Kapunka Skincare para preguntas, consultas sobre asociaciones o soporte al cliente.",
+    "headerTitle": "Ponte en Contacto",
+    "headerSubtitle": "Estamos aquí para ayudar. Ya sea que tengas una pregunta sobre nuestros productos o quieras compartir tu viaje con la piel, nos encantaría saber de ti.",
+    "formTitle": "Envíanos un mensaje",
+    "form": {
+      "name": "Nombre Completo",
+      "email": "Correo Electrónico",
+      "message": "Tu Mensaje",
+      "sending": "Enviando...",
+      "submit": "Enviar Mensaje",
+      "success": "¡Gracias! Tu mensaje ha sido enviado.",
+      "error": "Lo sentimos, algo salió mal. Por favor, inténtalo de nuevo."
+    },
+    "infoTitle": "Otras formas de conectar",
+    "emailTitle": "Correo electrónico",
+    "phoneTitle": "Teléfono",
+    "whatsappTitle": "WhatsApp",
+    "whatsappAction": "Chatea con nosotros"
+  }
+}

--- a/site/content/translations/cookies.json
+++ b/site/content/translations/cookies.json
@@ -1,0 +1,21 @@
+{
+  "type": "translations_cookies",
+  "en": {
+    "message": "We use cookies to enhance your experience.",
+    "learnMore": "Learn more",
+    "decline": "Decline",
+    "accept": "Accept"
+  },
+  "pt": {
+    "message": "Usamos cookies para melhorar sua experiência.",
+    "learnMore": "Saiba mais",
+    "decline": "Recusar",
+    "accept": "Aceitar"
+  },
+  "es": {
+    "message": "Usamos cookies para mejorar tu experiencia.",
+    "learnMore": "Saber más",
+    "decline": "Rechazar",
+    "accept": "Aceptar"
+  }
+}

--- a/site/content/translations/footer.json
+++ b/site/content/translations/footer.json
@@ -1,0 +1,48 @@
+{
+  "type": "translations_footer",
+  "en": {
+    "tagline": "Science-backed skincare for a healthy barrier.",
+    "followUs": "Follow Us",
+    "shop": "Shop",
+    "allProducts": "All Products",
+    "guides": "Skincare Guides",
+    "about": "About Kapunka",
+    "ourStory": "Our Story",
+    "contact": "Contact Us",
+    "policies": "Policies",
+    "shipping": "Shipping Policy",
+    "returns": "Return Policy",
+    "privacy": "Privacy Policy",
+    "terms": "Terms of Service"
+  },
+  "pt": {
+    "tagline": "Cuidados com a pele baseados na ciência para uma barreira saudável.",
+    "followUs": "Siga-nos",
+    "shop": "Loja",
+    "allProducts": "Todos os Produtos",
+    "guides": "Guias de Skincare",
+    "about": "Sobre a Kapunka",
+    "ourStory": "Nossa História",
+    "contact": "Contate-nos",
+    "policies": "Políticas",
+    "shipping": "Política de Envio",
+    "returns": "Política de Devolução",
+    "privacy": "Política de Privacidade",
+    "terms": "Termos de Serviço"
+  },
+  "es": {
+    "tagline": "Cuidado de la piel respaldado por la ciencia para una barrera saludable.",
+    "followUs": "Síguenos",
+    "shop": "Tienda",
+    "allProducts": "Todos los Productos",
+    "guides": "Guías de Skincare",
+    "about": "Sobre Kapunka",
+    "ourStory": "Nuestra Historia",
+    "contact": "Contáctanos",
+    "policies": "Políticas",
+    "shipping": "Política de Envío",
+    "returns": "Política de Devolución",
+    "privacy": "Política de Privacidad",
+    "terms": "Términos de Servicio"
+  }
+}

--- a/site/content/translations/home.json
+++ b/site/content/translations/home.json
@@ -1,0 +1,246 @@
+{
+  "type": "translations_home",
+  "en": {
+    "metaTitle": "Kapunka Skincare | Moroccan Argan Rituals for Clinics & Sensitive Skin",
+    "metaDescription": "Kapunka formulates Moroccan argan oils, mists, and hammam treatments trusted by aesthetic clinics for post-procedure recovery, barrier repair, and daily rituals.",
+    "meta": {
+      "title": "Kapunka Skincare | Moroccan Argan Rituals for Clinics & Sensitive Skin",
+      "description": "Kapunka formulates Moroccan argan oils, mists, and hammam treatments trusted by aesthetic clinics for post-procedure recovery, barrier repair, and daily rituals."
+    },
+    "heroTitle": "Clinical-grade Moroccan argan rituals for sensitive, recovering skin",
+    "heroSubtitle": "From single-origin argan oil to dermal mists and hammam staples, Kapunka pairs Moroccan heritage with aesthetic expertise so post-procedure and delicate skin stays calm, nourished, and resilient.",
+    "hero": {
+      "title": "Clinical-grade Moroccan argan rituals for sensitive, recovering skin",
+      "subtitle": "From single-origin argan oil to dermal mists and hammam staples, Kapunka pairs Moroccan heritage with aesthetic expertise so post-procedure and delicate skin stays calm, nourished, and resilient.",
+      "ctaPrimary": "Shop argan rituals",
+      "ctaSecondary": "Clinics partnership"
+    },
+    "ctaShop": "Shop argan rituals",
+    "ctaClinics": "Clinics partnership",
+    "bestsellersTitle": "Our Bestsellers",
+    "bestsellers": {
+      "intro": "Meet the three-step ritual clinics rely on most—cleanse, replenish, and seal with nutrient-dense argan care.",
+      "cards": [
+        {
+          "slug": "pure-argan-oil",
+          "blurb": "Lightweight moisture; face, body, hair."
+        },
+        {
+          "slug": "kapunka-cicatrices",
+          "blurb": "Targeted argan care for scars and marks."
+        },
+        {
+          "slug": "pack-kapunka",
+          "blurb": "Travel-ready hammam pack with Kessa mitt."
+        }
+      ]
+    },
+    "value1": "Traceable Moroccan sourcing",
+    "value2": "Post-treatment safe",
+    "value3": "Multifunction rituals",
+    "value4": "Sustainable impact",
+    "valueProps": [
+      {
+        "title": "Traceable Moroccan sourcing",
+        "subtitle": "Hand-harvested kernels pressed within 24 hours to preserve omega density."
+      },
+      {
+        "title": "Post-treatment safe",
+        "subtitle": "Dermatology reviewed formulas bottled in GMP facilities for maximum purity."
+      },
+      {
+        "title": "Multifunction rituals",
+        "subtitle": "One oil to repair the barrier, soothe scalp flare-ups, and gloss the body without residue."
+      },
+      {
+        "title": "Sustainable impact",
+        "subtitle": "Partnership with Essaouira cooperatives reinvesting in women-led agriculture."
+      }
+    ],
+    "reviewsTitle": "What Professionals Say",
+    "clinics": {
+      "title": "Trusted by dermatologists and aesthetic clinics",
+      "copy": "Clinics select Kapunka for its purity and performance in post-laser and sensitive-skin care. Our minimalist routines support faster recovery, barrier integrity, and lasting comfort.",
+      "cta": "Become a Partner"
+    },
+    "socialProof": {
+      "line": "Seen in skin clinics and care practices across Europe."
+    },
+    "learn": {
+      "teaser": "Clear answers to real routines—post-procedure, scalp care, baby skin, and barrier support."
+    },
+    "newsletterTitle": "Join The List",
+    "newsletterSubtitle": "Tips for sensitive-skin routines, once or twice a month. No spam. Unsubscribe anytime.",
+    "newsletter": {
+      "pitch": "Join our community for monthly guidance on barrier health, post-treatment recovery, and skincare rooted in science. No spam, just insight."
+    },
+    "newsletterThanks": "Thank you for subscribing!",
+    "newsletterPlaceholder": "Enter your email address",
+    "newsletterSubmit": "Subscribe",
+    "footer": {
+      "complianceNote": "Cosmetic use only. Not intended to diagnose, treat, cure, or prevent disease."
+    }
+  },
+  "pt": {
+    "metaTitle": "Kapunka Skincare | Rituais de argan marroquino para clínicas e pele sensível",
+    "metaDescription": "A Kapunka formula óleos de argan, névoas e tratamentos de hammam marroquinos confiados por clínicas estéticas para recuperação pós-procedimento, reparo da barreira e rituais diários.",
+    "meta": {
+      "title": "Kapunka Skincare | Rituais de argan marroquino para clínicas e pele sensível",
+      "description": "A Kapunka formula óleos de argan, névoas e tratamentos de hammam marroquinos confiados por clínicas estéticas para recuperação pós-procedimento, reparo da barreira e rituais diários."
+    },
+    "heroTitle": "Rituais de argan marroquino de padrão clínico para pele sensível e em recuperação",
+    "heroSubtitle": "Dos óleos de argan de origem única às névoas dérmicas e clássicos do hammam, a Kapunka une herança marroquina e expertise estética para manter a pele pós-procedimento calma, nutrida e resiliente.",
+    "hero": {
+      "title": "Rituais de argan marroquino de padrão clínico para pele sensível e em recuperação",
+      "subtitle": "Dos óleos de argan de origem única às névoas dérmicas e clássicos do hammam, a Kapunka une herança marroquina e expertise estética para manter a pele pós-procedimento calma, nutrida e resiliente.",
+      "ctaPrimary": "Comprar rituais de argan",
+      "ctaSecondary": "Parceria para clínicas"
+    },
+    "ctaShop": "Comprar rituais de argan",
+    "ctaClinics": "Parceria para clínicas",
+    "bestsellersTitle": "Nossos Mais Vendidos",
+    "bestsellers": {
+      "intro": "Conheça o ritual em três etapas preferido nas clínicas—limpar, repor e selar com o cuidado nutritivo do argan.",
+      "cards": [
+        {
+          "slug": "pure-argan-oil",
+          "blurb": "Hidratação leve; rosto, corpo, cabelo."
+        },
+        {
+          "slug": "kapunka-cicatrices",
+          "blurb": "Cuidado de argan direcionado para cicatrizes e marcas."
+        },
+        {
+          "slug": "pack-kapunka",
+          "blurb": "Pack hammam pronto para viajar com luva Kessa."
+        }
+      ]
+    },
+    "value1": "Origem marroquina rastreável",
+    "value2": "Seguro pós-tratamento",
+    "value3": "Rituais multifuncionais",
+    "value4": "Impacto sustentável",
+    "valueProps": [
+      {
+        "title": "Origem marroquina rastreável",
+        "subtitle": "Sementes colhidas à mão e prensadas em até 24 horas para preservar os ômegas."
+      },
+      {
+        "title": "Seguro pós-tratamento",
+        "subtitle": "Fórmulas avaliadas por dermatologistas e envasadas em instalações GMP para pureza máxima."
+      },
+      {
+        "title": "Rituais multifuncionais",
+        "subtitle": "Um único óleo para reparar a barreira, acalmar o couro cabeludo e iluminar o corpo sem resíduos."
+      },
+      {
+        "title": "Impacto sustentável",
+        "subtitle": "Parcerias com cooperativas de Essaouira lideradas por mulheres que fortalecem a agricultura local."
+      }
+    ],
+    "reviewsTitle": "O Que Dizem os Profissionais",
+    "clinics": {
+      "title": "Confiado por dermatologistas e clínicas estéticas",
+      "copy": "As clínicas escolhem a Kapunka pela pureza e performance no cuidado pós-laser e pele sensível. Nossas rotinas minimalistas favorecem recuperação mais rápida, integridade da barreira e conforto duradouro.",
+      "cta": "Seja parceiro"
+    },
+    "socialProof": {
+      "line": "Presente em clínicas e consultórios de cuidados da pele na Europa."
+    },
+    "learn": {
+      "teaser": "Respostas claras para rotinas reais—pós-procedimento, couro cabeludo, pele do bebé e apoio da barreira."
+    },
+    "newsletterTitle": "Junte-se à Lista",
+    "newsletterSubtitle": "Dicas para rotinas de pele sensível, uma ou duas vezes por mês. Sem spam. Cancele quando quiser.",
+    "newsletter": {
+      "pitch": "Junte-se à nossa comunidade para orientações mensais sobre saúde da barreira, recuperação pós-tratamento e cuidados com a pele baseados em ciência. Sem spam, apenas insights."
+    },
+    "newsletterThanks": "Obrigado por se inscrever!",
+    "newsletterPlaceholder": "Digite seu e-mail",
+    "newsletterSubmit": "Inscrever-se",
+    "footer": {
+      "complianceNote": "Uso cosmético. Não destinado a diagnosticar, tratar, curar ou prevenir doenças."
+    }
+  },
+  "es": {
+    "metaTitle": "Kapunka Skincare | Rituales de argán marroquí para clínicas y piel sensible",
+    "metaDescription": "Kapunka formula aceites de argán, brumas y tratamientos de hammam marroquíes en los que confían las clínicas estéticas para la recuperación post-procedimiento, la reparación de la barrera y los rituales diarios.",
+    "meta": {
+      "title": "Kapunka Skincare | Rituales de argán marroquí para clínicas y piel sensible",
+      "description": "Kapunka formula aceites de argán, brumas y tratamientos de hammam marroquíes en los que confían las clínicas estéticas para la recuperación post-procedimiento, la reparación de la barrera y los rituales diarios."
+    },
+    "heroTitle": "Rituales de argán marroquí de nivel clínico para piel sensible y en recuperación",
+    "heroSubtitle": "Desde el argán de origen único hasta las brumas dérmicas y los clásicos del hammam, Kapunka une la herencia marroquí con la experiencia estética para que la piel post-procedimiento se mantenga calmada, nutrida y resiliente.",
+    "hero": {
+      "title": "Rituales de argán marroquí de nivel clínico para piel sensible y en recuperación",
+      "subtitle": "Desde el argán de origen único hasta las brumas dérmicas y los clásicos del hammam, Kapunka une la herencia marroquí con la experiencia estética para que la piel post-procedimiento se mantenga calmada, nutrida y resiliente.",
+      "ctaPrimary": "Comprar rituales de argán",
+      "ctaSecondary": "Alianza para clínicas"
+    },
+    "ctaShop": "Comprar rituales de argán",
+    "ctaClinics": "Alianza para clínicas",
+    "bestsellersTitle": "Nuestros Más Vendidos",
+    "bestsellers": {
+      "intro": "Conoce el ritual de tres pasos más querido por las clínicas: limpiar, reponer y sellar con el cuidado nutritivo del argán.",
+      "cards": [
+        {
+          "slug": "pure-argan-oil",
+          "blurb": "Hidratación ligera; rostro, cuerpo, cabello."
+        },
+        {
+          "slug": "kapunka-cicatrices",
+          "blurb": "Cuidado de argán focalizado para cicatrices y marcas."
+        },
+        {
+          "slug": "pack-kapunka",
+          "blurb": "Pack hammam listo para viajar con manopla Kessa."
+        }
+      ]
+    },
+    "value1": "Origen marroquí trazable",
+    "value2": "Seguro post-tratamiento",
+    "value3": "Rituales multifunción",
+    "value4": "Impacto sostenible",
+    "valueProps": [
+      {
+        "title": "Origen marroquí trazable",
+        "subtitle": "Semillas recolectadas a mano y prensadas en 24 horas para preservar los omegas."
+      },
+      {
+        "title": "Seguro post-tratamiento",
+        "subtitle": "Fórmulas revisadas por dermatología y envasadas en instalaciones GMP para pureza máxima."
+      },
+      {
+        "title": "Rituales multifunción",
+        "subtitle": "Un solo aceite para reparar la barrera, calmar el cuero cabelludo y dar brillo al cuerpo sin residuos."
+      },
+      {
+        "title": "Impacto sostenible",
+        "subtitle": "Alianza con cooperativas de Essaouira lideradas por mujeres que sostienen la agricultura local."
+      }
+    ],
+    "reviewsTitle": "Lo que Dicen los Profesionales",
+    "clinics": {
+      "title": "Confiado por dermatólogos y clínicas estéticas",
+      "copy": "Las clínicas eligen Kapunka por su pureza y desempeño en el cuidado post-láser y de piel sensible. Nuestras rutinas minimalistas favorecen una recuperación más rápida, la integridad de la barrera y un confort duradero.",
+      "cta": "Hazte partner"
+    },
+    "socialProof": {
+      "line": "Presente en clínicas y consultas de cuidado de la piel en Europa."
+    },
+    "learn": {
+      "teaser": "Respuestas claras para rutinas reales—post-procedimiento, cuero cabelludo, piel de bebé y apoyo de la barrera."
+    },
+    "newsletterTitle": "Únete a la Lista",
+    "newsletterSubtitle": "Consejos para rutinas de piel sensible, una o dos veces al mes. Sin spam. Baja cuando quieras.",
+    "newsletter": {
+      "pitch": "Únete a nuestra comunidad para recibir orientación mensual sobre salud de la barrera, recuperación post-tratamiento y cuidado de la piel basado en ciencia. Sin spam, solo ideas."
+    },
+    "newsletterThanks": "¡Gracias por suscribirte!",
+    "newsletterPlaceholder": "Introduce tu correo electrónico",
+    "newsletterSubmit": "Suscribirse",
+    "footer": {
+      "complianceNote": "Uso cosmético. No destinado a diagnosticar, tratar, curar ni prevenir enfermedades."
+    }
+  }
+}

--- a/site/content/translations/learn.json
+++ b/site/content/translations/learn.json
@@ -1,0 +1,48 @@
+{
+  "type": "translations_learn",
+  "en": {
+    "metaTitle": "Skincare Library",
+    "metaDescription": "Explore articles and guides on skincare, ingredients, and maintaining a healthy skin barrier.",
+    "title": "Skincare Library",
+    "subtitle": "Guides and insights to help you understand your skin better.",
+    "categories": {
+      "all": "All topics",
+      "argan-oil": "Argan Oil",
+      "uses-applications": "Uses & Applications",
+      "post-procedure": "Post-Procedure",
+      "skin-barrier": "Skin Barrier",
+      "baby": "Baby Care",
+      "scars": "Scars & Recovery"
+    }
+  },
+  "pt": {
+    "metaTitle": "Biblioteca de Skincare",
+    "metaDescription": "Explore artigos e guias sobre skincare, ingredientes e como manter uma barreira cutânea saudável.",
+    "title": "Biblioteca de Skincare",
+    "subtitle": "Guias e insights para ajudar você a entender melhor a sua pele.",
+    "categories": {
+      "all": "Todos os temas",
+      "argan-oil": "Óleo de Argan",
+      "uses-applications": "Usos e Aplicações",
+      "post-procedure": "Pós-Procedimento",
+      "skin-barrier": "Barreira Cutânea",
+      "baby": "Cuidados com Bebês",
+      "scars": "Cicatrizes e Recuperação"
+    }
+  },
+  "es": {
+    "metaTitle": "Biblioteca de Skincare",
+    "metaDescription": "Explora artículos y guías sobre skincare, ingredientes y cómo mantener una barrera cutánea saludable.",
+    "title": "Biblioteca de Skincare",
+    "subtitle": "Guías e ideas para ayudarte a entender mejor tu piel.",
+    "categories": {
+      "all": "Todos los temas",
+      "argan-oil": "Aceite de Argán",
+      "uses-applications": "Usos y Aplicaciones",
+      "post-procedure": "Post-Procedimiento",
+      "skin-barrier": "Barrera Cutánea",
+      "baby": "Cuidado del Bebé",
+      "scars": "Cicatrices y Recuperación"
+    }
+  }
+}

--- a/site/content/translations/nav.json
+++ b/site/content/translations/nav.json
@@ -1,0 +1,33 @@
+{
+  "type": "translations_nav",
+  "en": {
+    "shop": "Shop",
+    "learn": "Learn",
+    "videos": "Videos",
+    "training": "Training",
+    "method": "Method",
+    "forClinics": "For Clinics",
+    "about": "About",
+    "contact": "Contact"
+  },
+  "pt": {
+    "shop": "Loja",
+    "learn": "Aprender",
+    "videos": "Vídeos",
+    "training": "Treinamento",
+    "method": "Método",
+    "forClinics": "Para Clínicas",
+    "about": "Sobre",
+    "contact": "Contato"
+  },
+  "es": {
+    "shop": "Tienda",
+    "learn": "Aprender",
+    "videos": "Videos",
+    "training": "Formación",
+    "method": "Método",
+    "forClinics": "Para Clínicas",
+    "about": "Nosotros",
+    "contact": "Contacto"
+  }
+}

--- a/site/content/translations/pdp.json
+++ b/site/content/translations/pdp.json
@@ -1,0 +1,99 @@
+{
+  "type": "translations_pdp",
+  "en": {
+    "notFound": "Product not found.",
+    "size": "Size",
+    "addToCart": "Add to Cart",
+    "tabs": {
+      "benefits": "Benefits",
+      "howToUse": "How to Use",
+      "ingredients": "Ingredients",
+      "labTested": "Origin & Purity",
+      "originStory": "Origin story",
+      "scientificEvidence": "Research & clinical notes",
+      "multiUseTips": "Multi-use tips",
+      "faqs": "FAQs"
+    },
+    "bundleIncludes": "Bundle includes",
+    "relatedProducts": "You Might Also Like",
+    "knowledge": {
+      "title": "Deep dive into the formula",
+      "subtitle": "Explore how this product fits into modern dermal science and time-honored rituals.",
+      "sections": {
+        "whatItIs": "What it is",
+        "howItWorks": "How it works on skin & scalp",
+        "whoItsFor": "Who it's for",
+        "scientificBacking": "Scientific backing",
+        "culturalContext": "Cultural & traditional context"
+      }
+    },
+    "faq": {
+      "title": "Product FAQs",
+      "subtitle": "Answers to the most searched questions about this treatment."
+    }
+  },
+  "pt": {
+    "notFound": "Produto não encontrado.",
+    "size": "Tamanho",
+    "addToCart": "Adicionar ao Carrinho",
+    "tabs": {
+      "benefits": "Benefícios",
+      "howToUse": "Como Usar",
+      "ingredients": "Ingredientes",
+      "labTested": "Origem e Pureza",
+      "originStory": "História da origem",
+      "scientificEvidence": "Pesquisa e notas clínicas",
+      "multiUseTips": "Dicas multiuso",
+      "faqs": "Perguntas frequentes"
+    },
+    "bundleIncludes": "O conjunto inclui",
+    "relatedProducts": "Você Também Pode Gostar",
+    "knowledge": {
+      "title": "Mergulho na fórmula",
+      "subtitle": "Descubra como este produto se encaixa na ciência dérmica moderna e nos rituais ancestrais.",
+      "sections": {
+        "whatItIs": "O que é",
+        "howItWorks": "Como atua na pele e no couro cabeludo",
+        "whoItsFor": "Para quem é indicado",
+        "scientificBacking": "Comprovação científica",
+        "culturalContext": "Contexto cultural e tradicional"
+      }
+    },
+    "faq": {
+      "title": "Perguntas frequentes",
+      "subtitle": "Respostas para as dúvidas mais buscadas sobre este tratamento."
+    }
+  },
+  "es": {
+    "notFound": "Producto no encontrado.",
+    "size": "Tamaño",
+    "addToCart": "Añadir al Carrito",
+    "tabs": {
+      "benefits": "Beneficios",
+      "howToUse": "Modo de Uso",
+      "ingredients": "Ingredientes",
+      "labTested": "Origen y Pureza",
+      "originStory": "Historia de origen",
+      "scientificEvidence": "Investigación y notas clínicas",
+      "multiUseTips": "Consejos multiuso",
+      "faqs": "Preguntas frecuentes"
+    },
+    "bundleIncludes": "El pack incluye",
+    "relatedProducts": "También te podría gustar",
+    "knowledge": {
+      "title": "Profundiza en la fórmula",
+      "subtitle": "Descubre cómo este producto se integra a la ciencia dérmica moderna y a los rituales ancestrales.",
+      "sections": {
+        "whatItIs": "Qué es",
+        "howItWorks": "Cómo actúa en piel y cuero cabelludo",
+        "whoItsFor": "Para quién es",
+        "scientificBacking": "Respaldo científico",
+        "culturalContext": "Contexto cultural y tradicional"
+      }
+    },
+    "faq": {
+      "title": "Preguntas frecuentes",
+      "subtitle": "Respuestas a las preguntas más buscadas sobre este tratamiento."
+    }
+  }
+}

--- a/site/content/translations/policy.json
+++ b/site/content/translations/policy.json
@@ -1,0 +1,18 @@
+{
+  "type": "translations_policy",
+  "en": {
+    "loading": "Loading policy...",
+    "notFound": "The requested policy page could not be found.",
+    "contactPrompt": "For more detailed information or specific questions, please contact us."
+  },
+  "pt": {
+    "loading": "Carregando política...",
+    "notFound": "A página de política solicitada não foi encontrada.",
+    "contactPrompt": "Para informações mais detalhadas ou dúvidas específicas, entre em contato conosco."
+  },
+  "es": {
+    "loading": "Cargando política...",
+    "notFound": "La página de política solicitada no se encontró.",
+    "contactPrompt": "Para obtener información más detallada o preguntas específicas, contáctanos."
+  }
+}

--- a/site/content/translations/shop.json
+++ b/site/content/translations/shop.json
@@ -1,0 +1,45 @@
+{
+  "type": "translations_shop",
+  "en": {
+    "title": "All Products",
+    "metaDescription": "Shop our complete collection of skincare products formulated to support a healthy skin barrier.",
+    "subtitle": "Gentle yet effective solutions for every skin type, focusing on barrier health and minimalist formulas.",
+    "sortFeatured": "Featured",
+    "sortPriceAsc": "Price: Low to High",
+    "sortPriceDesc": "Price: High to Low",
+    "sortNameAsc": "Alphabetically: A-Z",
+    "sortNameDesc": "Alphabetically: Z-A",
+    "sortLabel": "Sort products",
+    "categoryFilterLabel": "Browse by collection",
+    "relatedResources": "Related resources",
+    "noProducts": "No products found in this collection."
+  },
+  "pt": {
+    "title": "Todos os Produtos",
+    "metaDescription": "Compre nossa coleção completa de produtos de skincare formulados para apoiar uma barreira cutânea saudável.",
+    "subtitle": "Soluções suaves mas eficazes para todos os tipos de pele, focando na saúde da barreira e em fórmulas minimalistas.",
+    "sortFeatured": "Destaque",
+    "sortPriceAsc": "Preço: Menor para Maior",
+    "sortPriceDesc": "Preço: Maior para Menor",
+    "sortNameAsc": "Alfabeticamente: A-Z",
+    "sortNameDesc": "Alfabeticamente: Z-A",
+    "sortLabel": "Ordenar produtos",
+    "categoryFilterLabel": "Navegue por coleção",
+    "relatedResources": "Recursos relacionados",
+    "noProducts": "Nenhum produto encontrado nesta coleção."
+  },
+  "es": {
+    "title": "Todos los Productos",
+    "metaDescription": "Compra nuestra colección completa de productos para el cuidado de la piel formulados para apoyar una barrera cutánea saludable.",
+    "subtitle": "Soluciones suaves pero eficaces para cada tipo de piel, centradas en la salud de la barrera y fórmulas minimalistas.",
+    "sortFeatured": "Destacado",
+    "sortPriceAsc": "Precio: Menor a Mayor",
+    "sortPriceDesc": "Precio: Mayor a Menor",
+    "sortNameAsc": "Alfabéticamente: A-Z",
+    "sortNameDesc": "Alfabéticamente: Z-A",
+    "sortLabel": "Ordenar productos",
+    "categoryFilterLabel": "Explorar por colección",
+    "relatedResources": "Recursos relacionados",
+    "noProducts": "No se encontraron productos en esta colección."
+  }
+}

--- a/site/content/translations/training.json
+++ b/site/content/translations/training.json
@@ -1,0 +1,27 @@
+{
+  "type": "translations_training",
+  "en": {
+    "title": "Training Hub",
+    "subtitle": "Stay ahead with courses and professional content curated for practitioners and partners.",
+    "metaTitle": "Training Hub",
+    "metaDescription": "Browse Kapunka's training catalog featuring professional development, product education, and partner resources.",
+    "emptyState": "Training resources are coming soon.",
+    "learnMore": "Learn More"
+  },
+  "pt": {
+    "title": "Centro de Treinamento",
+    "subtitle": "Atualize-se com cursos e conteúdos profissionais selecionados para praticantes e parceiros.",
+    "metaTitle": "Centro de Treinamento",
+    "metaDescription": "Conheça o catálogo de treinamentos Kapunka com desenvolvimento profissional, educação sobre produtos e recursos para parceiros.",
+    "emptyState": "Os recursos de treinamento estarão disponíveis em breve.",
+    "learnMore": "Saiba mais"
+  },
+  "es": {
+    "title": "Centro de Formación",
+    "subtitle": "Mantente al día con cursos y contenidos profesionales creados para practicantes y socios.",
+    "metaTitle": "Centro de Formación",
+    "metaDescription": "Explora el catálogo de formación de Kapunka con desarrollo profesional, educación sobre productos y recursos para socios.",
+    "emptyState": "Los recursos de formación estarán disponibles pronto.",
+    "learnMore": "Más información"
+  }
+}

--- a/site/content/translations/videos.json
+++ b/site/content/translations/videos.json
@@ -1,0 +1,27 @@
+{
+  "type": "translations_videos",
+  "en": {
+    "title": "Video Library",
+    "subtitle": "Discover tutorials, rituals, and behind-the-scenes moments from the Kapunka world.",
+    "metaTitle": "Video Library",
+    "metaDescription": "Explore Kapunka's video tutorials, founder stories, and educational moments curated for our community.",
+    "emptyState": "Video programming is coming soon.",
+    "watchLabel": "Watch Video"
+  },
+  "pt": {
+    "title": "Videoteca",
+    "subtitle": "Descubra tutoriais, rituais e bastidores do universo Kapunka.",
+    "metaTitle": "Videoteca",
+    "metaDescription": "Explore tutoriais em vídeo, histórias da marca e conteúdos educativos Kapunka para a nossa comunidade.",
+    "emptyState": "Os vídeos estarão disponíveis em breve.",
+    "watchLabel": "Assistir ao vídeo"
+  },
+  "es": {
+    "title": "Videoteca",
+    "subtitle": "Descubre tutoriales, rituales y momentos detrás de escena del mundo Kapunka.",
+    "metaTitle": "Videoteca",
+    "metaDescription": "Explora los tutoriales en video, historias de la marca y contenidos educativos de Kapunka para nuestra comunidad.",
+    "emptyState": "El contenido en video estará disponible pronto.",
+    "watchLabel": "Ver video"
+  }
+}


### PR DESCRIPTION
## Summary
- mirror translation datasets into `site/content` so the Netlify Visual Editor can locate navigation and footer objects
- sync `site/content/site.json` with the canonical site settings to unblock image edits from the Visual Editor

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dd184b90d48320af7d653f3a235326