### PR TITLE
chore: add home page models to visual editor metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -130,6 +130,24 @@
       "filePath": "content/site.json"
     },
     {
+      "id": "home",
+      "label": "Home Page (English)",
+      "type": "single",
+      "filePath": "content/pages/en/home.json"
+    },
+    {
+      "id": "home_pt",
+      "label": "Home Page (Portuguese)",
+      "type": "single",
+      "filePath": "content/pages/pt/home.json"
+    },
+    {
+      "id": "home_es",
+      "label": "Home Page (Spanish)",
+      "type": "single",
+      "filePath": "content/pages/es/home.json"
+    },
+    {
       "id": "method",
       "label": "Method Page (English)",
       "type": "single",
@@ -474,6 +492,2082 @@
               "type": "boolean"
             }
           ]
+        }
+      ]
+    },
+    {
+      "name": "home",
+      "label": "Home Page (English)",
+      "type": "data",
+      "singleInstance": true,
+      "filePath": "content/pages/en/home.json",
+      "fields": [
+        {
+          "name": "type",
+          "label": "Type",
+          "type": "string"
+        },
+        {
+          "name": "metaTitle",
+          "label": "Meta Title",
+          "type": "string"
+        },
+        {
+          "name": "metaDescription",
+          "label": "Meta Description",
+          "type": "text"
+        },
+        {
+          "name": "meta",
+          "label": "Meta Overrides",
+          "type": "object",
+          "fields": [
+            {
+              "name": "metaTitle",
+              "label": "Meta Title",
+              "type": "string"
+            },
+            {
+              "name": "metaDescription",
+              "label": "Meta Description",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "name": "heroHeadline",
+          "label": "Hero Headline",
+          "type": "string"
+        },
+        {
+          "name": "heroSubheadline",
+          "label": "Hero Subheadline",
+          "type": "text"
+        },
+        {
+          "name": "heroCtas",
+          "label": "Hero CTAs",
+          "type": "object",
+          "fields": [
+            {
+              "name": "ctaPrimary",
+              "label": "Primary CTA",
+              "type": "object",
+              "fields": [
+                {
+                  "name": "label",
+                  "label": "Label",
+                  "type": "string"
+                },
+                {
+                  "name": "href",
+                  "label": "Link",
+                  "type": "string"
+                }
+              ]
+            },
+            {
+              "name": "ctaSecondary",
+              "label": "Secondary CTA",
+              "type": "object",
+              "fields": [
+                {
+                  "name": "label",
+                  "label": "Label",
+                  "type": "string"
+                },
+                {
+                  "name": "href",
+                  "label": "Link",
+                  "type": "string"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "heroAlignment",
+          "label": "Hero Alignment",
+          "type": "object",
+          "fields": [
+            {
+              "name": "heroAlignX",
+              "label": "Horizontal Alignment",
+              "type": "string"
+            },
+            {
+              "name": "heroAlignY",
+              "label": "Vertical Alignment",
+              "type": "string"
+            },
+            {
+              "name": "heroTextPosition",
+              "label": "Text Position",
+              "type": "string"
+            },
+            {
+              "name": "heroTextAnchor",
+              "label": "Text Anchor",
+              "type": "string"
+            },
+            {
+              "name": "heroOverlay",
+              "label": "Overlay",
+              "type": "string"
+            },
+            {
+              "name": "heroLayoutHint",
+              "label": "Layout Hint",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "heroImages",
+          "label": "Hero Images",
+          "type": "object",
+          "fields": [
+            {
+              "name": "heroImageLeft",
+              "label": "Left Image",
+              "type": "image"
+            },
+            {
+              "name": "heroImageRight",
+              "label": "Right Image",
+              "type": "image"
+            },
+            {
+              "name": "heroImageLeftRef",
+              "label": "Left Image Reference",
+              "type": "string"
+            },
+            {
+              "name": "heroImageRightRef",
+              "label": "Right Image Reference",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "heroPrimaryCta",
+          "label": "Hero Primary CTA (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "heroSecondaryCta",
+          "label": "Hero Secondary CTA (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "heroCtaPrimary",
+          "label": "Hero CTA Primary (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "heroCtaSecondary",
+          "label": "Hero CTA Secondary (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "ctaPrimary",
+          "label": "CTA Primary (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "ctaSecondary",
+          "label": "CTA Secondary (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "heroOverlay",
+          "label": "Hero Overlay",
+          "type": "string"
+        },
+        {
+          "name": "heroLayoutHint",
+          "label": "Hero Layout Hint",
+          "type": "string"
+        },
+        {
+          "name": "heroAlignX",
+          "label": "Hero Align X",
+          "type": "string"
+        },
+        {
+          "name": "heroAlignY",
+          "label": "Hero Align Y",
+          "type": "string"
+        },
+        {
+          "name": "heroTextPosition",
+          "label": "Hero Text Position",
+          "type": "string"
+        },
+        {
+          "name": "heroImageLeft",
+          "label": "Hero Image Left",
+          "type": "image"
+        },
+        {
+          "name": "heroImageRight",
+          "label": "Hero Image Right",
+          "type": "image"
+        },
+        {
+          "name": "heroImageLeftRef",
+          "label": "Hero Image Left Ref",
+          "type": "string"
+        },
+        {
+          "name": "heroImageRightRef",
+          "label": "Hero Image Right Ref",
+          "type": "string"
+        },
+        {
+          "name": "brandIntro",
+          "label": "Brand Intro",
+          "type": "object",
+          "fields": [
+            {
+              "name": "title",
+              "label": "Title",
+              "type": "string"
+            },
+            {
+              "name": "text",
+              "label": "Text",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "name": "clinicsBlock",
+          "label": "Clinics Block",
+          "type": "object",
+          "fields": [
+            {
+              "name": "clinicsTitle",
+              "label": "Title",
+              "type": "string"
+            },
+            {
+              "name": "clinicsBody",
+              "label": "Body",
+              "type": "text"
+            },
+            {
+              "name": "clinicsCtaLabel",
+              "label": "CTA Label",
+              "type": "string"
+            },
+            {
+              "name": "clinicsCtaHref",
+              "label": "CTA Href",
+              "type": "string"
+            },
+            {
+              "name": "clinicsImage",
+              "label": "Image",
+              "type": "image"
+            }
+          ]
+        },
+        {
+          "name": "galleryRows",
+          "label": "Gallery Rows",
+          "type": "list",
+          "items": {
+            "type": "object",
+            "fields": [
+              {
+                "name": "layout",
+                "label": "Layout",
+                "type": "string"
+              },
+              {
+                "name": "items",
+                "label": "Items",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "image",
+                      "label": "Image",
+                      "type": "image"
+                    },
+                    {
+                      "name": "alt",
+                      "label": "Alt Text",
+                      "type": "string"
+                    },
+                    {
+                      "name": "caption",
+                      "label": "Caption",
+                      "type": "text"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "bestsellersIntro",
+          "label": "Bestsellers Intro",
+          "type": "text"
+        },
+        {
+          "name": "sections",
+          "label": "Sections",
+          "type": "list",
+          "items": {
+            "type": "object",
+            "fields": [
+              {
+                "name": "type",
+                "label": "Section Type",
+                "type": "string"
+              },
+              {
+                "name": "title",
+                "label": "Title",
+                "type": "string"
+              },
+              {
+                "name": "subtitle",
+                "label": "Subtitle",
+                "type": "string"
+              },
+              {
+                "name": "headline",
+                "label": "Headline",
+                "type": "string"
+              },
+              {
+                "name": "text",
+                "label": "Text",
+                "type": "text"
+              },
+              {
+                "name": "body",
+                "label": "Body",
+                "type": "text"
+              },
+              {
+                "name": "layout",
+                "label": "Layout",
+                "type": "string"
+              },
+              {
+                "name": "columns",
+                "label": "Columns",
+                "type": "number"
+              },
+              {
+                "name": "alignment",
+                "label": "Alignment",
+                "type": "string"
+              },
+              {
+                "name": "background",
+                "label": "Background",
+                "type": "string"
+              },
+              {
+                "name": "placeholder",
+                "label": "Placeholder",
+                "type": "string"
+              },
+              {
+                "name": "ctaLabel",
+                "label": "CTA Label",
+                "type": "string"
+              },
+              {
+                "name": "cta",
+                "label": "CTA Text",
+                "type": "string"
+              },
+              {
+                "name": "ctaHref",
+                "label": "CTA Href",
+                "type": "string"
+              },
+              {
+                "name": "ctaPrimary",
+                "label": "Primary CTA",
+                "type": "string"
+              },
+              {
+                "name": "ctaSecondary",
+                "label": "Secondary CTA",
+                "type": "string"
+              },
+              {
+                "name": "image",
+                "label": "Image",
+                "type": "image"
+              },
+              {
+                "name": "imageRef",
+                "label": "Image Reference",
+                "type": "string"
+              },
+              {
+                "name": "imageAlt",
+                "label": "Image Alt Text",
+                "type": "string"
+              },
+              {
+                "name": "url",
+                "label": "URL",
+                "type": "string"
+              },
+              {
+                "name": "items",
+                "label": "Items",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "label",
+                      "label": "Label",
+                      "type": "string"
+                    },
+                    {
+                      "name": "description",
+                      "label": "Description",
+                      "type": "text"
+                    },
+                    {
+                      "name": "icon",
+                      "label": "Icon",
+                      "type": "string"
+                    },
+                    {
+                      "name": "eyebrow",
+                      "label": "Eyebrow",
+                      "type": "string"
+                    },
+                    {
+                      "name": "title",
+                      "label": "Title",
+                      "type": "string"
+                    },
+                    {
+                      "name": "subtitle",
+                      "label": "Subtitle",
+                      "type": "string"
+                    },
+                    {
+                      "name": "body",
+                      "label": "Body",
+                      "type": "text"
+                    },
+                    {
+                      "name": "text",
+                      "label": "Text",
+                      "type": "text"
+                    },
+                    {
+                      "name": "image",
+                      "label": "Image",
+                      "type": "image"
+                    },
+                    {
+                      "name": "imageRef",
+                      "label": "Image Reference",
+                      "type": "string"
+                    },
+                    {
+                      "name": "imageAlt",
+                      "label": "Image Alt Text",
+                      "type": "string"
+                    },
+                    {
+                      "name": "ctaLabel",
+                      "label": "CTA Label",
+                      "type": "string"
+                    },
+                    {
+                      "name": "ctaHref",
+                      "label": "CTA Href",
+                      "type": "string"
+                    },
+                    {
+                      "name": "url",
+                      "label": "URL",
+                      "type": "string"
+                    },
+                    {
+                      "name": "q",
+                      "label": "Question",
+                      "type": "string"
+                    },
+                    {
+                      "name": "a",
+                      "label": "Answer",
+                      "type": "text"
+                    },
+                    {
+                      "name": "name",
+                      "label": "Name",
+                      "type": "string"
+                    },
+                    {
+                      "name": "role",
+                      "label": "Role",
+                      "type": "string"
+                    },
+                    {
+                      "name": "id",
+                      "label": "ID",
+                      "type": "string"
+                    },
+                    {
+                      "name": "placeholder",
+                      "label": "Placeholder",
+                      "type": "string"
+                    },
+                    {
+                      "name": "confirmation",
+                      "label": "Confirmation",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "products",
+                "label": "Products",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "id",
+                      "label": "Product ID",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "quotes",
+                "label": "Quotes",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "text",
+                      "label": "Quote",
+                      "type": "text"
+                    },
+                    {
+                      "name": "author",
+                      "label": "Author",
+                      "type": "string"
+                    },
+                    {
+                      "name": "role",
+                      "label": "Role",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "slides",
+                "label": "Slides",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "image",
+                      "label": "Image",
+                      "type": "image"
+                    },
+                    {
+                      "name": "imageRef",
+                      "label": "Image Reference",
+                      "type": "string"
+                    },
+                    {
+                      "name": "alt",
+                      "label": "Alt Text",
+                      "type": "string"
+                    },
+                    {
+                      "name": "quote",
+                      "label": "Quote",
+                      "type": "text"
+                    },
+                    {
+                      "name": "name",
+                      "label": "Name",
+                      "type": "string"
+                    },
+                    {
+                      "name": "role",
+                      "label": "Role",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "overlay",
+                "label": "Overlay",
+                "type": "object",
+                "fields": [
+                  {
+                    "name": "columnStart",
+                    "label": "Column Start",
+                    "type": "number"
+                  },
+                  {
+                    "name": "columnSpan",
+                    "label": "Column Span",
+                    "type": "number"
+                  },
+                  {
+                    "name": "rowStart",
+                    "label": "Row Start",
+                    "type": "number"
+                  },
+                  {
+                    "name": "rowSpan",
+                    "label": "Row Span",
+                    "type": "number"
+                  },
+                  {
+                    "name": "textAlign",
+                    "label": "Text Align",
+                    "type": "string"
+                  },
+                  {
+                    "name": "verticalAlign",
+                    "label": "Vertical Align",
+                    "type": "string"
+                  },
+                  {
+                    "name": "theme",
+                    "label": "Theme",
+                    "type": "string"
+                  },
+                  {
+                    "name": "background",
+                    "label": "Background",
+                    "type": "string"
+                  },
+                  {
+                    "name": "cardWidth",
+                    "label": "Card Width",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "name": "slideDuration",
+                "label": "Slide Duration",
+                "type": "number"
+              },
+              {
+                "name": "quoteDuration",
+                "label": "Quote Duration",
+                "type": "number"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "home_pt",
+      "label": "Home Page (Portuguese)",
+      "type": "data",
+      "singleInstance": true,
+      "filePath": "content/pages/pt/home.json",
+      "fields": [
+        {
+          "name": "type",
+          "label": "Type",
+          "type": "string"
+        },
+        {
+          "name": "metaTitle",
+          "label": "Meta Title",
+          "type": "string"
+        },
+        {
+          "name": "metaDescription",
+          "label": "Meta Description",
+          "type": "text"
+        },
+        {
+          "name": "meta",
+          "label": "Meta Overrides",
+          "type": "object",
+          "fields": [
+            {
+              "name": "metaTitle",
+              "label": "Meta Title",
+              "type": "string"
+            },
+            {
+              "name": "metaDescription",
+              "label": "Meta Description",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "name": "heroHeadline",
+          "label": "Hero Headline",
+          "type": "string"
+        },
+        {
+          "name": "heroSubheadline",
+          "label": "Hero Subheadline",
+          "type": "text"
+        },
+        {
+          "name": "heroCtas",
+          "label": "Hero CTAs",
+          "type": "object",
+          "fields": [
+            {
+              "name": "ctaPrimary",
+              "label": "Primary CTA",
+              "type": "object",
+              "fields": [
+                {
+                  "name": "label",
+                  "label": "Label",
+                  "type": "string"
+                },
+                {
+                  "name": "href",
+                  "label": "Link",
+                  "type": "string"
+                }
+              ]
+            },
+            {
+              "name": "ctaSecondary",
+              "label": "Secondary CTA",
+              "type": "object",
+              "fields": [
+                {
+                  "name": "label",
+                  "label": "Label",
+                  "type": "string"
+                },
+                {
+                  "name": "href",
+                  "label": "Link",
+                  "type": "string"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "heroAlignment",
+          "label": "Hero Alignment",
+          "type": "object",
+          "fields": [
+            {
+              "name": "heroAlignX",
+              "label": "Horizontal Alignment",
+              "type": "string"
+            },
+            {
+              "name": "heroAlignY",
+              "label": "Vertical Alignment",
+              "type": "string"
+            },
+            {
+              "name": "heroTextPosition",
+              "label": "Text Position",
+              "type": "string"
+            },
+            {
+              "name": "heroTextAnchor",
+              "label": "Text Anchor",
+              "type": "string"
+            },
+            {
+              "name": "heroOverlay",
+              "label": "Overlay",
+              "type": "string"
+            },
+            {
+              "name": "heroLayoutHint",
+              "label": "Layout Hint",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "heroImages",
+          "label": "Hero Images",
+          "type": "object",
+          "fields": [
+            {
+              "name": "heroImageLeft",
+              "label": "Left Image",
+              "type": "image"
+            },
+            {
+              "name": "heroImageRight",
+              "label": "Right Image",
+              "type": "image"
+            },
+            {
+              "name": "heroImageLeftRef",
+              "label": "Left Image Reference",
+              "type": "string"
+            },
+            {
+              "name": "heroImageRightRef",
+              "label": "Right Image Reference",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "heroPrimaryCta",
+          "label": "Hero Primary CTA (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "heroSecondaryCta",
+          "label": "Hero Secondary CTA (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "heroCtaPrimary",
+          "label": "Hero CTA Primary (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "heroCtaSecondary",
+          "label": "Hero CTA Secondary (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "ctaPrimary",
+          "label": "CTA Primary (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "ctaSecondary",
+          "label": "CTA Secondary (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "heroOverlay",
+          "label": "Hero Overlay",
+          "type": "string"
+        },
+        {
+          "name": "heroLayoutHint",
+          "label": "Hero Layout Hint",
+          "type": "string"
+        },
+        {
+          "name": "heroAlignX",
+          "label": "Hero Align X",
+          "type": "string"
+        },
+        {
+          "name": "heroAlignY",
+          "label": "Hero Align Y",
+          "type": "string"
+        },
+        {
+          "name": "heroTextPosition",
+          "label": "Hero Text Position",
+          "type": "string"
+        },
+        {
+          "name": "heroImageLeft",
+          "label": "Hero Image Left",
+          "type": "image"
+        },
+        {
+          "name": "heroImageRight",
+          "label": "Hero Image Right",
+          "type": "image"
+        },
+        {
+          "name": "heroImageLeftRef",
+          "label": "Hero Image Left Ref",
+          "type": "string"
+        },
+        {
+          "name": "heroImageRightRef",
+          "label": "Hero Image Right Ref",
+          "type": "string"
+        },
+        {
+          "name": "brandIntro",
+          "label": "Brand Intro",
+          "type": "object",
+          "fields": [
+            {
+              "name": "title",
+              "label": "Title",
+              "type": "string"
+            },
+            {
+              "name": "text",
+              "label": "Text",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "name": "clinicsBlock",
+          "label": "Clinics Block",
+          "type": "object",
+          "fields": [
+            {
+              "name": "clinicsTitle",
+              "label": "Title",
+              "type": "string"
+            },
+            {
+              "name": "clinicsBody",
+              "label": "Body",
+              "type": "text"
+            },
+            {
+              "name": "clinicsCtaLabel",
+              "label": "CTA Label",
+              "type": "string"
+            },
+            {
+              "name": "clinicsCtaHref",
+              "label": "CTA Href",
+              "type": "string"
+            },
+            {
+              "name": "clinicsImage",
+              "label": "Image",
+              "type": "image"
+            }
+          ]
+        },
+        {
+          "name": "galleryRows",
+          "label": "Gallery Rows",
+          "type": "list",
+          "items": {
+            "type": "object",
+            "fields": [
+              {
+                "name": "layout",
+                "label": "Layout",
+                "type": "string"
+              },
+              {
+                "name": "items",
+                "label": "Items",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "image",
+                      "label": "Image",
+                      "type": "image"
+                    },
+                    {
+                      "name": "alt",
+                      "label": "Alt Text",
+                      "type": "string"
+                    },
+                    {
+                      "name": "caption",
+                      "label": "Caption",
+                      "type": "text"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "bestsellersIntro",
+          "label": "Bestsellers Intro",
+          "type": "text"
+        },
+        {
+          "name": "sections",
+          "label": "Sections",
+          "type": "list",
+          "items": {
+            "type": "object",
+            "fields": [
+              {
+                "name": "type",
+                "label": "Section Type",
+                "type": "string"
+              },
+              {
+                "name": "title",
+                "label": "Title",
+                "type": "string"
+              },
+              {
+                "name": "subtitle",
+                "label": "Subtitle",
+                "type": "string"
+              },
+              {
+                "name": "headline",
+                "label": "Headline",
+                "type": "string"
+              },
+              {
+                "name": "text",
+                "label": "Text",
+                "type": "text"
+              },
+              {
+                "name": "body",
+                "label": "Body",
+                "type": "text"
+              },
+              {
+                "name": "layout",
+                "label": "Layout",
+                "type": "string"
+              },
+              {
+                "name": "columns",
+                "label": "Columns",
+                "type": "number"
+              },
+              {
+                "name": "alignment",
+                "label": "Alignment",
+                "type": "string"
+              },
+              {
+                "name": "background",
+                "label": "Background",
+                "type": "string"
+              },
+              {
+                "name": "placeholder",
+                "label": "Placeholder",
+                "type": "string"
+              },
+              {
+                "name": "ctaLabel",
+                "label": "CTA Label",
+                "type": "string"
+              },
+              {
+                "name": "cta",
+                "label": "CTA Text",
+                "type": "string"
+              },
+              {
+                "name": "ctaHref",
+                "label": "CTA Href",
+                "type": "string"
+              },
+              {
+                "name": "ctaPrimary",
+                "label": "Primary CTA",
+                "type": "string"
+              },
+              {
+                "name": "ctaSecondary",
+                "label": "Secondary CTA",
+                "type": "string"
+              },
+              {
+                "name": "image",
+                "label": "Image",
+                "type": "image"
+              },
+              {
+                "name": "imageRef",
+                "label": "Image Reference",
+                "type": "string"
+              },
+              {
+                "name": "imageAlt",
+                "label": "Image Alt Text",
+                "type": "string"
+              },
+              {
+                "name": "url",
+                "label": "URL",
+                "type": "string"
+              },
+              {
+                "name": "items",
+                "label": "Items",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "label",
+                      "label": "Label",
+                      "type": "string"
+                    },
+                    {
+                      "name": "description",
+                      "label": "Description",
+                      "type": "text"
+                    },
+                    {
+                      "name": "icon",
+                      "label": "Icon",
+                      "type": "string"
+                    },
+                    {
+                      "name": "eyebrow",
+                      "label": "Eyebrow",
+                      "type": "string"
+                    },
+                    {
+                      "name": "title",
+                      "label": "Title",
+                      "type": "string"
+                    },
+                    {
+                      "name": "subtitle",
+                      "label": "Subtitle",
+                      "type": "string"
+                    },
+                    {
+                      "name": "body",
+                      "label": "Body",
+                      "type": "text"
+                    },
+                    {
+                      "name": "text",
+                      "label": "Text",
+                      "type": "text"
+                    },
+                    {
+                      "name": "image",
+                      "label": "Image",
+                      "type": "image"
+                    },
+                    {
+                      "name": "imageRef",
+                      "label": "Image Reference",
+                      "type": "string"
+                    },
+                    {
+                      "name": "imageAlt",
+                      "label": "Image Alt Text",
+                      "type": "string"
+                    },
+                    {
+                      "name": "ctaLabel",
+                      "label": "CTA Label",
+                      "type": "string"
+                    },
+                    {
+                      "name": "ctaHref",
+                      "label": "CTA Href",
+                      "type": "string"
+                    },
+                    {
+                      "name": "url",
+                      "label": "URL",
+                      "type": "string"
+                    },
+                    {
+                      "name": "q",
+                      "label": "Question",
+                      "type": "string"
+                    },
+                    {
+                      "name": "a",
+                      "label": "Answer",
+                      "type": "text"
+                    },
+                    {
+                      "name": "name",
+                      "label": "Name",
+                      "type": "string"
+                    },
+                    {
+                      "name": "role",
+                      "label": "Role",
+                      "type": "string"
+                    },
+                    {
+                      "name": "id",
+                      "label": "ID",
+                      "type": "string"
+                    },
+                    {
+                      "name": "placeholder",
+                      "label": "Placeholder",
+                      "type": "string"
+                    },
+                    {
+                      "name": "confirmation",
+                      "label": "Confirmation",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "products",
+                "label": "Products",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "id",
+                      "label": "Product ID",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "quotes",
+                "label": "Quotes",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "text",
+                      "label": "Quote",
+                      "type": "text"
+                    },
+                    {
+                      "name": "author",
+                      "label": "Author",
+                      "type": "string"
+                    },
+                    {
+                      "name": "role",
+                      "label": "Role",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "slides",
+                "label": "Slides",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "image",
+                      "label": "Image",
+                      "type": "image"
+                    },
+                    {
+                      "name": "imageRef",
+                      "label": "Image Reference",
+                      "type": "string"
+                    },
+                    {
+                      "name": "alt",
+                      "label": "Alt Text",
+                      "type": "string"
+                    },
+                    {
+                      "name": "quote",
+                      "label": "Quote",
+                      "type": "text"
+                    },
+                    {
+                      "name": "name",
+                      "label": "Name",
+                      "type": "string"
+                    },
+                    {
+                      "name": "role",
+                      "label": "Role",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "overlay",
+                "label": "Overlay",
+                "type": "object",
+                "fields": [
+                  {
+                    "name": "columnStart",
+                    "label": "Column Start",
+                    "type": "number"
+                  },
+                  {
+                    "name": "columnSpan",
+                    "label": "Column Span",
+                    "type": "number"
+                  },
+                  {
+                    "name": "rowStart",
+                    "label": "Row Start",
+                    "type": "number"
+                  },
+                  {
+                    "name": "rowSpan",
+                    "label": "Row Span",
+                    "type": "number"
+                  },
+                  {
+                    "name": "textAlign",
+                    "label": "Text Align",
+                    "type": "string"
+                  },
+                  {
+                    "name": "verticalAlign",
+                    "label": "Vertical Align",
+                    "type": "string"
+                  },
+                  {
+                    "name": "theme",
+                    "label": "Theme",
+                    "type": "string"
+                  },
+                  {
+                    "name": "background",
+                    "label": "Background",
+                    "type": "string"
+                  },
+                  {
+                    "name": "cardWidth",
+                    "label": "Card Width",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "name": "slideDuration",
+                "label": "Slide Duration",
+                "type": "number"
+              },
+              {
+                "name": "quoteDuration",
+                "label": "Quote Duration",
+                "type": "number"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "home_es",
+      "label": "Home Page (Spanish)",
+      "type": "data",
+      "singleInstance": true,
+      "filePath": "content/pages/es/home.json",
+      "fields": [
+        {
+          "name": "type",
+          "label": "Type",
+          "type": "string"
+        },
+        {
+          "name": "metaTitle",
+          "label": "Meta Title",
+          "type": "string"
+        },
+        {
+          "name": "metaDescription",
+          "label": "Meta Description",
+          "type": "text"
+        },
+        {
+          "name": "meta",
+          "label": "Meta Overrides",
+          "type": "object",
+          "fields": [
+            {
+              "name": "metaTitle",
+              "label": "Meta Title",
+              "type": "string"
+            },
+            {
+              "name": "metaDescription",
+              "label": "Meta Description",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "name": "heroHeadline",
+          "label": "Hero Headline",
+          "type": "string"
+        },
+        {
+          "name": "heroSubheadline",
+          "label": "Hero Subheadline",
+          "type": "text"
+        },
+        {
+          "name": "heroCtas",
+          "label": "Hero CTAs",
+          "type": "object",
+          "fields": [
+            {
+              "name": "ctaPrimary",
+              "label": "Primary CTA",
+              "type": "object",
+              "fields": [
+                {
+                  "name": "label",
+                  "label": "Label",
+                  "type": "string"
+                },
+                {
+                  "name": "href",
+                  "label": "Link",
+                  "type": "string"
+                }
+              ]
+            },
+            {
+              "name": "ctaSecondary",
+              "label": "Secondary CTA",
+              "type": "object",
+              "fields": [
+                {
+                  "name": "label",
+                  "label": "Label",
+                  "type": "string"
+                },
+                {
+                  "name": "href",
+                  "label": "Link",
+                  "type": "string"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "heroAlignment",
+          "label": "Hero Alignment",
+          "type": "object",
+          "fields": [
+            {
+              "name": "heroAlignX",
+              "label": "Horizontal Alignment",
+              "type": "string"
+            },
+            {
+              "name": "heroAlignY",
+              "label": "Vertical Alignment",
+              "type": "string"
+            },
+            {
+              "name": "heroTextPosition",
+              "label": "Text Position",
+              "type": "string"
+            },
+            {
+              "name": "heroTextAnchor",
+              "label": "Text Anchor",
+              "type": "string"
+            },
+            {
+              "name": "heroOverlay",
+              "label": "Overlay",
+              "type": "string"
+            },
+            {
+              "name": "heroLayoutHint",
+              "label": "Layout Hint",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "heroImages",
+          "label": "Hero Images",
+          "type": "object",
+          "fields": [
+            {
+              "name": "heroImageLeft",
+              "label": "Left Image",
+              "type": "image"
+            },
+            {
+              "name": "heroImageRight",
+              "label": "Right Image",
+              "type": "image"
+            },
+            {
+              "name": "heroImageLeftRef",
+              "label": "Left Image Reference",
+              "type": "string"
+            },
+            {
+              "name": "heroImageRightRef",
+              "label": "Right Image Reference",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "heroPrimaryCta",
+          "label": "Hero Primary CTA (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "heroSecondaryCta",
+          "label": "Hero Secondary CTA (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "heroCtaPrimary",
+          "label": "Hero CTA Primary (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "heroCtaSecondary",
+          "label": "Hero CTA Secondary (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "ctaPrimary",
+          "label": "CTA Primary (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "ctaSecondary",
+          "label": "CTA Secondary (legacy)",
+          "type": "string"
+        },
+        {
+          "name": "heroOverlay",
+          "label": "Hero Overlay",
+          "type": "string"
+        },
+        {
+          "name": "heroLayoutHint",
+          "label": "Hero Layout Hint",
+          "type": "string"
+        },
+        {
+          "name": "heroAlignX",
+          "label": "Hero Align X",
+          "type": "string"
+        },
+        {
+          "name": "heroAlignY",
+          "label": "Hero Align Y",
+          "type": "string"
+        },
+        {
+          "name": "heroTextPosition",
+          "label": "Hero Text Position",
+          "type": "string"
+        },
+        {
+          "name": "heroImageLeft",
+          "label": "Hero Image Left",
+          "type": "image"
+        },
+        {
+          "name": "heroImageRight",
+          "label": "Hero Image Right",
+          "type": "image"
+        },
+        {
+          "name": "heroImageLeftRef",
+          "label": "Hero Image Left Ref",
+          "type": "string"
+        },
+        {
+          "name": "heroImageRightRef",
+          "label": "Hero Image Right Ref",
+          "type": "string"
+        },
+        {
+          "name": "brandIntro",
+          "label": "Brand Intro",
+          "type": "object",
+          "fields": [
+            {
+              "name": "title",
+              "label": "Title",
+              "type": "string"
+            },
+            {
+              "name": "text",
+              "label": "Text",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "name": "clinicsBlock",
+          "label": "Clinics Block",
+          "type": "object",
+          "fields": [
+            {
+              "name": "clinicsTitle",
+              "label": "Title",
+              "type": "string"
+            },
+            {
+              "name": "clinicsBody",
+              "label": "Body",
+              "type": "text"
+            },
+            {
+              "name": "clinicsCtaLabel",
+              "label": "CTA Label",
+              "type": "string"
+            },
+            {
+              "name": "clinicsCtaHref",
+              "label": "CTA Href",
+              "type": "string"
+            },
+            {
+              "name": "clinicsImage",
+              "label": "Image",
+              "type": "image"
+            }
+          ]
+        },
+        {
+          "name": "galleryRows",
+          "label": "Gallery Rows",
+          "type": "list",
+          "items": {
+            "type": "object",
+            "fields": [
+              {
+                "name": "layout",
+                "label": "Layout",
+                "type": "string"
+              },
+              {
+                "name": "items",
+                "label": "Items",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "image",
+                      "label": "Image",
+                      "type": "image"
+                    },
+                    {
+                      "name": "alt",
+                      "label": "Alt Text",
+                      "type": "string"
+                    },
+                    {
+                      "name": "caption",
+                      "label": "Caption",
+                      "type": "text"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "bestsellersIntro",
+          "label": "Bestsellers Intro",
+          "type": "text"
+        },
+        {
+          "name": "sections",
+          "label": "Sections",
+          "type": "list",
+          "items": {
+            "type": "object",
+            "fields": [
+              {
+                "name": "type",
+                "label": "Section Type",
+                "type": "string"
+              },
+              {
+                "name": "title",
+                "label": "Title",
+                "type": "string"
+              },
+              {
+                "name": "subtitle",
+                "label": "Subtitle",
+                "type": "string"
+              },
+              {
+                "name": "headline",
+                "label": "Headline",
+                "type": "string"
+              },
+              {
+                "name": "text",
+                "label": "Text",
+                "type": "text"
+              },
+              {
+                "name": "body",
+                "label": "Body",
+                "type": "text"
+              },
+              {
+                "name": "layout",
+                "label": "Layout",
+                "type": "string"
+              },
+              {
+                "name": "columns",
+                "label": "Columns",
+                "type": "number"
+              },
+              {
+                "name": "alignment",
+                "label": "Alignment",
+                "type": "string"
+              },
+              {
+                "name": "background",
+                "label": "Background",
+                "type": "string"
+              },
+              {
+                "name": "placeholder",
+                "label": "Placeholder",
+                "type": "string"
+              },
+              {
+                "name": "ctaLabel",
+                "label": "CTA Label",
+                "type": "string"
+              },
+              {
+                "name": "cta",
+                "label": "CTA Text",
+                "type": "string"
+              },
+              {
+                "name": "ctaHref",
+                "label": "CTA Href",
+                "type": "string"
+              },
+              {
+                "name": "ctaPrimary",
+                "label": "Primary CTA",
+                "type": "string"
+              },
+              {
+                "name": "ctaSecondary",
+                "label": "Secondary CTA",
+                "type": "string"
+              },
+              {
+                "name": "image",
+                "label": "Image",
+                "type": "image"
+              },
+              {
+                "name": "imageRef",
+                "label": "Image Reference",
+                "type": "string"
+              },
+              {
+                "name": "imageAlt",
+                "label": "Image Alt Text",
+                "type": "string"
+              },
+              {
+                "name": "url",
+                "label": "URL",
+                "type": "string"
+              },
+              {
+                "name": "items",
+                "label": "Items",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "label",
+                      "label": "Label",
+                      "type": "string"
+                    },
+                    {
+                      "name": "description",
+                      "label": "Description",
+                      "type": "text"
+                    },
+                    {
+                      "name": "icon",
+                      "label": "Icon",
+                      "type": "string"
+                    },
+                    {
+                      "name": "eyebrow",
+                      "label": "Eyebrow",
+                      "type": "string"
+                    },
+                    {
+                      "name": "title",
+                      "label": "Title",
+                      "type": "string"
+                    },
+                    {
+                      "name": "subtitle",
+                      "label": "Subtitle",
+                      "type": "string"
+                    },
+                    {
+                      "name": "body",
+                      "label": "Body",
+                      "type": "text"
+                    },
+                    {
+                      "name": "text",
+                      "label": "Text",
+                      "type": "text"
+                    },
+                    {
+                      "name": "image",
+                      "label": "Image",
+                      "type": "image"
+                    },
+                    {
+                      "name": "imageRef",
+                      "label": "Image Reference",
+                      "type": "string"
+                    },
+                    {
+                      "name": "imageAlt",
+                      "label": "Image Alt Text",
+                      "type": "string"
+                    },
+                    {
+                      "name": "ctaLabel",
+                      "label": "CTA Label",
+                      "type": "string"
+                    },
+                    {
+                      "name": "ctaHref",
+                      "label": "CTA Href",
+                      "type": "string"
+                    },
+                    {
+                      "name": "url",
+                      "label": "URL",
+                      "type": "string"
+                    },
+                    {
+                      "name": "q",
+                      "label": "Question",
+                      "type": "string"
+                    },
+                    {
+                      "name": "a",
+                      "label": "Answer",
+                      "type": "text"
+                    },
+                    {
+                      "name": "name",
+                      "label": "Name",
+                      "type": "string"
+                    },
+                    {
+                      "name": "role",
+                      "label": "Role",
+                      "type": "string"
+                    },
+                    {
+                      "name": "id",
+                      "label": "ID",
+                      "type": "string"
+                    },
+                    {
+                      "name": "placeholder",
+                      "label": "Placeholder",
+                      "type": "string"
+                    },
+                    {
+                      "name": "confirmation",
+                      "label": "Confirmation",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "products",
+                "label": "Products",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "id",
+                      "label": "Product ID",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "quotes",
+                "label": "Quotes",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "text",
+                      "label": "Quote",
+                      "type": "text"
+                    },
+                    {
+                      "name": "author",
+                      "label": "Author",
+                      "type": "string"
+                    },
+                    {
+                      "name": "role",
+                      "label": "Role",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "slides",
+                "label": "Slides",
+                "type": "list",
+                "items": {
+                  "type": "object",
+                  "fields": [
+                    {
+                      "name": "image",
+                      "label": "Image",
+                      "type": "image"
+                    },
+                    {
+                      "name": "imageRef",
+                      "label": "Image Reference",
+                      "type": "string"
+                    },
+                    {
+                      "name": "alt",
+                      "label": "Alt Text",
+                      "type": "string"
+                    },
+                    {
+                      "name": "quote",
+                      "label": "Quote",
+                      "type": "text"
+                    },
+                    {
+                      "name": "name",
+                      "label": "Name",
+                      "type": "string"
+                    },
+                    {
+                      "name": "role",
+                      "label": "Role",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "overlay",
+                "label": "Overlay",
+                "type": "object",
+                "fields": [
+                  {
+                    "name": "columnStart",
+                    "label": "Column Start",
+                    "type": "number"
+                  },
+                  {
+                    "name": "columnSpan",
+                    "label": "Column Span",
+                    "type": "number"
+                  },
+                  {
+                    "name": "rowStart",
+                    "label": "Row Start",
+                    "type": "number"
+                  },
+                  {
+                    "name": "rowSpan",
+                    "label": "Row Span",
+                    "type": "number"
+                  },
+                  {
+                    "name": "textAlign",
+                    "label": "Text Align",
+                    "type": "string"
+                  },
+                  {
+                    "name": "verticalAlign",
+                    "label": "Vertical Align",
+                    "type": "string"
+                  },
+                  {
+                    "name": "theme",
+                    "label": "Theme",
+                    "type": "string"
+                  },
+                  {
+                    "name": "background",
+                    "label": "Background",
+                    "type": "string"
+                  },
+                  {
+                    "name": "cardWidth",
+                    "label": "Card Width",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "name": "slideDuration",
+                "label": "Slide Duration",
+                "type": "number"
+              },
+              {
+                "name": "quoteDuration",
+                "label": "Quote Duration",
+                "type": "number"
+              }
+            ]
+          }
         }
       ]
     },


### PR DESCRIPTION
## Summary
- register en/pt/es home page entries in `metadata.json`
- expose hero, CTA, and section fields for each home page model so the visual editor can bind to `pages/Home.tsx`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dd228caac483208f50ab4b7edea172