### PR TITLE
Refine Decap section CTAs and reorganize pages schema

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -8,15 +8,677 @@ media_folder: "content/uploads"
 public_folder: "/content/uploads"
 
 collections:
-  - name: "pages"
-    label: "Pages"
-    folder: "content/cms/pages"
-    create: true
+  - name: pages
+    label: Pages
+    folder: content/pages
+    create: false
     slug: "{{slug}}"
-    extension: "json"
-    format: "json"
+    extension: json
+    format: json
+    preview_path: "{{slug}}"
+    i18n:
+      structure: multiple_folders
+      locales:
+        - en
+        - pt
+        - es
+      default_locale: en
     fields:
-      - { label: "Title", name: "title", widget: "string", required: false }
-      - { label: "Slug", name: "slug", widget: "string" }
-      - { label: "Description", name: "description", widget: "text", required: false }
-      - { label: "Body", name: "body", widget: "markdown", required: false }
+      - label: Page Type
+        name: type
+        widget: string
+        i18n: duplicate
+      - label: Meta Title
+        name: metaTitle
+        widget: string
+        required: false
+        i18n: translate
+      - label: Meta Description
+        name: metaDescription
+        widget: text
+        required: false
+        i18n: translate
+      - label: Hero Headline
+        name: heroHeadline
+        widget: string
+        required: false
+        i18n: translate
+      - label: Hero Subheadline
+        name: heroSubheadline
+        widget: text
+        required: false
+        i18n: translate
+      - label: Hero Title
+        name: heroTitle
+        widget: string
+        required: false
+        i18n: translate
+      - label: Hero Subtitle
+        name: heroSubtitle
+        widget: text
+        required: false
+        i18n: translate
+      - label: Hero CTAs
+        name: heroCtas
+        widget: object
+        collapsed: true
+        required: false
+        i18n: translate
+        fields:
+          - label: Primary CTA
+            name: ctaPrimary
+            widget: object
+            collapsed: true
+            required: false
+            fields: &link_fields
+              - label: Label
+                name: label
+                widget: string
+                required: false
+                i18n: translate
+              - label: URL
+                name: href
+                widget: string
+                required: false
+                i18n: translate
+          - label: Secondary CTA
+            name: ctaSecondary
+            widget: object
+            collapsed: true
+            required: false
+            fields: *link_fields
+      - label: Hero Alignment
+        name: heroAlignment
+        widget: object
+        collapsed: true
+        required: false
+        i18n: translate
+        fields:
+          - label: Horizontal Align
+            name: heroAlignX
+            widget: select
+            options:
+              - { label: Left, value: left }
+              - { label: Center, value: center }
+              - { label: Right, value: right }
+            required: false
+          - label: Vertical Align
+            name: heroAlignY
+            widget: select
+            options:
+              - { label: Top, value: top }
+              - { label: Middle, value: middle }
+              - { label: Bottom, value: bottom }
+            required: false
+          - label: Text Position
+            name: heroTextPosition
+            widget: select
+            options:
+              - { label: Overlay, value: overlay }
+              - { label: Below, value: below }
+            required: false
+          - label: Text Anchor
+            name: heroTextAnchor
+            widget: select
+            options:
+              - { label: Top Left, value: top-left }
+              - { label: Top Center, value: top-center }
+              - { label: Top Right, value: top-right }
+              - { label: Middle Left, value: middle-left }
+              - { label: Middle Center, value: middle-center }
+              - { label: Middle Right, value: middle-right }
+              - { label: Bottom Left, value: bottom-left }
+              - { label: Bottom Center, value: bottom-center }
+              - { label: Bottom Right, value: bottom-right }
+            required: false
+          - label: Layout Hint
+            name: heroLayoutHint
+            widget: select
+            options:
+              - { label: Image Left, value: image-left }
+              - { label: Image Right, value: image-right }
+              - { label: Full Background, value: image-full }
+              - { label: Overlay Legacy, value: text-over-media }
+              - { label: Split Legacy, value: side-by-side }
+              - { label: Background Legacy, value: bg }
+              - { label: Background Image Legacy, value: bgImage }
+            required: false
+          - label: Overlay Token
+            name: heroOverlay
+            widget: string
+            required: false
+            i18n: translate
+      - label: Hero Images
+        name: heroImages
+        widget: object
+        collapsed: true
+        required: false
+        i18n: translate
+        fields:
+          - label: Left Image
+            name: heroImageLeft
+            widget: image
+            required: false
+            i18n: duplicate
+          - label: Right Image
+            name: heroImageRight
+            widget: image
+            required: false
+            i18n: duplicate
+      - label: Intro Block
+        name: intro
+        widget: object
+        collapsed: true
+        required: false
+        i18n: translate
+        fields:
+          - { label: Title, name: title, widget: string, required: false, i18n: translate }
+          - { label: Primary Copy, name: text1, widget: text, required: false, i18n: translate }
+          - { label: Secondary Copy, name: text2, widget: text, required: false, i18n: translate }
+      - label: Protocol Section
+        name: protocolSection
+        widget: object
+        collapsed: true
+        required: false
+        i18n: translate
+        fields:
+          - { label: Title, name: title, widget: string, required: false, i18n: translate }
+          - { label: Subtitle, name: subtitle, widget: text, required: false, i18n: translate }
+          - label: Cards
+            name: cards
+            widget: list
+            collapsed: true
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Focus, name: focus, widget: text, required: false, i18n: translate }
+              - label: Steps
+                name: steps
+                widget: list
+                field:
+                  label: Step
+                  name: value
+                  widget: text
+                  i18n: translate
+              - { label: Evidence, name: evidence, widget: text, required: false, i18n: translate }
+      - label: References Section
+        name: referencesSection
+        widget: object
+        collapsed: true
+        required: false
+        i18n: translate
+        fields:
+          - { label: Title, name: title, widget: string, required: false, i18n: translate }
+          - { label: Studies Title, name: studiesTitle, widget: string, required: false, i18n: translate }
+          - label: Studies
+            name: studies
+            widget: list
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Details, name: details, widget: text, required: false, i18n: translate }
+          - { label: Testimonials Title, name: testimonialsTitle, widget: string, required: false, i18n: translate }
+          - label: Testimonials
+            name: testimonials
+            widget: list
+            fields:
+              - { label: Quote, name: quote, widget: text, required: false, i18n: translate }
+              - { label: Name, name: name, widget: string, required: false, i18n: translate }
+              - { label: Credentials, name: credentials, widget: string, required: false, i18n: translate }
+      - label: Keyword Section
+        name: keywordSection
+        widget: object
+        collapsed: true
+        required: false
+        i18n: translate
+        fields:
+          - { label: Title, name: title, widget: string, required: false, i18n: translate }
+          - { label: Subtitle, name: subtitle, widget: text, required: false, i18n: translate }
+          - label: Keywords
+            name: keywords
+            widget: list
+            field:
+              label: Keyword
+              name: value
+              widget: string
+              i18n: translate
+      - label: FAQ Section
+        name: faqSection
+        widget: object
+        collapsed: true
+        required: false
+        i18n: translate
+        fields:
+          - { label: Title, name: title, widget: string, required: false, i18n: translate }
+          - { label: Subtitle, name: subtitle, widget: text, required: false, i18n: translate }
+          - label: Questions
+            name: items
+            widget: list
+            fields:
+              - { label: Question, name: question, widget: string, required: false, i18n: translate }
+              - { label: Answer, name: answer, widget: text, required: false, i18n: translate }
+      - label: Learn Categories
+        name: categories
+        widget: list
+        collapsed: true
+        required: false
+        fields:
+          - { label: ID, name: id, widget: string, i18n: duplicate }
+          - { label: Label, name: label, widget: string, i18n: translate }
+      - label: Clinical Notes
+        name: clinicalNotes
+        widget: list
+        collapsed: true
+        required: false
+        fields:
+          - { label: Title, name: title, widget: string, required: false, i18n: translate }
+          - label: Bullets
+            name: bullets
+            widget: list
+            field:
+              label: Bullet
+              name: value
+              widget: string
+              i18n: translate
+      - label: Story Narrative
+        name: story
+        widget: text
+        required: false
+        i18n: translate
+      - label: Story Tagline
+        name: tagline
+        widget: string
+        required: false
+        i18n: translate
+      - label: Clinics Header Title
+        name: headerTitle
+        widget: string
+        required: false
+        i18n: translate
+      - label: Clinics Header Subtitle
+        name: headerSubtitle
+        widget: text
+        required: false
+        i18n: translate
+      - label: Clinics Section Title
+        name: section1Title
+        widget: string
+        required: false
+        i18n: translate
+      - label: Clinics Section Copy A
+        name: section1Text1
+        widget: text
+        required: false
+        i18n: translate
+      - label: Clinics Section Copy B
+        name: section1Text2
+        widget: text
+        required: false
+        i18n: translate
+      - label: Doctors Title
+        name: doctorsTitle
+        widget: string
+        required: false
+        i18n: translate
+      - label: Partners Title
+        name: partnersTitle
+        widget: string
+        required: false
+        i18n: translate
+      - label: CTA Title
+        name: ctaTitle
+        widget: string
+        required: false
+        i18n: translate
+      - label: CTA Subtitle
+        name: ctaSubtitle
+        widget: text
+        required: false
+        i18n: translate
+      - label: CTA Button Label
+        name: ctaButton
+        widget: string
+        required: false
+        i18n: translate
+      - label: Page Title (Test Page)
+        name: title
+        widget: string
+        required: false
+        i18n: translate
+      - label: Sections
+        name: sections
+        widget: list
+        collapsed: true
+        i18n: translate
+        types:
+          - label: Media + Copy
+            name: mediaCopy
+            widget: object
+            summary: "{{title}}"
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Body, name: body, widget: markdown, required: false, i18n: translate }
+              - label: Layout
+                name: layout
+                widget: select
+                options:
+                  - { label: Image Right, value: image-right }
+                  - { label: Image Left, value: image-left }
+                  - { label: Overlay, value: overlay }
+                required: false
+              - { label: Columns, name: columns, widget: number, required: false, value_type: int }
+              - label: Image
+                name: image
+                widget: image
+                required: false
+                i18n: duplicate
+              - { label: Alt Text, name: imageAlt, widget: string, required: false, i18n: translate }
+              - label: Overlay Settings
+                name: overlay
+                widget: object
+                collapsed: true
+                required: false
+                fields:
+                  - { label: Column Start, name: columnStart, widget: number, required: false, value_type: int }
+                  - { label: Column Span, name: columnSpan, widget: number, required: false, value_type: int }
+                  - { label: Row Start, name: rowStart, widget: number, required: false, value_type: int }
+                  - { label: Row Span, name: rowSpan, widget: number, required: false, value_type: int }
+                  - label: Text Align
+                    name: textAlign
+                    widget: select
+                    options:
+                      - { label: Left, value: left }
+                      - { label: Center, value: center }
+                      - { label: Right, value: right }
+                    required: false
+                  - label: Vertical Align
+                    name: verticalAlign
+                    widget: select
+                    options:
+                      - { label: Start, value: start }
+                      - { label: Center, value: center }
+                      - { label: End, value: end }
+                    required: false
+                  - label: Theme
+                    name: theme
+                    widget: select
+                    options:
+                      - { label: Light, value: light }
+                      - { label: Dark, value: dark }
+                    required: false
+                  - label: Background
+                    name: background
+                    widget: select
+                    options:
+                      - { label: None, value: none }
+                      - { label: Light Scrim, value: scrim-light }
+                      - { label: Dark Scrim, value: scrim-dark }
+                      - { label: Panel, value: panel }
+                    required: false
+                  - label: Card Width
+                    name: cardWidth
+                    widget: select
+                    options:
+                      - { label: Compact, value: sm }
+                      - { label: Balanced, value: md }
+                      - { label: Wide, value: lg }
+                    required: false
+          - label: Media Showcase
+            name: mediaShowcase
+            widget: object
+            summary: "{{title}}"
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - label: Highlights
+                name: items
+                widget: list
+                collapsed: true
+                fields:
+                  - { label: Eyebrow, name: eyebrow, widget: string, required: false, i18n: translate }
+                  - { label: Title, name: title, widget: string, required: false, i18n: translate }
+                  - { label: Body, name: body, widget: text, required: false, i18n: translate }
+                  - label: Image
+                    name: image
+                    widget: image
+                    required: false
+                    i18n: duplicate
+                  - { label: Alt Text, name: imageAlt, widget: string, required: false, i18n: translate }
+                  - label: CTA
+                    name: cta
+                    widget: object
+                    collapsed: true
+                    required: false
+                    fields: *link_fields
+          - label: Feature Grid
+            name: featureGrid
+            widget: object
+            summary: "{{title}}"
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Columns, name: columns, widget: number, required: false, value_type: int }
+              - label: Items
+                name: items
+                widget: list
+                fields:
+                  - { label: Label, name: label, widget: string, required: false, i18n: translate }
+                  - { label: Description, name: description, widget: text, required: false, i18n: translate }
+          - label: Product Grid
+            name: productGrid
+            widget: object
+            summary: "{{title}}"
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Columns, name: columns, widget: number, required: false, value_type: int }
+              - label: Products
+                name: products
+                widget: list
+                fields:
+                  - { label: Product ID, name: id, widget: string, i18n: duplicate }
+          - label: Community Carousel
+            name: communityCarousel
+            widget: object
+            summary: "{{title}}"
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - label: Slides
+                name: slides
+                widget: list
+                collapsed: true
+                fields:
+                  - label: Image
+                    name: image
+                    widget: image
+                    required: false
+                    i18n: duplicate
+                  - { label: Alt Text, name: alt, widget: string, required: false, i18n: translate }
+                  - { label: Quote, name: quote, widget: text, required: false, i18n: translate }
+                  - { label: Name, name: name, widget: string, required: false, i18n: translate }
+                  - { label: Role, name: role, widget: string, required: false, i18n: translate }
+              - { label: Slide Duration (ms), name: slideDuration, widget: number, required: false, value_type: int }
+              - { label: Quote Duration (ms), name: quoteDuration, widget: number, required: false, value_type: int }
+          - label: Newsletter Signup
+            name: newsletterSignup
+            widget: object
+            summary: "{{title}}"
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Subtitle, name: subtitle, widget: text, required: false, i18n: translate }
+              - { label: Email Placeholder, name: placeholder, widget: string, required: false, i18n: translate }
+              - { label: Button Label, name: ctaLabel, widget: string, required: false, i18n: translate }
+              - { label: Confirmation Message, name: confirmation, widget: text, required: false, i18n: translate }
+              - label: Background
+                name: background
+                widget: select
+                options:
+                  - { label: Light, value: light }
+                  - { label: Beige, value: beige }
+                  - { label: Dark, value: dark }
+                required: false
+              - label: Alignment
+                name: alignment
+                widget: select
+                options:
+                  - { label: Left, value: left }
+                  - { label: Center, value: center }
+                required: false
+          - label: Testimonials
+            name: testimonials
+            widget: object
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - label: Quotes
+                name: quotes
+                widget: list
+                fields:
+                  - { label: Quote, name: text, widget: text, required: false, i18n: translate }
+                  - { label: Author, name: author, widget: string, required: false, i18n: translate }
+                  - { label: Role, name: role, widget: string, required: false, i18n: translate }
+          - label: Banner
+            name: banner
+            widget: object
+            fields:
+              - { label: Text, name: text, widget: text, required: false, i18n: translate }
+              - label: CTA
+                name: cta
+                widget: object
+                collapsed: true
+                required: false
+                fields: *link_fields
+              - { label: Style Variant, name: style, widget: string, required: false, i18n: translate }
+          - label: Facts
+            name: facts
+            widget: object
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Body, name: text, widget: text, required: false, i18n: translate }
+          - label: Bullet List
+            name: bullets
+            widget: object
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - label: Items
+                name: items
+                widget: list
+                field:
+                  label: Bullet
+                  name: value
+                  widget: string
+                  i18n: translate
+          - label: Specialties
+            name: specialties
+            widget: object
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - label: Specialties
+                name: items
+                widget: list
+                collapsed: true
+                fields:
+                  - { label: Title, name: title, widget: string, required: false, i18n: translate }
+                  - label: Bullets
+                    name: bullets
+                    widget: list
+                    field:
+                      label: Bullet
+                      name: value
+                      widget: string
+                      i18n: translate
+          - label: Video Embed
+            name: video
+            widget: object
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Video URL, name: url, widget: string, required: false, i18n: translate }
+          - label: Video Gallery
+            name: videoGallery
+            widget: object
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Description, name: description, widget: text, required: false, i18n: translate }
+              - label: Entries
+                name: entries
+                widget: list
+                collapsed: true
+                fields:
+                  - { label: Title, name: title, widget: string, required: false, i18n: translate }
+                  - { label: Description, name: description, widget: text, required: false, i18n: translate }
+                  - { label: Video URL, name: videoUrl, widget: string, required: false, i18n: translate }
+                  - label: Thumbnail
+                    name: thumbnail
+                    widget: image
+                    required: false
+                    i18n: duplicate
+          - label: Training List
+            name: trainingList
+            widget: object
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Description, name: description, widget: text, required: false, i18n: translate }
+              - label: Entries
+                name: entries
+                widget: list
+                fields:
+                  - { label: Course Title, name: courseTitle, widget: string, required: false, i18n: translate }
+                  - { label: Summary, name: courseSummary, widget: text, required: false, i18n: translate }
+                  - { label: Link URL, name: linkUrl, widget: string, required: false, i18n: translate }
+          - label: FAQ Section (Legacy)
+            name: faq
+            widget: object
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - label: Items
+                name: items
+                widget: list
+                fields:
+                  - { label: Question, name: q, widget: string, required: false, i18n: translate }
+                  - { label: Answer, name: a, widget: text, required: false, i18n: translate }
+          - label: Timeline (Legacy)
+            name: timeline
+            widget: object
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - label: Entries
+                name: entries
+                widget: list
+                fields:
+                  - { label: Year, name: year, widget: string, required: false, i18n: translate }
+                  - { label: Title, name: title, widget: string, required: false, i18n: translate }
+                  - { label: Description, name: description, widget: text, required: false, i18n: translate }
+                  - label: Image
+                    name: image
+                    widget: image
+                    required: false
+                    i18n: duplicate
+          - label: Image + Text Half (Legacy)
+            name: imageTextHalf
+            widget: object
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Subtitle, name: subtitle, widget: string, required: false, i18n: translate }
+              - { label: Body, name: text, widget: markdown, required: false, i18n: translate }
+              - label: Button
+                name: button
+                widget: object
+                collapsed: true
+                required: false
+                fields: *link_fields
+              - label: Image
+                name: image
+                widget: image
+                required: false
+                i18n: duplicate
+          - label: Image Grid (Legacy)
+            name: imageGrid
+            widget: object
+            fields:
+              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Description, name: description, widget: text, required: false, i18n: translate }
+              - label: Items
+                name: items
+                widget: list
+                fields:
+                  - label: Image
+                    name: image
+                    widget: image
+                    required: false
+                    i18n: duplicate
+                  - { label: Alt Text, name: alt, widget: string, required: false, i18n: translate }
+                  - { label: Caption, name: caption, widget: text, required: false, i18n: translate }

--- a/components/sections/MediaShowcase.tsx
+++ b/components/sections/MediaShowcase.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
 
+export interface MediaShowcaseItemCta {
+  label?: string;
+  href?: string;
+  fieldPath?: string;
+  labelFieldPath?: string;
+  hrefFieldPath?: string;
+}
+
 export interface MediaShowcaseItem {
   eyebrow?: string;
   title?: string;
@@ -13,10 +21,7 @@ export interface MediaShowcaseItem {
   eyebrowFieldPath?: string;
   titleFieldPath?: string;
   bodyFieldPath?: string;
-  ctaLabel?: string;
-  ctaHref?: string;
-  ctaLabelFieldPath?: string;
-  ctaHrefFieldPath?: string;
+  cta?: MediaShowcaseItemCta;
 }
 
 interface MediaShowcaseProps {
@@ -59,8 +64,11 @@ const MediaShowcase: React.FC<MediaShowcaseProps> = ({ title, items, fieldPath }
             const eyebrow = item.eyebrow?.trim();
             const itemTitle = item.title?.trim();
             const body = item.body?.trim();
-            const ctaLabel = item.ctaLabel?.trim();
-            const ctaHref = item.ctaHref?.trim();
+            const ctaLabel = item.cta?.label?.trim();
+            const ctaHref = item.cta?.href?.trim();
+            const ctaFieldPath = item.cta?.fieldPath;
+            const ctaLabelFieldPath = item.cta?.labelFieldPath ?? (ctaFieldPath ? `${ctaFieldPath}.label` : undefined);
+            const ctaHrefFieldPath = item.cta?.hrefFieldPath ?? (ctaFieldPath ? `${ctaFieldPath}.href` : undefined);
 
             const layoutClasses = (() => {
               if (index === 0) {
@@ -144,12 +152,12 @@ const MediaShowcase: React.FC<MediaShowcaseProps> = ({ title, items, fieldPath }
                           <Link
                             to={normalizeInternal(ctaHref)}
                             className="inline-flex items-center rounded-full border border-white/60 bg-white/10 px-5 py-2 text-sm font-medium tracking-wide text-white transition hover:bg-white hover:text-stone-900"
-                            {...getVisualEditorAttributes(item.ctaHrefFieldPath)}
-                            data-sb-field-path={item.ctaHrefFieldPath}
+                            {...getVisualEditorAttributes(ctaHrefFieldPath)}
+                            data-sb-field-path={ctaHrefFieldPath}
                           >
                             <span
-                              {...getVisualEditorAttributes(item.ctaLabelFieldPath)}
-                              data-sb-field-path={item.ctaLabelFieldPath}
+                              {...getVisualEditorAttributes(ctaLabelFieldPath)}
+                              data-sb-field-path={ctaLabelFieldPath}
                             >
                               {ctaLabel}
                             </span>
@@ -158,14 +166,14 @@ const MediaShowcase: React.FC<MediaShowcaseProps> = ({ title, items, fieldPath }
                           <a
                             href={ctaHref}
                             className="inline-flex items-center rounded-full border border-white/60 bg-white/10 px-5 py-2 text-sm font-medium tracking-wide text-white transition hover:bg-white hover:text-stone-900"
-                            {...getVisualEditorAttributes(item.ctaHrefFieldPath)}
-                            data-sb-field-path={item.ctaHrefFieldPath}
+                            {...getVisualEditorAttributes(ctaHrefFieldPath)}
+                            data-sb-field-path={ctaHrefFieldPath}
                             target="_blank"
                             rel="noreferrer"
                           >
                             <span
-                              {...getVisualEditorAttributes(item.ctaLabelFieldPath)}
-                              data-sb-field-path={item.ctaLabelFieldPath}
+                              {...getVisualEditorAttributes(ctaLabelFieldPath)}
+                              data-sb-field-path={ctaLabelFieldPath}
                             >
                               {ctaLabel}
                             </span>

--- a/content/pages/en/clinics.json
+++ b/content/pages/en/clinics.json
@@ -32,8 +32,10 @@
     {
       "type": "banner",
       "text": "Explore wholesale and training",
-      "cta": "Contact our team",
-      "url": "/contact"
+      "cta": {
+        "label": "Contact our team",
+        "href": "/contact"
+      }
     }
   ],
   "headerTitle": "Professional Clinic Partnership Program",

--- a/content/pages/en/home.json
+++ b/content/pages/en/home.json
@@ -33,40 +33,44 @@
           "title": "From gratitude to method",
           "body": "How a simple gesture of care became a therapeutic protocol.",
           "imageAlt": "Hands applying argan oil in warm light",
-          "ctaLabel": "Our Story",
-          "ctaHref": "/about",
           "image": "/content/uploads/9bae3f87-12d5-43f4-a2a0-5cfc768e429d.jpg",
-          "imageUrl": "/content/uploads/roots-olive-tree.jpg"
+          "cta": {
+            "label": "Our Story",
+            "href": "/about"
+          }
         },
         {
           "eyebrow": "For clinics",
           "title": "Trusted by professionals",
           "body": "Used by dermatologists, medspas, and recovery clinics for over a decade.",
           "imageAlt": "Practitioner massaging a client's face with argan care",
-          "ctaLabel": "Partner With Us",
-          "ctaHref": "/clinics",
           "image": "/content/uploads/pexels-elly-fairytale-3865548.jpg",
-          "imageUrl": "/content/uploads/clinic-hands.jpg"
+          "cta": {
+            "label": "Partner With Us",
+            "href": "/clinics"
+          }
         },
         {
           "eyebrow": "Supply chain",
           "title": "Heritage sourcing, clinical standards",
           "body": "From Moroccan cooperatives to hospital rooms.",
           "imageAlt": "Harvested argan fruit gathered in a woven basket",
-          "ctaLabel": "Our Standards",
-          "ctaHref": "/method",
           "image": "/content/uploads/a-woman-picks-fruit-from-an-argan-tree-1-.jpg",
-          "imageUrl": "/content/uploads/argan-coop.jpg"
+          "cta": {
+            "label": "Our Standards",
+            "href": "/method"
+          }
         },
         {
           "eyebrow": "Rituals",
           "title": "From hammam rituals to modern recovery",
           "body": "Ancient wisdom, scientifically structured.",
           "imageAlt": "Steam-filled hammam room with a person resting",
-          "ctaLabel": "Shop Rituals",
-          "ctaHref": "/shop",
           "image": "/content/uploads/342cecc0-3c00-4094-97d6-5c9d9da02330.jpg",
-          "imageUrl": "/content/uploads/hammam-light.jpg"
+          "cta": {
+            "label": "Shop Rituals",
+            "href": "/shop"
+          }
         }
       ]
     },

--- a/content/pages/en/method.json
+++ b/content/pages/en/method.json
@@ -76,44 +76,6 @@
             "After Sun"
           ]
         }
-      ],
-      "specialties": [
-        {
-          "title": "Pediatrics",
-          "bullets": [
-            "Hydration from 3 months",
-            "Diaper dermatitis",
-            "Atopic dermatitis"
-          ]
-        },
-        {
-          "title": "Dermatology",
-          "bullets": [
-            "Dry, scaly skin",
-            "Psoriasis/dermatitis",
-            "Post-acne or surgery marks"
-          ]
-        },
-        {
-          "title": "Post-op",
-          "bullets": [
-            "Supports faster epithelial recovery with lighter scarring"
-          ]
-        },
-        {
-          "title": "Physio",
-          "bullets": [
-            "Rehabilitative massage",
-            "Skin recovery after dressings"
-          ]
-        },
-        {
-          "title": "Aesthetics",
-          "bullets": [
-            "Post-treatment care (waxing/peels/RF)",
-            "After Sun"
-          ]
-        }
       ]
     }
   ]

--- a/content/pages/es/clinics.json
+++ b/content/pages/es/clinics.json
@@ -32,8 +32,10 @@
     {
       "type": "banner",
       "text": "Explora mayoristas y capacitación",
-      "cta": "Contacta a nuestro equipo",
-      "url": "/contact"
+      "cta": {
+        "label": "Contacta a nuestro equipo",
+        "href": "/contact"
+      }
     }
   ],
   "headerTitle": "Programa Profesional Kapunka",

--- a/content/pages/es/home.json
+++ b/content/pages/es/home.json
@@ -32,36 +32,44 @@
           "title": "De la gratitud al método",
           "body": "De un gesto sencillo nació un protocolo terapéutico.",
           "imageAlt": "Manos aplicando aceite de argán con luz cálida",
-          "ctaLabel": "Nuestra historia",
-          "ctaHref": "/about",
-          "image": "/content/uploads/roots-olive-tree.jpg"
+          "image": "/content/uploads/roots-olive-tree.jpg",
+          "cta": {
+            "label": "Nuestra historia",
+            "href": "/about"
+          }
         },
         {
           "eyebrow": "Para clínicas",
           "title": "De confianza profesional",
           "body": "Utilizado desde hace más de una década por dermatólogos y clínicas de recuperación.",
           "imageAlt": "Profesional masajeando el rostro de una clienta con cuidado de argán",
-          "ctaLabel": "Aliarte con nosotros",
-          "ctaHref": "/clinics",
-          "image": "/content/uploads/clinic-hands.jpg"
+          "image": "/content/uploads/clinic-hands.jpg",
+          "cta": {
+            "label": "Aliarte con nosotros",
+            "href": "/clinics"
+          }
         },
         {
           "eyebrow": "Cadena de suministro",
           "title": "Origen con herencia, estándar clínico",
           "body": "De las cooperativas marroquíes a las salas hospitalarias.",
           "imageAlt": "Frutos de argán recién cosechados en una cesta tejida",
-          "ctaLabel": "Nuestros estándares",
-          "ctaHref": "/method",
-          "image": "/content/uploads/argan-coop.jpg"
+          "image": "/content/uploads/argan-coop.jpg",
+          "cta": {
+            "label": "Nuestros estándares",
+            "href": "/method"
+          }
         },
         {
           "eyebrow": "Rituales",
           "title": "Del hammam a la recuperación moderna",
           "body": "Sabiduría ancestral, estructura científica.",
           "imageAlt": "Sala de hammam llena de vapor con una persona descansando",
-          "ctaLabel": "Comprar rituales",
-          "ctaHref": "/shop",
-          "image": "/content/uploads/hammam-light.jpg"
+          "image": "/content/uploads/hammam-light.jpg",
+          "cta": {
+            "label": "Comprar rituales",
+            "href": "/shop"
+          }
         }
       ]
     },

--- a/content/pages/es/method.json
+++ b/content/pages/es/method.json
@@ -76,44 +76,6 @@
             "Post-solar"
           ]
         }
-      ],
-      "specialties": [
-        {
-          "title": "Pediatría",
-          "bullets": [
-            "Hidratación desde los 3 meses",
-            "Dermatitis del pañal",
-            "Dermatitis atópica"
-          ]
-        },
-        {
-          "title": "Dermatología",
-          "bullets": [
-            "Piel seca y descamada",
-            "Psoriasis/dermatitis",
-            "Marcas postacné o cirugía"
-          ]
-        },
-        {
-          "title": "Postoperatorio",
-          "bullets": [
-            "Favorece una recuperación epitelial más rápida con cicatrices ligeras"
-          ]
-        },
-        {
-          "title": "Fisioterapia",
-          "bullets": [
-            "Masaje rehabilitador",
-            "Recuperación cutánea tras vendajes"
-          ]
-        },
-        {
-          "title": "Estética",
-          "bullets": [
-            "Cuidado posterior a tratamientos (depilación/peelings/RF)",
-            "Post-solar"
-          ]
-        }
       ]
     }
   ]

--- a/content/pages/pt/clinics.json
+++ b/content/pages/pt/clinics.json
@@ -32,8 +32,10 @@
     {
       "type": "banner",
       "text": "Explore atacado e treinamentos",
-      "cta": "Fale com nossa equipe",
-      "url": "/contact"
+      "cta": {
+        "label": "Fale com nossa equipe",
+        "href": "/contact"
+      }
     }
   ],
   "headerTitle": "Programa Profissional Kapunka",

--- a/content/pages/pt/home.json
+++ b/content/pages/pt/home.json
@@ -32,36 +32,44 @@
           "title": "Da gratidão ao método",
           "body": "De um gesto simples nasceu um protocolo terapêutico.",
           "imageAlt": "Mãos aplicando óleo de argan sob luz quente",
-          "ctaLabel": "Nossa história",
-          "ctaHref": "/about",
-          "image": "/content/uploads/roots-olive-tree.jpg"
+          "image": "/content/uploads/roots-olive-tree.jpg",
+          "cta": {
+            "label": "Nossa história",
+            "href": "/about"
+          }
         },
         {
           "eyebrow": "Para clínicas",
           "title": "De confiança profissional",
           "body": "Utilizado há mais de uma década por dermatologistas e clínicas de recuperação.",
           "imageAlt": "Profissional massageando o rosto de uma cliente com cuidado de argan",
-          "ctaLabel": "Parceria conosco",
-          "ctaHref": "/clinics",
-          "image": "/content/uploads/clinic-hands.jpg"
+          "image": "/content/uploads/clinic-hands.jpg",
+          "cta": {
+            "label": "Parceria conosco",
+            "href": "/clinics"
+          }
         },
         {
           "eyebrow": "Cadeia de fornecimento",
           "title": "Origem com herança, padrão clínico",
           "body": "Das cooperativas marroquinas às salas de hospital.",
           "imageAlt": "Frutos de argan recém-colhidos em um cesto de palha",
-          "ctaLabel": "Nossos padrões",
-          "ctaHref": "/method",
-          "image": "/content/uploads/argan-coop.jpg"
+          "image": "/content/uploads/argan-coop.jpg",
+          "cta": {
+            "label": "Nossos padrões",
+            "href": "/method"
+          }
         },
         {
           "eyebrow": "Rituais",
           "title": "Do hammam à recuperação moderna",
           "body": "Sabedoria ancestral com estrutura científica.",
           "imageAlt": "Sala de hammam com vapor e uma pessoa relaxando",
-          "ctaLabel": "Comprar rituais",
-          "ctaHref": "/shop",
-          "image": "/content/uploads/hammam-light.jpg"
+          "image": "/content/uploads/hammam-light.jpg",
+          "cta": {
+            "label": "Comprar rituais",
+            "href": "/shop"
+          }
         }
       ]
     },

--- a/content/pages/pt/method.json
+++ b/content/pages/pt/method.json
@@ -76,44 +76,6 @@
             "Pós-sol"
           ]
         }
-      ],
-      "specialties": [
-        {
-          "title": "Pediatria",
-          "bullets": [
-            "Hidratação a partir dos 3 meses",
-            "Dermatite da fralda",
-            "Dermatite atópica"
-          ]
-        },
-        {
-          "title": "Dermatologia",
-          "bullets": [
-            "Pele seca e descamativa",
-            "Psoríase/dermatite",
-            "Marcas pós-acne ou cirurgia"
-          ]
-        },
-        {
-          "title": "Pós-operatório",
-          "bullets": [
-            "Favorece recuperação epitelial mais rápida com cicatrização leve"
-          ]
-        },
-        {
-          "title": "Fisioterapia",
-          "bullets": [
-            "Massagem reabilitadora",
-            "Recuperação da pele após curativos"
-          ]
-        },
-        {
-          "title": "Estética",
-          "bullets": [
-            "Cuidados pós-tratamento (depilação/peelings/RF)",
-            "Pós-sol"
-          ]
-        }
       ]
     }
   ]

--- a/content/pages_v2/index.json
+++ b/content/pages_v2/index.json
@@ -219,21 +219,23 @@
           }
         },
         {
-          "cta": {
-            "en": "Contact our team",
-            "pt": "Fale com nossa equipe",
-            "es": "Contacta a nuestro equipo"
-          },
           "text": {
             "en": "Explore wholesale and training",
             "pt": "Explore atacado e treinamentos",
             "es": "Explora mayoristas y capacitación"
           },
           "type": "banner",
-          "url": {
-            "en": "/contact",
-            "pt": "/contact",
-            "es": "/contact"
+          "cta": {
+            "label": {
+              "en": "Contact our team",
+              "pt": "Fale com nossa equipe",
+              "es": "Contacta a nuestro equipo"
+            },
+            "href": {
+              "en": "/contact",
+              "pt": "/contact",
+              "es": "/contact"
+            }
           }
         }
       ],
@@ -1052,14 +1054,6 @@
                 "pt": "De um gesto simples nasceu um protocolo terapêutico.",
                 "es": "De un gesto sencillo nació un protocolo terapéutico."
               },
-              "ctaHref": {
-                "pt": "/about",
-                "es": "/about"
-              },
-              "ctaLabel": {
-                "pt": "Nossa história",
-                "es": "Nuestra historia"
-              },
               "eyebrow": {
                 "pt": "Do blog",
                 "es": "Desde el blog"
@@ -1071,20 +1065,22 @@
               "title": {
                 "pt": "Da gratidão ao método",
                 "es": "De la gratitud al método"
+              },
+              "cta": {
+                "label": {
+                  "pt": "Nossa história",
+                  "es": "Nuestra historia"
+                },
+                "href": {
+                  "pt": "/about",
+                  "es": "/about"
+                }
               }
             },
             {
               "body": {
                 "pt": "Utilizado há mais de uma década por dermatologistas e clínicas de recuperação.",
                 "es": "Utilizado desde hace más de una década por dermatólogos y clínicas de recuperación."
-              },
-              "ctaHref": {
-                "pt": "/clinics",
-                "es": "/clinics"
-              },
-              "ctaLabel": {
-                "pt": "Parceria conosco",
-                "es": "Aliarte con nosotros"
               },
               "eyebrow": {
                 "pt": "Para clínicas",
@@ -1097,20 +1093,22 @@
               "title": {
                 "pt": "De confiança profissional",
                 "es": "De confianza profesional"
+              },
+              "cta": {
+                "label": {
+                  "pt": "Parceria conosco",
+                  "es": "Aliarte con nosotros"
+                },
+                "href": {
+                  "pt": "/clinics",
+                  "es": "/clinics"
+                }
               }
             },
             {
               "body": {
                 "pt": "Das cooperativas marroquinas às salas de hospital.",
                 "es": "De las cooperativas marroquíes a las salas hospitalarias."
-              },
-              "ctaHref": {
-                "pt": "/method",
-                "es": "/method"
-              },
-              "ctaLabel": {
-                "pt": "Nossos padrões",
-                "es": "Nuestros estándares"
               },
               "eyebrow": {
                 "pt": "Cadeia de fornecimento",
@@ -1123,20 +1121,22 @@
               "title": {
                 "pt": "Origem com herança, padrão clínico",
                 "es": "Origen con herencia, estándar clínico"
+              },
+              "cta": {
+                "label": {
+                  "pt": "Nossos padrões",
+                  "es": "Nuestros estándares"
+                },
+                "href": {
+                  "pt": "/method",
+                  "es": "/method"
+                }
               }
             },
             {
               "body": {
                 "pt": "Sabedoria ancestral com estrutura científica.",
                 "es": "Sabiduría ancestral, estructura científica."
-              },
-              "ctaHref": {
-                "pt": "/shop",
-                "es": "/shop"
-              },
-              "ctaLabel": {
-                "pt": "Comprar rituais",
-                "es": "Comprar rituales"
               },
               "eyebrow": {
                 "pt": "Rituais",
@@ -1149,6 +1149,16 @@
               "title": {
                 "pt": "Do hammam à recuperação moderna",
                 "es": "Del hammam a la recuperación moderna"
+              },
+              "cta": {
+                "label": {
+                  "pt": "Comprar rituais",
+                  "es": "Comprar rituales"
+                },
+                "href": {
+                  "pt": "/shop",
+                  "es": "/shop"
+                }
               }
             }
           ],
@@ -1185,12 +1195,6 @@
               "body": {
                 "en": "How a simple gesture of care became a therapeutic protocol."
               },
-              "ctaHref": {
-                "en": "/about"
-              },
-              "ctaLabel": {
-                "en": "Our Story"
-              },
               "description": {
                 "pt": "Amigável para a pele, puro e prensado a frio.",
                 "es": "Amables con la piel, puros y prensados en frío."
@@ -1208,17 +1212,19 @@
               },
               "title": {
                 "en": "From gratitude to method"
+              },
+              "cta": {
+                "label": {
+                  "en": "Our Story"
+                },
+                "href": {
+                  "en": "/about"
+                }
               }
             },
             {
               "body": {
                 "en": "Used by dermatologists, medspas, and recovery clinics for over a decade."
-              },
-              "ctaHref": {
-                "en": "/clinics"
-              },
-              "ctaLabel": {
-                "en": "Partner With Us"
               },
               "description": {
                 "pt": "Texturas de baixa deposição e aromas suaves para pele sensível.",
@@ -1237,17 +1243,19 @@
               },
               "title": {
                 "en": "Trusted by professionals"
+              },
+              "cta": {
+                "label": {
+                  "en": "Partner With Us"
+                },
+                "href": {
+                  "en": "/clinics"
+                }
               }
             },
             {
               "body": {
                 "en": "From Moroccan cooperatives to hospital rooms."
-              },
-              "ctaHref": {
-                "en": "/method"
-              },
-              "ctaLabel": {
-                "en": "Our Standards"
               },
               "description": {
                 "pt": "Conjuntos iniciais e formação para rotinas consistentes em casa.",
@@ -1266,17 +1274,19 @@
               },
               "title": {
                 "en": "Heritage sourcing, clinical standards"
+              },
+              "cta": {
+                "label": {
+                  "en": "Our Standards"
+                },
+                "href": {
+                  "en": "/method"
+                }
               }
             },
             {
               "body": {
                 "en": "Ancient wisdom, scientifically structured."
-              },
-              "ctaHref": {
-                "en": "/shop"
-              },
-              "ctaLabel": {
-                "en": "Shop Rituals"
               },
               "description": {
                 "pt": "Relações justas com as cooperativas de Marrocos.",
@@ -1295,6 +1305,14 @@
               },
               "title": {
                 "en": "From hammam rituals to modern recovery"
+              },
+              "cta": {
+                "label": {
+                  "en": "Shop Rituals"
+                },
+                "href": {
+                  "en": "/shop"
+                }
               }
             }
           ],
@@ -1492,11 +1510,6 @@
             "pt": "Obrigado por se inscrever!",
             "es": "¡Gracias por suscribirte!"
           },
-          "ctaLabel": {
-            "en": "Subscribe",
-            "pt": "Subscrever",
-            "es": "Suscribirme"
-          },
           "placeholder": {
             "en": "Enter your email address",
             "pt": "Introduza o seu e-mail",
@@ -1512,7 +1525,14 @@
             "pt": "Junte-se à Lista",
             "es": "Únete a la Lista"
           },
-          "type": "newsletterSignup"
+          "type": "newsletterSignup",
+          "cta": {
+            "label": {
+              "en": "Subscribe",
+              "pt": "Subscrever",
+              "es": "Suscribirme"
+            }
+          }
         },
         {
           "quotes": [
@@ -2330,108 +2350,6 @@
         },
         {
           "items": [
-            {
-              "bullets": [
-                {
-                  "en": "Hydration from 3 months",
-                  "pt": "Hidratação a partir dos 3 meses",
-                  "es": "Hidratación desde los 3 meses"
-                },
-                {
-                  "en": "Diaper dermatitis",
-                  "pt": "Dermatite da fralda",
-                  "es": "Dermatitis del pañal"
-                },
-                {
-                  "en": "Atopic dermatitis",
-                  "pt": "Dermatite atópica",
-                  "es": "Dermatitis atópica"
-                }
-              ],
-              "title": {
-                "en": "Pediatrics",
-                "pt": "Pediatria",
-                "es": "Pediatría"
-              }
-            },
-            {
-              "bullets": [
-                {
-                  "en": "Dry, scaly skin",
-                  "pt": "Pele seca e descamativa",
-                  "es": "Piel seca y descamada"
-                },
-                {
-                  "en": "Psoriasis/dermatitis",
-                  "pt": "Psoríase/dermatite",
-                  "es": "Psoriasis/dermatitis"
-                },
-                {
-                  "en": "Post-acne or surgery marks",
-                  "pt": "Marcas pós-acne ou cirurgia",
-                  "es": "Marcas postacné o cirugía"
-                }
-              ],
-              "title": {
-                "en": "Dermatology",
-                "pt": "Dermatologia",
-                "es": "Dermatología"
-              }
-            },
-            {
-              "bullets": [
-                {
-                  "en": "Supports faster epithelial recovery with lighter scarring",
-                  "pt": "Favorece recuperação epitelial mais rápida com cicatrização leve",
-                  "es": "Favorece una recuperación epitelial más rápida con cicatrices ligeras"
-                }
-              ],
-              "title": {
-                "en": "Post-op",
-                "pt": "Pós-operatório",
-                "es": "Postoperatorio"
-              }
-            },
-            {
-              "bullets": [
-                {
-                  "en": "Rehabilitative massage",
-                  "pt": "Massagem reabilitadora",
-                  "es": "Masaje rehabilitador"
-                },
-                {
-                  "en": "Skin recovery after dressings",
-                  "pt": "Recuperação da pele após curativos",
-                  "es": "Recuperación cutánea tras vendajes"
-                }
-              ],
-              "title": {
-                "en": "Physio",
-                "pt": "Fisioterapia",
-                "es": "Fisioterapia"
-              }
-            },
-            {
-              "bullets": [
-                {
-                  "en": "Post-treatment care (waxing/peels/RF)",
-                  "pt": "Cuidados pós-tratamento (depilação/peelings/RF)",
-                  "es": "Cuidado posterior a tratamientos (depilación/peelings/RF)"
-                },
-                {
-                  "en": "After Sun",
-                  "pt": "Pós-sol",
-                  "es": "Post-solar"
-                }
-              ],
-              "title": {
-                "en": "Aesthetics",
-                "pt": "Estética",
-                "es": "Estética"
-              }
-            }
-          ],
-          "specialties": [
             {
               "bullets": [
                 {

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -40,3 +40,8 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 - **What changed**: Flattened locale-specific image objects in the unified pages schema and corrected i18n keys so Netlify builds and Stackbit sync use the same field structure.
 - **Impact & follow-up**: Resolved asset hydration errors during previews and ensures editors only manage one image per locale. Continue monitoring Stackbit sync logs for regressions when adding new unified sections.
 - **References**: [PR #199](https://github.com/ptbandeira/kapunka-new/pull/199) · [Commit 8873572](https://github.com/ptbandeira/kapunka-new/commit/8873572b02dd9db01df958524dc77f9c3e0b3905) · [Visual editor audit](./visual-editor-audit.md)
+
+## 2025-10-04 — Rebuilt pages CMS schema for CTA and banner cleanup
+- **What changed**: Reworked the Decap pages collection so section types reuse shared CTA/link anchors, removed unused `imageUrl` mirrors, and migrated showcase and banner CTAs into nested objects across `content/` and `site/content/`.
+- **Impact & follow-up**: Editors now see grouped CTA controls without duplicate URL inputs, Stackbit models stay aligned, and mirrored content stays in sync. Verify new CTA objects save correctly when editors publish multi-locale updates.
+- **References**: Pending PR

--- a/pages/Method.tsx
+++ b/pages/Method.tsx
@@ -32,7 +32,6 @@ type MethodSection =
       type: 'specialties';
       title?: string;
       items?: SpecialtyItem[];
-      specialties?: SpecialtyItem[];
     };
 
 interface MethodPageContent {
@@ -95,7 +94,7 @@ const isMethodSection = (value: unknown): value is MethodSection => {
   }
 
   if (type === 'specialties') {
-    const items = section.items ?? section.specialties;
+    const items = section.items;
     return (
       (section.title === undefined || typeof section.title === 'string') &&
       Array.isArray(items) &&
@@ -263,7 +262,7 @@ const createMethodKey = (prefix: string, parts: Array<string | null | undefined>
       );
     }
 
-    const specialtyItems = section.specialties ?? section.items ?? [];
+    const specialtyItems = section.items ?? [];
     const specialtyKeyParts = specialtyItems.map((item) =>
       [item.title, ...(item.bullets ?? [])]
         .filter((value): value is string => typeof value === 'string' && value.length > 0)

--- a/site/content/pages/en/clinics.json
+++ b/site/content/pages/en/clinics.json
@@ -32,8 +32,10 @@
     {
       "type": "banner",
       "text": "Explore wholesale and training",
-      "cta": "Contact our team",
-      "url": "/contact"
+      "cta": {
+        "label": "Contact our team",
+        "href": "/contact"
+      }
     }
   ],
   "headerTitle": "Professional Clinic Partnership Program",

--- a/site/content/pages/en/home.json
+++ b/site/content/pages/en/home.json
@@ -33,40 +33,44 @@
           "title": "From gratitude to method",
           "body": "How a simple gesture of care became a therapeutic protocol.",
           "imageAlt": "Hands applying argan oil in warm light",
-          "ctaLabel": "Our Story",
-          "ctaHref": "/about",
           "image": "/content/uploads/9bae3f87-12d5-43f4-a2a0-5cfc768e429d.jpg",
-          "imageUrl": "/content/uploads/roots-olive-tree.jpg"
+          "cta": {
+            "label": "Our Story",
+            "href": "/about"
+          }
         },
         {
           "eyebrow": "For clinics",
           "title": "Trusted by professionals",
           "body": "Used by dermatologists, medspas, and recovery clinics for over a decade.",
           "imageAlt": "Practitioner massaging a client's face with argan care",
-          "ctaLabel": "Partner With Us",
-          "ctaHref": "/clinics",
           "image": "/content/uploads/pexels-elly-fairytale-3865548.jpg",
-          "imageUrl": "/content/uploads/clinic-hands.jpg"
+          "cta": {
+            "label": "Partner With Us",
+            "href": "/clinics"
+          }
         },
         {
           "eyebrow": "Supply chain",
           "title": "Heritage sourcing, clinical standards",
           "body": "From Moroccan cooperatives to hospital rooms.",
           "imageAlt": "Harvested argan fruit gathered in a woven basket",
-          "ctaLabel": "Our Standards",
-          "ctaHref": "/method",
           "image": "/content/uploads/a-woman-picks-fruit-from-an-argan-tree-1-.jpg",
-          "imageUrl": "/content/uploads/argan-coop.jpg"
+          "cta": {
+            "label": "Our Standards",
+            "href": "/method"
+          }
         },
         {
           "eyebrow": "Rituals",
           "title": "From hammam rituals to modern recovery",
           "body": "Ancient wisdom, scientifically structured.",
           "imageAlt": "Steam-filled hammam room with a person resting",
-          "ctaLabel": "Shop Rituals",
-          "ctaHref": "/shop",
           "image": "/content/uploads/342cecc0-3c00-4094-97d6-5c9d9da02330.jpg",
-          "imageUrl": "/content/uploads/hammam-light.jpg"
+          "cta": {
+            "label": "Shop Rituals",
+            "href": "/shop"
+          }
         }
       ]
     },

--- a/site/content/pages/en/method.json
+++ b/site/content/pages/en/method.json
@@ -76,44 +76,6 @@
             "After Sun"
           ]
         }
-      ],
-      "specialties": [
-        {
-          "title": "Pediatrics",
-          "bullets": [
-            "Hydration from 3 months",
-            "Diaper dermatitis",
-            "Atopic dermatitis"
-          ]
-        },
-        {
-          "title": "Dermatology",
-          "bullets": [
-            "Dry, scaly skin",
-            "Psoriasis/dermatitis",
-            "Post-acne or surgery marks"
-          ]
-        },
-        {
-          "title": "Post-op",
-          "bullets": [
-            "Supports faster epithelial recovery with lighter scarring"
-          ]
-        },
-        {
-          "title": "Physio",
-          "bullets": [
-            "Rehabilitative massage",
-            "Skin recovery after dressings"
-          ]
-        },
-        {
-          "title": "Aesthetics",
-          "bullets": [
-            "Post-treatment care (waxing/peels/RF)",
-            "After Sun"
-          ]
-        }
       ]
     }
   ]

--- a/site/content/pages/es/clinics.json
+++ b/site/content/pages/es/clinics.json
@@ -32,8 +32,10 @@
     {
       "type": "banner",
       "text": "Explora mayoristas y capacitación",
-      "cta": "Contacta a nuestro equipo",
-      "url": "/contact"
+      "cta": {
+        "label": "Contacta a nuestro equipo",
+        "href": "/contact"
+      }
     }
   ],
   "headerTitle": "Programa Profesional Kapunka",

--- a/site/content/pages/es/home.json
+++ b/site/content/pages/es/home.json
@@ -32,36 +32,44 @@
           "title": "De la gratitud al método",
           "body": "De un gesto sencillo nació un protocolo terapéutico.",
           "imageAlt": "Manos aplicando aceite de argán con luz cálida",
-          "ctaLabel": "Nuestra historia",
-          "ctaHref": "/about",
-          "image": "/content/uploads/roots-olive-tree.jpg"
+          "image": "/content/uploads/roots-olive-tree.jpg",
+          "cta": {
+            "label": "Nuestra historia",
+            "href": "/about"
+          }
         },
         {
           "eyebrow": "Para clínicas",
           "title": "De confianza profesional",
           "body": "Utilizado desde hace más de una década por dermatólogos y clínicas de recuperación.",
           "imageAlt": "Profesional masajeando el rostro de una clienta con cuidado de argán",
-          "ctaLabel": "Aliarte con nosotros",
-          "ctaHref": "/clinics",
-          "image": "/content/uploads/clinic-hands.jpg"
+          "image": "/content/uploads/clinic-hands.jpg",
+          "cta": {
+            "label": "Aliarte con nosotros",
+            "href": "/clinics"
+          }
         },
         {
           "eyebrow": "Cadena de suministro",
           "title": "Origen con herencia, estándar clínico",
           "body": "De las cooperativas marroquíes a las salas hospitalarias.",
           "imageAlt": "Frutos de argán recién cosechados en una cesta tejida",
-          "ctaLabel": "Nuestros estándares",
-          "ctaHref": "/method",
-          "image": "/content/uploads/argan-coop.jpg"
+          "image": "/content/uploads/argan-coop.jpg",
+          "cta": {
+            "label": "Nuestros estándares",
+            "href": "/method"
+          }
         },
         {
           "eyebrow": "Rituales",
           "title": "Del hammam a la recuperación moderna",
           "body": "Sabiduría ancestral, estructura científica.",
           "imageAlt": "Sala de hammam llena de vapor con una persona descansando",
-          "ctaLabel": "Comprar rituales",
-          "ctaHref": "/shop",
-          "image": "/content/uploads/hammam-light.jpg"
+          "image": "/content/uploads/hammam-light.jpg",
+          "cta": {
+            "label": "Comprar rituales",
+            "href": "/shop"
+          }
         }
       ]
     },

--- a/site/content/pages/es/method.json
+++ b/site/content/pages/es/method.json
@@ -76,44 +76,6 @@
             "Post-solar"
           ]
         }
-      ],
-      "specialties": [
-        {
-          "title": "Pediatría",
-          "bullets": [
-            "Hidratación desde los 3 meses",
-            "Dermatitis del pañal",
-            "Dermatitis atópica"
-          ]
-        },
-        {
-          "title": "Dermatología",
-          "bullets": [
-            "Piel seca y descamada",
-            "Psoriasis/dermatitis",
-            "Marcas postacné o cirugía"
-          ]
-        },
-        {
-          "title": "Postoperatorio",
-          "bullets": [
-            "Favorece una recuperación epitelial más rápida con cicatrices ligeras"
-          ]
-        },
-        {
-          "title": "Fisioterapia",
-          "bullets": [
-            "Masaje rehabilitador",
-            "Recuperación cutánea tras vendajes"
-          ]
-        },
-        {
-          "title": "Estética",
-          "bullets": [
-            "Cuidado posterior a tratamientos (depilación/peelings/RF)",
-            "Post-solar"
-          ]
-        }
       ]
     }
   ]

--- a/site/content/pages/pt/clinics.json
+++ b/site/content/pages/pt/clinics.json
@@ -32,8 +32,10 @@
     {
       "type": "banner",
       "text": "Explore atacado e treinamentos",
-      "cta": "Fale com nossa equipe",
-      "url": "/contact"
+      "cta": {
+        "label": "Fale com nossa equipe",
+        "href": "/contact"
+      }
     }
   ],
   "headerTitle": "Programa Profissional Kapunka",

--- a/site/content/pages/pt/home.json
+++ b/site/content/pages/pt/home.json
@@ -32,36 +32,44 @@
           "title": "Da gratidão ao método",
           "body": "De um gesto simples nasceu um protocolo terapêutico.",
           "imageAlt": "Mãos aplicando óleo de argan sob luz quente",
-          "ctaLabel": "Nossa história",
-          "ctaHref": "/about",
-          "image": "/content/uploads/roots-olive-tree.jpg"
+          "image": "/content/uploads/roots-olive-tree.jpg",
+          "cta": {
+            "label": "Nossa história",
+            "href": "/about"
+          }
         },
         {
           "eyebrow": "Para clínicas",
           "title": "De confiança profissional",
           "body": "Utilizado há mais de uma década por dermatologistas e clínicas de recuperação.",
           "imageAlt": "Profissional massageando o rosto de uma cliente com cuidado de argan",
-          "ctaLabel": "Parceria conosco",
-          "ctaHref": "/clinics",
-          "image": "/content/uploads/clinic-hands.jpg"
+          "image": "/content/uploads/clinic-hands.jpg",
+          "cta": {
+            "label": "Parceria conosco",
+            "href": "/clinics"
+          }
         },
         {
           "eyebrow": "Cadeia de fornecimento",
           "title": "Origem com herança, padrão clínico",
           "body": "Das cooperativas marroquinas às salas de hospital.",
           "imageAlt": "Frutos de argan recém-colhidos em um cesto de palha",
-          "ctaLabel": "Nossos padrões",
-          "ctaHref": "/method",
-          "image": "/content/uploads/argan-coop.jpg"
+          "image": "/content/uploads/argan-coop.jpg",
+          "cta": {
+            "label": "Nossos padrões",
+            "href": "/method"
+          }
         },
         {
           "eyebrow": "Rituais",
           "title": "Do hammam à recuperação moderna",
           "body": "Sabedoria ancestral com estrutura científica.",
           "imageAlt": "Sala de hammam com vapor e uma pessoa relaxando",
-          "ctaLabel": "Comprar rituais",
-          "ctaHref": "/shop",
-          "image": "/content/uploads/hammam-light.jpg"
+          "image": "/content/uploads/hammam-light.jpg",
+          "cta": {
+            "label": "Comprar rituais",
+            "href": "/shop"
+          }
         }
       ]
     },

--- a/site/content/pages/pt/method.json
+++ b/site/content/pages/pt/method.json
@@ -76,44 +76,6 @@
             "Pós-sol"
           ]
         }
-      ],
-      "specialties": [
-        {
-          "title": "Pediatria",
-          "bullets": [
-            "Hidratação a partir dos 3 meses",
-            "Dermatite da fralda",
-            "Dermatite atópica"
-          ]
-        },
-        {
-          "title": "Dermatologia",
-          "bullets": [
-            "Pele seca e descamativa",
-            "Psoríase/dermatite",
-            "Marcas pós-acne ou cirurgia"
-          ]
-        },
-        {
-          "title": "Pós-operatório",
-          "bullets": [
-            "Favorece recuperação epitelial mais rápida com cicatrização leve"
-          ]
-        },
-        {
-          "title": "Fisioterapia",
-          "bullets": [
-            "Massagem reabilitadora",
-            "Recuperação da pele após curativos"
-          ]
-        },
-        {
-          "title": "Estética",
-          "bullets": [
-            "Cuidados pós-tratamento (depilação/peelings/RF)",
-            "Pós-sol"
-          ]
-        }
       ]
     }
   ]

--- a/site/content/pages_v2/index.json
+++ b/site/content/pages_v2/index.json
@@ -219,21 +219,23 @@
           }
         },
         {
-          "cta": {
-            "en": "Contact our team",
-            "pt": "Fale com nossa equipe",
-            "es": "Contacta a nuestro equipo"
-          },
           "text": {
             "en": "Explore wholesale and training",
             "pt": "Explore atacado e treinamentos",
             "es": "Explora mayoristas y capacitación"
           },
           "type": "banner",
-          "url": {
-            "en": "/contact",
-            "pt": "/contact",
-            "es": "/contact"
+          "cta": {
+            "label": {
+              "en": "Contact our team",
+              "pt": "Fale com nossa equipe",
+              "es": "Contacta a nuestro equipo"
+            },
+            "href": {
+              "en": "/contact",
+              "pt": "/contact",
+              "es": "/contact"
+            }
           }
         }
       ],
@@ -1052,14 +1054,6 @@
                 "pt": "De um gesto simples nasceu um protocolo terapêutico.",
                 "es": "De un gesto sencillo nació un protocolo terapéutico."
               },
-              "ctaHref": {
-                "pt": "/about",
-                "es": "/about"
-              },
-              "ctaLabel": {
-                "pt": "Nossa história",
-                "es": "Nuestra historia"
-              },
               "eyebrow": {
                 "pt": "Do blog",
                 "es": "Desde el blog"
@@ -1071,20 +1065,22 @@
               "title": {
                 "pt": "Da gratidão ao método",
                 "es": "De la gratitud al método"
+              },
+              "cta": {
+                "label": {
+                  "pt": "Nossa história",
+                  "es": "Nuestra historia"
+                },
+                "href": {
+                  "pt": "/about",
+                  "es": "/about"
+                }
               }
             },
             {
               "body": {
                 "pt": "Utilizado há mais de uma década por dermatologistas e clínicas de recuperação.",
                 "es": "Utilizado desde hace más de una década por dermatólogos y clínicas de recuperación."
-              },
-              "ctaHref": {
-                "pt": "/clinics",
-                "es": "/clinics"
-              },
-              "ctaLabel": {
-                "pt": "Parceria conosco",
-                "es": "Aliarte con nosotros"
               },
               "eyebrow": {
                 "pt": "Para clínicas",
@@ -1097,20 +1093,22 @@
               "title": {
                 "pt": "De confiança profissional",
                 "es": "De confianza profesional"
+              },
+              "cta": {
+                "label": {
+                  "pt": "Parceria conosco",
+                  "es": "Aliarte con nosotros"
+                },
+                "href": {
+                  "pt": "/clinics",
+                  "es": "/clinics"
+                }
               }
             },
             {
               "body": {
                 "pt": "Das cooperativas marroquinas às salas de hospital.",
                 "es": "De las cooperativas marroquíes a las salas hospitalarias."
-              },
-              "ctaHref": {
-                "pt": "/method",
-                "es": "/method"
-              },
-              "ctaLabel": {
-                "pt": "Nossos padrões",
-                "es": "Nuestros estándares"
               },
               "eyebrow": {
                 "pt": "Cadeia de fornecimento",
@@ -1123,20 +1121,22 @@
               "title": {
                 "pt": "Origem com herança, padrão clínico",
                 "es": "Origen con herencia, estándar clínico"
+              },
+              "cta": {
+                "label": {
+                  "pt": "Nossos padrões",
+                  "es": "Nuestros estándares"
+                },
+                "href": {
+                  "pt": "/method",
+                  "es": "/method"
+                }
               }
             },
             {
               "body": {
                 "pt": "Sabedoria ancestral com estrutura científica.",
                 "es": "Sabiduría ancestral, estructura científica."
-              },
-              "ctaHref": {
-                "pt": "/shop",
-                "es": "/shop"
-              },
-              "ctaLabel": {
-                "pt": "Comprar rituais",
-                "es": "Comprar rituales"
               },
               "eyebrow": {
                 "pt": "Rituais",
@@ -1149,6 +1149,16 @@
               "title": {
                 "pt": "Do hammam à recuperação moderna",
                 "es": "Del hammam a la recuperación moderna"
+              },
+              "cta": {
+                "label": {
+                  "pt": "Comprar rituais",
+                  "es": "Comprar rituales"
+                },
+                "href": {
+                  "pt": "/shop",
+                  "es": "/shop"
+                }
               }
             }
           ],
@@ -1185,12 +1195,6 @@
               "body": {
                 "en": "How a simple gesture of care became a therapeutic protocol."
               },
-              "ctaHref": {
-                "en": "/about"
-              },
-              "ctaLabel": {
-                "en": "Our Story"
-              },
               "description": {
                 "pt": "Amigável para a pele, puro e prensado a frio.",
                 "es": "Amables con la piel, puros y prensados en frío."
@@ -1208,17 +1212,19 @@
               },
               "title": {
                 "en": "From gratitude to method"
+              },
+              "cta": {
+                "label": {
+                  "en": "Our Story"
+                },
+                "href": {
+                  "en": "/about"
+                }
               }
             },
             {
               "body": {
                 "en": "Used by dermatologists, medspas, and recovery clinics for over a decade."
-              },
-              "ctaHref": {
-                "en": "/clinics"
-              },
-              "ctaLabel": {
-                "en": "Partner With Us"
               },
               "description": {
                 "pt": "Texturas de baixa deposição e aromas suaves para pele sensível.",
@@ -1237,17 +1243,19 @@
               },
               "title": {
                 "en": "Trusted by professionals"
+              },
+              "cta": {
+                "label": {
+                  "en": "Partner With Us"
+                },
+                "href": {
+                  "en": "/clinics"
+                }
               }
             },
             {
               "body": {
                 "en": "From Moroccan cooperatives to hospital rooms."
-              },
-              "ctaHref": {
-                "en": "/method"
-              },
-              "ctaLabel": {
-                "en": "Our Standards"
               },
               "description": {
                 "pt": "Conjuntos iniciais e formação para rotinas consistentes em casa.",
@@ -1266,17 +1274,19 @@
               },
               "title": {
                 "en": "Heritage sourcing, clinical standards"
+              },
+              "cta": {
+                "label": {
+                  "en": "Our Standards"
+                },
+                "href": {
+                  "en": "/method"
+                }
               }
             },
             {
               "body": {
                 "en": "Ancient wisdom, scientifically structured."
-              },
-              "ctaHref": {
-                "en": "/shop"
-              },
-              "ctaLabel": {
-                "en": "Shop Rituals"
               },
               "description": {
                 "pt": "Relações justas com as cooperativas de Marrocos.",
@@ -1295,6 +1305,14 @@
               },
               "title": {
                 "en": "From hammam rituals to modern recovery"
+              },
+              "cta": {
+                "label": {
+                  "en": "Shop Rituals"
+                },
+                "href": {
+                  "en": "/shop"
+                }
               }
             }
           ],
@@ -1492,11 +1510,6 @@
             "pt": "Obrigado por se inscrever!",
             "es": "¡Gracias por suscribirte!"
           },
-          "ctaLabel": {
-            "en": "Subscribe",
-            "pt": "Subscrever",
-            "es": "Suscribirme"
-          },
           "placeholder": {
             "en": "Enter your email address",
             "pt": "Introduza o seu e-mail",
@@ -1512,7 +1525,14 @@
             "pt": "Junte-se à Lista",
             "es": "Únete a la Lista"
           },
-          "type": "newsletterSignup"
+          "type": "newsletterSignup",
+          "cta": {
+            "label": {
+              "en": "Subscribe",
+              "pt": "Subscrever",
+              "es": "Suscribirme"
+            }
+          }
         },
         {
           "quotes": [
@@ -2330,108 +2350,6 @@
         },
         {
           "items": [
-            {
-              "bullets": [
-                {
-                  "en": "Hydration from 3 months",
-                  "pt": "Hidratação a partir dos 3 meses",
-                  "es": "Hidratación desde los 3 meses"
-                },
-                {
-                  "en": "Diaper dermatitis",
-                  "pt": "Dermatite da fralda",
-                  "es": "Dermatitis del pañal"
-                },
-                {
-                  "en": "Atopic dermatitis",
-                  "pt": "Dermatite atópica",
-                  "es": "Dermatitis atópica"
-                }
-              ],
-              "title": {
-                "en": "Pediatrics",
-                "pt": "Pediatria",
-                "es": "Pediatría"
-              }
-            },
-            {
-              "bullets": [
-                {
-                  "en": "Dry, scaly skin",
-                  "pt": "Pele seca e descamativa",
-                  "es": "Piel seca y descamada"
-                },
-                {
-                  "en": "Psoriasis/dermatitis",
-                  "pt": "Psoríase/dermatite",
-                  "es": "Psoriasis/dermatitis"
-                },
-                {
-                  "en": "Post-acne or surgery marks",
-                  "pt": "Marcas pós-acne ou cirurgia",
-                  "es": "Marcas postacné o cirugía"
-                }
-              ],
-              "title": {
-                "en": "Dermatology",
-                "pt": "Dermatologia",
-                "es": "Dermatología"
-              }
-            },
-            {
-              "bullets": [
-                {
-                  "en": "Supports faster epithelial recovery with lighter scarring",
-                  "pt": "Favorece recuperação epitelial mais rápida com cicatrização leve",
-                  "es": "Favorece una recuperación epitelial más rápida con cicatrices ligeras"
-                }
-              ],
-              "title": {
-                "en": "Post-op",
-                "pt": "Pós-operatório",
-                "es": "Postoperatorio"
-              }
-            },
-            {
-              "bullets": [
-                {
-                  "en": "Rehabilitative massage",
-                  "pt": "Massagem reabilitadora",
-                  "es": "Masaje rehabilitador"
-                },
-                {
-                  "en": "Skin recovery after dressings",
-                  "pt": "Recuperação da pele após curativos",
-                  "es": "Recuperación cutánea tras vendajes"
-                }
-              ],
-              "title": {
-                "en": "Physio",
-                "pt": "Fisioterapia",
-                "es": "Fisioterapia"
-              }
-            },
-            {
-              "bullets": [
-                {
-                  "en": "Post-treatment care (waxing/peels/RF)",
-                  "pt": "Cuidados pós-tratamento (depilação/peelings/RF)",
-                  "es": "Cuidado posterior a tratamientos (depilación/peelings/RF)"
-                },
-                {
-                  "en": "After Sun",
-                  "pt": "Pós-sol",
-                  "es": "Post-solar"
-                }
-              ],
-              "title": {
-                "en": "Aesthetics",
-                "pt": "Estética",
-                "es": "Estética"
-              }
-            }
-          ],
-          "specialties": [
             {
               "bullets": [
                 {

--- a/stackbit.config.ts
+++ b/stackbit.config.ts
@@ -506,15 +506,10 @@ const customModels = [
         required: false,
       },
       {
-        name: 'ctaLabel',
-        type: 'string',
-        label: 'CTA Label',
-        required: false,
-      },
-      {
-        name: 'ctaHref',
-        type: 'string',
-        label: 'CTA URL',
+        name: 'cta',
+        type: 'model',
+        label: 'CTA',
+        models: ['Link'],
         required: false,
       },
     ],
@@ -759,14 +754,9 @@ const customModels = [
       },
       {
         name: 'cta',
-        type: 'string',
-        label: 'CTA Label',
-        required: false,
-      },
-      {
-        name: 'url',
-        type: 'string',
-        label: 'CTA URL',
+        type: 'model',
+        label: 'CTA',
+        models: ['Link'],
         required: false,
       },
       {


### PR DESCRIPTION
## Summary
- rebuild the Decap pages collection with reusable CTA anchors, expanded localized fields, and reorganized section type definitions
- migrate media showcase and banner content across locales to nested CTA objects while removing redundant fields and syncing the site mirror
- update Stackbit models, React render logic, and documentation to align with the new CTA schema and preserve Visual Editor annotations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dff83463c48320ae42ea34d0438ddb