### PR TITLE
Add Decap CMS rolling log and reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,6 @@ When committing changes, keep these safeguards in mind:
 4. Enable **Identity** and **Git Gateway** from the Netlify dashboard so Decap CMS can authenticate editors and commit updates.
 5. Make sure the branch selected in Netlify matches the `branch` value in [`admin/config.yml`](admin/config.yml). The configuration now defaults to `main`; change it if your production site uses a different branch.
 6. After deploying, visit `/admin/` on your Netlify site to log in with Netlify Identity and manage all site content through Decap CMS.
+
+### Further reading for editors
+- Track historical decisions around Decap CMS configuration and Netlify deploys in the [Decap CMS & Netlify rolling log](docs/decap-netlify-rolling-log.md) before making structural changes.

--- a/docs/decap-cms-audit.md
+++ b/docs/decap-cms-audit.md
@@ -1,5 +1,7 @@
 # Decap CMS Audit & Editor Navigation Guide
 
+> Looking for a change-by-change history? See the [Decap CMS & Netlify rolling log](./decap-netlify-rolling-log.md) for dated context before diving into specific audits.
+
 ## Executive Summary
 - Decap pulls all assets from `content/uploads`, so every image referenced across pages, products, and globals can be updated in one place without touching the codebase.【F:admin/config.yml†L8-L9】
 - Page schemas are repeated for each locale (English, Portuguese, Spanish), creating heavy duplication and longer editorial forms; introducing Decap's built-in i18n support or shared field groups would reduce bloat while keeping content structure intact.【F:admin/config.yml†L116-L639】

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -1,0 +1,22 @@
+# Decap CMS & Netlify Rolling Log
+
+This log records day-to-day investigations, fixes, and decisions that affect the Decap CMS configuration or Netlify delivery. Use it to understand why a change shipped, what problem it solved, and where to look for deeper context (PRs, commits, and audit docs).
+
+## How to add a new entry
+- **Date**: Use ISO format (`YYYY-MM-DD`).
+- **Title**: Summarise the change or discovery in a short phrase.
+- **What changed**: Explain the update or investigation outcome.
+- **Impact & follow-up**: Note whether editors, deploys, or automation were affected and document any TODOs.
+- **References**: Link to the relevant PRs/commits and any supporting documents in `docs/`.
+
+---
+
+## 2025-10-03 — Custom commit messages for editorial history
+- **What changed**: Added friendly commit message templates so Decap records the collection, slug, and editor responsible for each change committed through Netlify Identity.
+- **Impact & follow-up**: Improves auditability of CMS-driven content changes; no further action required unless new collections are added. Aligns with guidance in the Decap CMS audit for keeping editorial trails transparent.
+- **References**: [PR #198](https://github.com/ptbandeira/kapunka-new/pull/198) · [Commit 3cdbf99](https://github.com/ptbandeira/kapunka-new/commit/3cdbf99364cf5dc0f0c080030080260576421cef) · [Decap CMS audit](./decap-cms-audit.md)
+
+## 2025-10-03 — Unified page image sync fixes
+- **What changed**: Flattened locale-specific image objects in the unified pages schema and corrected i18n keys so Netlify builds and Stackbit sync use the same field structure.
+- **Impact & follow-up**: Resolved asset hydration errors during previews and ensures editors only manage one image per locale. Continue monitoring Stackbit sync logs for regressions when adding new unified sections.
+- **References**: [PR #199](https://github.com/ptbandeira/kapunka-new/pull/199) · [Commit 8873572](https://github.com/ptbandeira/kapunka-new/commit/8873572b02dd9db01df958524dc77f9c3e0b3905) · [Visual editor audit](./visual-editor-audit.md)


### PR DESCRIPTION
## Summary
- add a Decap CMS & Netlify rolling log with seeded entries for recent fixes
- link the new log from the Decap CMS audit and README so editors can find historical context

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68dfb616fe08832086a55d76b45fc356