### PR TITLE
Fix Decap unified pages image i18n configuration

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -131,7 +131,7 @@ shared_sections: &shared_sections
           - { label: "Eyebrow", name: "eyebrow", widget: "string", i18n: true, required: false }
           - { label: "Title", name: "title", widget: "string", i18n: true, required: false }
           - { label: "Body", name: "body", widget: "text", i18n: true, required: false }
-          - { label: "Image Upload", name: "image", widget: "image", choose_url: true, required: false }
+          - { label: "Image Upload", name: "image", widget: "image", choose_url: true, i18n: true, required: false }
           - { label: "Image Path (optional)", name: "imageRef", widget: "string", i18n: true, required: false }
           - { label: "Image Alt Text", name: "imageAlt", widget: "string", i18n: true, required: false }
           - { label: "CTA Label", name: "ctaLabel", widget: "string", i18n: true, required: false }
@@ -221,6 +221,7 @@ shared_sections: &shared_sections
             name: "image"
             widget: "image"
             choose_url: true
+            i18n: true
             required: false
           - label: "Image Path (optional)"
             name: "imageRef"


### PR DESCRIPTION
## Summary
- enable i18n support on unified page image widgets so Decap receives localized strings
- ensure community carousel slide images also declare i18n for consistency with stored data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dfa75010b88320b49c2bdb7a6ab47a