### PR TITLE
Add Visual Editor-aware content fetching helper

### DIFF
--- a/components/TrainingList.tsx
+++ b/components/TrainingList.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
 import type { TrainingCatalogContent, TrainingEntry } from '../types';
 import { useLanguage } from '../contexts/LanguageContext';
+import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 
 interface TrainingListProps {
   title?: string;
@@ -12,12 +13,7 @@ interface TrainingListProps {
 
 const loadTrainingCatalog = async (): Promise<TrainingEntry[]> => {
   try {
-    const response = await fetch('/content/training.json');
-    if (!response.ok) {
-      return [];
-    }
-
-    const data = (await response.json()) as TrainingCatalogContent;
+    const data = await fetchVisualEditorJson<TrainingCatalogContent>('/content/training.json');
     if (!data || !Array.isArray(data.trainings)) {
       return [];
     }

--- a/components/VideoGallery.tsx
+++ b/components/VideoGallery.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Play } from 'lucide-react';
 import type { VideoEntry, VideoLibraryContent } from '../types';
 import { useLanguage } from '../contexts/LanguageContext';
+import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 
 interface VideoGalleryProps {
   title?: string;
@@ -16,12 +17,7 @@ const placeholderThumbnailClasses =
 
 const loadVideoLibrary = async (): Promise<VideoEntry[]> => {
   try {
-    const response = await fetch('/content/videos.json');
-    if (!response.ok) {
-      return [];
-    }
-
-    const data = (await response.json()) as VideoLibraryContent;
+    const data = await fetchVisualEditorJson<VideoLibraryContent>('/content/videos.json');
     if (!data || !Array.isArray(data.videos)) {
       return [];
     }

--- a/contexts/LanguageContext.tsx
+++ b/contexts/LanguageContext.tsx
@@ -8,6 +8,7 @@ import React, {
   useEffect,
 } from 'react';
 import type { Language } from '../types';
+import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 
 type TranslationPrimitive = string | number | boolean | null;
 type TranslationNode = TranslationPrimitive | TranslationPrimitive[] | { [key: string]: TranslationNode };
@@ -88,11 +89,9 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       try {
         const responses = await Promise.all(
           translationEntries.map(async ([key]) => {
-            const res = await fetch(`/content/translations/${key}.json`);
-            if (!res.ok) {
-              throw new Error(`Failed to load ${key} translations`);
-            }
-            const data = (await res.json()) as TranslationModule;
+            const data = await fetchVisualEditorJson<TranslationModule>(
+              `/content/translations/${key}.json`,
+            );
             return [key, data] as [string, TranslationModule];
           }),
         );

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -5,6 +5,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
 import SectionRenderer from '../components/_legacy/SectionRenderer';
 import type { PageContent, PageSection, TimelineEntry, TimelineSectionContent } from '../types';
+import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 
 const isTimelineEntry = (value: unknown): value is TimelineEntry => {
   if (!value || typeof value !== 'object') {
@@ -190,12 +191,9 @@ const About: React.FC = () => {
 
             for (const locale of localesToTry) {
                 try {
-                    const response = await fetch(`/content/pages/${locale}/about.json`);
-                    if (!response.ok) {
-                        continue;
-                    }
-
-                    const data = (await response.json()) as unknown;
+                    const data = await fetchVisualEditorJson<unknown>(
+                        `/content/pages/${locale}/about.json`,
+                    );
                     if (!isMounted) {
                         return;
                     }
@@ -234,12 +232,9 @@ const About: React.FC = () => {
 
             for (const locale of localesToTry) {
                 try {
-                    const response = await fetch(`/content/pages/${locale}/story.json`);
-                    if (!response.ok) {
-                        continue;
-                    }
-
-                    const data = (await response.json()) as unknown;
+                    const data = await fetchVisualEditorJson<unknown>(
+                        `/content/pages/${locale}/story.json`,
+                    );
                     if (!isMounted) {
                         return;
                     }

--- a/pages/Article.tsx
+++ b/pages/Article.tsx
@@ -15,6 +15,15 @@ import {
   loadLearnPageContent,
   type LearnPageContentResult,
 } from '../utils/loadLearnPageContent';
+import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
+
+interface ArticlesResponse {
+    items?: Article[];
+}
+
+interface ProductsResponse {
+    items?: Product[];
+}
 
 const ArticlePage: React.FC = () => {
     const { slug } = useParams<{ slug: string }>();
@@ -55,11 +64,10 @@ const ArticlePage: React.FC = () => {
 
         const fetchArticleData = async () => {
             try {
-                const articlesRes = await fetch('/content/articles/index.json');
-                const articlesData = await articlesRes.json();
+                const articlesData = await fetchVisualEditorJson<ArticlesResponse>('/content/articles/index.json');
                 if (!isMounted) return;
 
-                const articleItems: Article[] = articlesData.items ?? [];
+                const articleItems: Article[] = Array.isArray(articlesData.items) ? articlesData.items : [];
                 const currentArticleIndex = articleItems.findIndex((a: Article) => a.slug === slug);
                 const currentArticle = currentArticleIndex >= 0 ? articleItems[currentArticleIndex] : null;
                 setArticle(currentArticle);
@@ -70,11 +78,10 @@ const ArticlePage: React.FC = () => {
 
                 if (productIds.length > 0) {
                     try {
-                        const productsRes = await fetch('/content/products/index.json');
-                        const productsData = await productsRes.json();
+                        const productsData = await fetchVisualEditorJson<ProductsResponse>('/content/products/index.json');
                         if (!isMounted) return;
 
-                        const productItems: Product[] = productsData.items ?? [];
+                        const productItems: Product[] = Array.isArray(productsData.items) ? productsData.items : [];
                         setAllProducts(productItems);
 
                         const matchedProducts = productIds

--- a/pages/Method.tsx
+++ b/pages/Method.tsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet-async';
 import { motion } from 'framer-motion';
 import { useLanguage } from '../contexts/LanguageContext';
 import type { Language } from '../types';
+import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 
 interface SpecialtyItem {
   title: string;
@@ -140,12 +141,9 @@ const Method: React.FC = () => {
 
       for (const locale of localesToTry) {
         try {
-          const response = await fetch(`/content/pages/${locale}/method.json`);
-          if (!response.ok) {
-            continue;
-          }
-
-          const data = (await response.json()) as unknown;
+          const data = await fetchVisualEditorJson<unknown>(
+            `/content/pages/${locale}/method.json`,
+          );
           if (!isMounted) {
             return;
           }

--- a/pages/Training.tsx
+++ b/pages/Training.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import SectionRenderer from '../components/_legacy/SectionRenderer';
 import { useLanguage } from '../contexts/LanguageContext';
 import type { PageContent, PageSection } from '../types';
+import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 
 const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
   'timeline',
@@ -74,12 +75,9 @@ const Training: React.FC = () => {
 
       for (const locale of localesToTry) {
         try {
-          const response = await fetch(`/content/pages/${locale}/training.json`);
-          if (!response.ok) {
-            continue;
-          }
-
-          const data = (await response.json()) as unknown;
+          const data = await fetchVisualEditorJson<unknown>(
+            `/content/pages/${locale}/training.json`,
+          );
           if (!isMounted) {
             return;
           }

--- a/pages/Videos.tsx
+++ b/pages/Videos.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import SectionRenderer from '../components/_legacy/SectionRenderer';
 import { useLanguage } from '../contexts/LanguageContext';
 import type { PageContent, PageSection } from '../types';
+import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 
 const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
   'timeline',
@@ -74,12 +75,9 @@ const Videos: React.FC = () => {
 
       for (const locale of localesToTry) {
         try {
-          const response = await fetch(`/content/pages/${locale}/videos.json`);
-          if (!response.ok) {
-            continue;
-          }
-
-          const data = (await response.json()) as unknown;
+          const data = await fetchVisualEditorJson<unknown>(
+            `/content/pages/${locale}/videos.json`,
+          );
           if (!isMounted) {
             return;
           }

--- a/utils/fetchVisualEditorJson.ts
+++ b/utils/fetchVisualEditorJson.ts
@@ -1,0 +1,67 @@
+const CONTENT_PREFIX = '/content/';
+const SITE_PREFIX = '/site/content/';
+const INDEX_SUFFIX = '/index.json';
+
+const buildSiteCandidates = (contentUrl: string): string[] => {
+  if (!contentUrl.startsWith(CONTENT_PREFIX)) {
+    return [];
+  }
+
+  const rawPath = contentUrl.slice(CONTENT_PREFIX.length);
+  const normalizedPath = rawPath.replace(/^\/+/, '');
+  const candidates = new Set<string>();
+
+  const directSitePath = `${SITE_PREFIX}${normalizedPath}`;
+  candidates.add(directSitePath);
+
+  if (normalizedPath.endsWith(INDEX_SUFFIX)) {
+    const withoutIndex = normalizedPath.slice(0, -INDEX_SUFFIX.length);
+    candidates.add(`${SITE_PREFIX}${withoutIndex}.json`);
+  }
+
+  const segments = normalizedPath.split('/');
+  if (segments[0] === 'pages' && segments.length >= 3) {
+    const [, locale, ...restSegments] = segments;
+    if (locale) {
+      const restPath = restSegments.join('/');
+      if (restPath) {
+        candidates.add(`${SITE_PREFIX}${locale}/pages/${restPath}`);
+        if (restPath.endsWith(INDEX_SUFFIX)) {
+          const withoutIndex = restPath.slice(0, -INDEX_SUFFIX.length);
+          candidates.add(`${SITE_PREFIX}${locale}/pages/${withoutIndex}.json`);
+        }
+      }
+    }
+  }
+
+  return Array.from(candidates);
+};
+
+export const fetchVisualEditorJson = async <T>(url: string, init?: RequestInit): Promise<T> => {
+  const candidateUrls: string[] = [];
+  candidateUrls.push(...buildSiteCandidates(url));
+  candidateUrls.push(url);
+
+  let lastError: unknown;
+
+  for (const candidate of candidateUrls) {
+    try {
+      const response = await fetch(candidate, init);
+      if (!response.ok) {
+        continue;
+      }
+
+      return (await response.json()) as T;
+    } catch (error) {
+      console.warn('fetchVisualEditorJson: failed to fetch', candidate, error);
+      lastError = error;
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+
+  throw new Error(`Unable to fetch JSON from ${url}`);
+};
+


### PR DESCRIPTION
## Summary
- add a shared fetchVisualEditorJson helper that favors the site content mirror before static content paths
- update page, component, and context loaders to use the helper so Visual Editor edits show immediately
- handle locale-aware paths and common index.json fallbacks when pulling JSON data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dd6726ce4883209890f9c4e0fc8c98