### PR TITLE
Fix footer translation annotations for Visual Editor

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,26 +3,18 @@ import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
 import { Facebook, Instagram, Linkedin, Youtube, Globe } from 'lucide-react';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
-import { getVisualEditorAttributes } from '../utils/stackbitBindings';
+import { getStackbitAttributes, getStackbitObjectId, getVisualEditorAttributes } from '../utils/stackbitBindings';
 
 const FooterLink: React.FC<{
     to: string;
     children: React.ReactNode;
     fieldPath?: string;
-    sbFieldPath?: string;
-    sbObjectId?: string;
-}> = ({ to, children, fieldPath, sbFieldPath, sbObjectId }) => (
+}> = ({ to, children, fieldPath }) => (
     <Link
         to={to}
         className="relative group text-stone-500 hover:text-stone-900 transition-colors duration-300"
-        data-sb-field-path={sbFieldPath ?? undefined}
-        data-sb-object-id={sbObjectId}
     >
-        <span
-          {...getVisualEditorAttributes(fieldPath ?? undefined)}
-        >
-          {children}
-        </span>
+        <span {...getVisualEditorAttributes(fieldPath ?? undefined)}>{children}</span>
         <span className="absolute bottom-0 left-0 block h-[1px] w-full bg-stone-700 transform scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out origin-left"></span>
     </Link>
 );
@@ -33,8 +25,8 @@ const Footer: React.FC = () => {
     const socialLinks = settings.footer?.socialLinks ?? [];
     const legalName = settings.footer?.legalName ?? 'Kapunka Skincare';
     const brandName = settings.brand?.name ?? 'KAPUNKA';
-    const footerTranslationsObjectId = 'translations_footer:content/translations/footer.json';
-    const siteConfigObjectId = 'SiteConfig:content/site.json';
+    const footerTranslationsObjectId = getStackbitObjectId('translations.en.footer.tagline');
+    const socialLinksAttributes = getStackbitAttributes('site.footer.socialLinks');
 
     const socialIconMap: Record<string, React.ComponentType<{ size?: number }>> = {
         facebook: Facebook,
@@ -55,7 +47,6 @@ const Footer: React.FC = () => {
               className="text-sm text-stone-500"
               {...getVisualEditorAttributes(`translations.${language}.footer.tagline`)}
               data-sb-object-id={footerTranslationsObjectId}
-              data-sb-field-path={`${language}.tagline`}
             >
               {t('footer.tagline')}
             </p>
@@ -64,15 +55,13 @@ const Footer: React.FC = () => {
                   className="font-semibold mb-3 text-sm"
                   {...getVisualEditorAttributes(`translations.${language}.footer.followUs`)}
                   data-sb-object-id={footerTranslationsObjectId}
-                  data-sb-field-path={`${language}.followUs`}
                 >
                   {t('footer.followUs')}
                 </h4>
                 {socialLinks.length > 0 && (
                     <div
                         className="flex space-x-4"
-                        data-sb-object-id={siteConfigObjectId}
-                        data-sb-field-path="footer.socialLinks"
+                        {...socialLinksAttributes}
                     >
                         {socialLinks.map((link, index) => {
                             const iconKey = link.icon ? link.icon.toLowerCase() : '';
@@ -86,8 +75,6 @@ const Footer: React.FC = () => {
                                     aria-label={link.label}
                                     className="text-stone-500 hover:text-stone-900 transition-colors"
                                     {...getVisualEditorAttributes(`site.footer.socialLinks.${index}`)}
-                                    data-sb-field-path={`footer.socialLinks.${index}`}
-                                    data-sb-object-id={siteConfigObjectId}
                                 >
                                     <Icon size={20} />
                                 </a>
@@ -102,7 +89,6 @@ const Footer: React.FC = () => {
               className="font-semibold mb-4"
               {...getVisualEditorAttributes(`translations.${language}.footer.shop`)}
               data-sb-object-id={footerTranslationsObjectId}
-              data-sb-field-path={`${language}.shop`}
             >
               {t('footer.shop')}
             </h4>
@@ -111,8 +97,6 @@ const Footer: React.FC = () => {
                 <FooterLink
                   to="/shop"
                   fieldPath={`translations.${language}.footer.allProducts`}
-                  sbFieldPath={`${language}.allProducts`}
-                  sbObjectId={footerTranslationsObjectId}
                 >
                   {t('footer.allProducts')}
                 </FooterLink>
@@ -121,8 +105,6 @@ const Footer: React.FC = () => {
                 <FooterLink
                   to="/learn"
                   fieldPath={`translations.${language}.footer.guides`}
-                  sbFieldPath={`${language}.guides`}
-                  sbObjectId={footerTranslationsObjectId}
                 >
                   {t('footer.guides')}
                 </FooterLink>
@@ -134,7 +116,6 @@ const Footer: React.FC = () => {
               className="font-semibold mb-4"
               {...getVisualEditorAttributes(`translations.${language}.footer.about`)}
               data-sb-object-id={footerTranslationsObjectId}
-              data-sb-field-path={`${language}.about`}
             >
               {t('footer.about')}
             </h4>
@@ -143,8 +124,6 @@ const Footer: React.FC = () => {
                 <FooterLink
                   to="/about"
                   fieldPath={`translations.${language}.footer.ourStory`}
-                  sbFieldPath={`${language}.ourStory`}
-                  sbObjectId={footerTranslationsObjectId}
                 >
                   {t('footer.ourStory')}
                 </FooterLink>
@@ -153,8 +132,6 @@ const Footer: React.FC = () => {
                 <FooterLink
                   to="/contact"
                   fieldPath={`translations.${language}.footer.contact`}
-                  sbFieldPath={`${language}.contact`}
-                  sbObjectId={footerTranslationsObjectId}
                 >
                   {t('footer.contact')}
                 </FooterLink>
@@ -166,7 +143,6 @@ const Footer: React.FC = () => {
               className="font-semibold mb-4"
               {...getVisualEditorAttributes(`translations.${language}.footer.policies`)}
               data-sb-object-id={footerTranslationsObjectId}
-              data-sb-field-path={`${language}.policies`}
             >
               {t('footer.policies')}
             </h4>
@@ -175,8 +151,6 @@ const Footer: React.FC = () => {
                 <FooterLink
                   to="/policy/shipping"
                   fieldPath={`translations.${language}.footer.shipping`}
-                  sbFieldPath={`${language}.shipping`}
-                  sbObjectId={footerTranslationsObjectId}
                 >
                   {t('footer.shipping')}
                 </FooterLink>
@@ -185,8 +159,6 @@ const Footer: React.FC = () => {
                 <FooterLink
                   to="/policy/returns"
                   fieldPath={`translations.${language}.footer.returns`}
-                  sbFieldPath={`${language}.returns`}
-                  sbObjectId={footerTranslationsObjectId}
                 >
                   {t('footer.returns')}
                 </FooterLink>
@@ -195,8 +167,6 @@ const Footer: React.FC = () => {
                 <FooterLink
                   to="/policy/privacy"
                   fieldPath={`translations.${language}.footer.privacy`}
-                  sbFieldPath={`${language}.privacy`}
-                  sbObjectId={footerTranslationsObjectId}
                 >
                   {t('footer.privacy')}
                 </FooterLink>
@@ -205,8 +175,6 @@ const Footer: React.FC = () => {
                 <FooterLink
                   to="/policy/terms"
                   fieldPath={`translations.${language}.footer.terms`}
-                  sbFieldPath={`${language}.terms`}
-                  sbObjectId={footerTranslationsObjectId}
                 >
                   {t('footer.terms')}
                 </FooterLink>

--- a/utils/stackbitBindings.ts
+++ b/utils/stackbitBindings.ts
@@ -198,7 +198,9 @@ const resolveTranslationBinding = (value: string): StackbitBinding | null => {
     return null;
   }
 
-  const objectId = `translations_${module}:content/translations/${module}.json`;
+  const filePath = `content/translations/${module}.json`;
+  const modelName = modelNameByFilePath.get(filePath) ?? `translations_${module}`;
+  const objectId = `${modelName}:${filePath}`;
   const normalizedRest = normalizeStackbitFieldPath(rest);
   const fieldPath = normalizedRest ? `${lang}.${normalizedRest}` : lang;
   return { objectId, fieldPath };


### PR DESCRIPTION
## Summary
- resolve translation object IDs using metadata so Stackbit bindings match the Visual Editor schema
- apply the shared annotation helpers throughout the footer so links and social icons inherit consistent `data-sb-*` attributes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68de55fb194083208ffc5cc493c37e40