### PR TITLE
Fix Decap hero i18n configuration

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -63,7 +63,7 @@ collections:
         widget: object
         collapsed: true
         required: false
-        i18n: translate
+        i18n: true
         fields:
           - label: Primary CTA
             name: ctaPrimary
@@ -75,12 +75,12 @@ collections:
                 name: label
                 widget: string
                 required: false
-                i18n: translate
+                i18n: true
               - label: URL
                 name: href
                 widget: string
                 required: false
-                i18n: translate
+                i18n: true
           - label: Secondary CTA
             name: ctaSecondary
             widget: object
@@ -92,7 +92,7 @@ collections:
         widget: object
         collapsed: true
         required: false
-        i18n: translate
+        i18n: true
         fields:
           - label: Horizontal Align
             name: heroAlignX
@@ -147,7 +147,7 @@ collections:
             name: heroOverlay
             widget: string
             required: false
-            i18n: translate
+            i18n: true
       - label: Hero Images
         name: heroImages
         widget: object

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -50,3 +50,8 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 - **What changed**: Removed `i18n: translate` from top-level object and list definitions in `admin/config.yml` after Decap validation flagged the string values for widgets that expect boolean flags.
 - **Impact & follow-up**: Restores CMS load without configuration errors while preserving localized nested fields. No further action required unless additional schema widgets are added.
 - **References**: Pending PR
+
+## 2025-10-05 — Normalized hero object i18n flags
+- **What changed**: Converted the hero CTA and alignment objects in `admin/config.yml` to use boolean `i18n` flags and updated nested link fields so Decap treats the widgets as valid localized objects.
+- **Impact & follow-up**: Decap CMS rebuild succeeds without schema errors for the hero editor, keeping CTA labels, URLs, and overlay tokens translatable across locales.
+- **References**: Pending PR


### PR DESCRIPTION
## Summary
- switch the hero CTA and alignment objects in the Decap schema to the boolean `i18n` mode so object widgets validate
- update nested CTA link fields and the overlay token to use boolean `i18n` flags for locale support without schema errors
- log the configuration tweak in `docs/decap-netlify-rolling-log.md`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e00a74ec288320bc723de1f9f290db