### PR TITLE
Switch to BrowserRouter and update allowed hosts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy, useEffect } from 'react';
-import { HashRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 
@@ -139,7 +139,7 @@ const App: React.FC = () => {
 
   return (
     <HelmetProvider>
-      <HashRouter>
+      <BrowserRouter>
         <div className="bg-stone-50 text-stone-800 min-h-screen flex flex-col">
           <Helmet>
             <title>{defaultTitle}</title>
@@ -155,7 +155,7 @@ const App: React.FC = () => {
           <MiniCart />
           <CookieConsent />
         </div>
-      </HashRouter>
+      </BrowserRouter>
     </HelmetProvider>
   );
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,8 +24,8 @@ export default defineConfig(({ mode }) => {
         : [
             "localhost",
             "127.0.0.1",
-            "devserver-main--kapunka-new.netlify.app",
-            "devserver-preview--kapunka-new.netlify.app"
+            "*.netlify.app",
+            "*.stackbit.dev"
           ],
       hmr: { protocol: "wss", clientPort: 443 } // reliable HMR behind Netlify proxy
     }


### PR DESCRIPTION
## Summary
- replace the HashRouter wrapper with BrowserRouter to improve URL handling for the Visual Editor
- expand Vite's allowedHosts list to cover localhost, Netlify, and Stackbit preview domains while keeping the Netlify dev bypass

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68de642d247c83209aeffe07dc2653b1