### PR TITLE
Remove redundant Stackbit field path props from Shop page

### DIFF
--- a/pages/Shop.tsx
+++ b/pages/Shop.tsx
@@ -277,7 +277,6 @@ const Shop: React.FC = () => {
                             ? `shop.categories.${activeCategoryIndex}.links.${linkIndex}.label.${language}`
                             : undefined
                         }
-                        data-sb-field-path={`.${linkIndex}`}
                       >
                         <Icon className="w-4 h-4" />
                         <span>{translate(link.label)}</span>
@@ -315,7 +314,6 @@ const Shop: React.FC = () => {
                 key={product.id}
                 product={product}
                 fieldPath={productFieldPath}
-                data-sb-field-path={`.${index}`}
               />
             );
           })}


### PR DESCRIPTION
## Summary
- remove the hard-coded `data-sb-field-path` props on shop tabs, related links, and product cards so the runtime binder can derive the correct bindings automatically

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68de40b2e9f0832092b283529eb39cc5