### PR TITLE
Tidy Decap pages field copy and panels

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -24,77 +24,85 @@ collections:
         - es
       default_locale: en
     fields:
-      - label: Page Type
+      - label: Page type
         name: type
         widget: string
+        hint: "Do not change unless you are switching the template layout."
         i18n: duplicate
-      - label: Meta Title
+      - label: Meta title
         name: metaTitle
         widget: string
         required: false
+        hint: "Appears in the browser tab and search results (aim for 60 characters or fewer)."
         i18n: translate
-      - label: Meta Description
+      - label: Meta description
         name: metaDescription
         widget: text
         required: false
+        hint: "Used for search snippets—keep to about 160 characters."
         i18n: translate
-      - label: Hero Headline
+      - label: Hero headline
         name: heroHeadline
         widget: string
         required: false
+        hint: "Primary hero heading shown on the page."
         i18n: translate
-      - label: Hero Subheadline
+      - label: Hero subheadline
         name: heroSubheadline
         widget: text
         required: false
+        hint: "Short supporting copy under the hero headline."
         i18n: translate
-      - label: Hero Title
+      - label: Hero title
         name: heroTitle
         widget: string
         required: false
+        hint: "Legacy hero title for alternate layouts."
         i18n: translate
-      - label: Hero Subtitle
+      - label: Hero subtitle
         name: heroSubtitle
         widget: text
         required: false
+        hint: "Legacy hero subtitle for alternate layouts."
         i18n: translate
-      - label: Hero CTAs
+      - label: Hero calls to action
         name: heroCtas
         widget: object
         collapsed: true
         required: false
         i18n: true
         fields:
-          - label: Primary CTA
+          - label: Primary button
             name: ctaPrimary
             widget: object
             collapsed: true
             required: false
             fields: &link_fields
-              - label: Label
+              - label: Button label
                 name: label
                 widget: string
                 required: false
                 i18n: true
-              - label: URL
+              - label: Button URL
                 name: href
                 widget: string
                 required: false
+                hint: "Use a full URL or a site-relative path (for example, /contact)."
                 i18n: true
-          - label: Secondary CTA
+          - label: Secondary button
             name: ctaSecondary
             widget: object
             collapsed: true
             required: false
             fields: *link_fields
-      - label: Hero Alignment
+      - label: Hero alignment
         name: heroAlignment
         widget: object
         collapsed: true
         required: false
         i18n: true
         fields:
-          - label: Horizontal Align
+          - label: Horizontal alignment
             name: heroAlignX
             widget: select
             options:
@@ -102,7 +110,7 @@ collections:
               - { label: Center, value: center }
               - { label: Right, value: right }
             required: false
-          - label: Vertical Align
+          - label: Vertical alignment
             name: heroAlignY
             widget: select
             options:
@@ -110,14 +118,14 @@ collections:
               - { label: Middle, value: middle }
               - { label: Bottom, value: bottom }
             required: false
-          - label: Text Position
+          - label: Text position
             name: heroTextPosition
             widget: select
             options:
               - { label: Overlay, value: overlay }
               - { label: Below, value: below }
             required: false
-          - label: Text Anchor
+          - label: Text anchor
             name: heroTextAnchor
             widget: select
             options:
@@ -131,7 +139,7 @@ collections:
               - { label: Bottom Center, value: bottom-center }
               - { label: Bottom Right, value: bottom-right }
             required: false
-          - label: Layout Hint
+          - label: Layout hint
             name: heroLayoutHint
             widget: select
             options:
@@ -143,51 +151,55 @@ collections:
               - { label: Background Legacy, value: bg }
               - { label: Background Image Legacy, value: bgImage }
             required: false
-          - label: Overlay Token
+            hint: "Only needed for legacy hero layouts—leave blank for default."
+          - label: Overlay token
             name: heroOverlay
             widget: string
             required: false
+            hint: "Optional design token (for example, overlay-dark)."
             i18n: true
-      - label: Hero Images
+      - label: Hero images
         name: heroImages
         widget: object
         collapsed: true
         required: false
         fields:
-          - label: Left Image
+          - label: Left image
             name: heroImageLeft
             widget: image
             required: false
+            hint: "Upload a JPG or PNG at least 1600px wide for desktop quality."
             i18n: duplicate
-          - label: Right Image
+          - label: Right image
             name: heroImageRight
             widget: image
             required: false
+            hint: "Upload a JPG or PNG at least 1600px wide for desktop quality."
             i18n: duplicate
-      - label: Intro Block
+      - label: Intro block
         name: intro
         widget: object
         collapsed: true
         required: false
         fields:
-          - { label: Title, name: title, widget: string, required: false, i18n: translate }
-          - { label: Primary Copy, name: text1, widget: text, required: false, i18n: translate }
-          - { label: Secondary Copy, name: text2, widget: text, required: false, i18n: translate }
-      - label: Protocol Section
+          - { label: Intro title, name: title, widget: string, required: false, i18n: translate }
+          - { label: Primary copy, name: text1, widget: text, required: false, i18n: translate }
+          - { label: Secondary copy, name: text2, widget: text, required: false, i18n: translate }
+      - label: Protocol section
         name: protocolSection
         widget: object
         collapsed: true
         required: false
         fields:
-          - { label: Title, name: title, widget: string, required: false, i18n: translate }
+          - { label: Section title, name: title, widget: string, required: false, i18n: translate }
           - { label: Subtitle, name: subtitle, widget: text, required: false, i18n: translate }
           - label: Cards
             name: cards
             widget: list
             collapsed: true
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
-              - { label: Focus, name: focus, widget: text, required: false, i18n: translate }
+              - { label: Card title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Focus text, name: focus, widget: text, required: false, i18n: translate }
               - label: Steps
                 name: steps
                 widget: list
@@ -197,21 +209,21 @@ collections:
                   widget: text
                   i18n: translate
               - { label: Evidence, name: evidence, widget: text, required: false, i18n: translate }
-      - label: References Section
+      - label: References section
         name: referencesSection
         widget: object
         collapsed: true
         required: false
         fields:
-          - { label: Title, name: title, widget: string, required: false, i18n: translate }
-          - { label: Studies Title, name: studiesTitle, widget: string, required: false, i18n: translate }
+          - { label: Section title, name: title, widget: string, required: false, i18n: translate }
+          - { label: Studies heading, name: studiesTitle, widget: string, required: false, i18n: translate }
           - label: Studies
             name: studies
             widget: list
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Study title, name: title, widget: string, required: false, i18n: translate }
               - { label: Details, name: details, widget: text, required: false, i18n: translate }
-          - { label: Testimonials Title, name: testimonialsTitle, widget: string, required: false, i18n: translate }
+          - { label: Testimonials heading, name: testimonialsTitle, widget: string, required: false, i18n: translate }
           - label: Testimonials
             name: testimonials
             widget: list
@@ -219,13 +231,13 @@ collections:
               - { label: Quote, name: quote, widget: text, required: false, i18n: translate }
               - { label: Name, name: name, widget: string, required: false, i18n: translate }
               - { label: Credentials, name: credentials, widget: string, required: false, i18n: translate }
-      - label: Keyword Section
+      - label: Keyword section
         name: keywordSection
         widget: object
         collapsed: true
         required: false
         fields:
-          - { label: Title, name: title, widget: string, required: false, i18n: translate }
+          - { label: Section title, name: title, widget: string, required: false, i18n: translate }
           - { label: Subtitle, name: subtitle, widget: text, required: false, i18n: translate }
           - label: Keywords
             name: keywords
@@ -235,13 +247,13 @@ collections:
               name: value
               widget: string
               i18n: translate
-      - label: FAQ Section
+      - label: FAQ section
         name: faqSection
         widget: object
         collapsed: true
         required: false
         fields:
-          - { label: Title, name: title, widget: string, required: false, i18n: translate }
+          - { label: Section title, name: title, widget: string, required: false, i18n: translate }
           - { label: Subtitle, name: subtitle, widget: text, required: false, i18n: translate }
           - label: Questions
             name: items
@@ -249,21 +261,21 @@ collections:
             fields:
               - { label: Question, name: question, widget: string, required: false, i18n: translate }
               - { label: Answer, name: answer, widget: text, required: false, i18n: translate }
-      - label: Learn Categories
+      - label: Learn categories
         name: categories
         widget: list
         collapsed: true
         required: false
         fields:
-          - { label: ID, name: id, widget: string, i18n: duplicate }
-          - { label: Label, name: label, widget: string, i18n: translate }
-      - label: Clinical Notes
+          - { label: Category ID, name: id, widget: string, i18n: duplicate, hint: "Match the ID used in the site code (no spaces)." }
+          - { label: Display label, name: label, widget: string, i18n: translate }
+      - label: Clinical notes
         name: clinicalNotes
         widget: list
         collapsed: true
         required: false
         fields:
-          - { label: Title, name: title, widget: string, required: false, i18n: translate }
+          - { label: Note title, name: title, widget: string, required: false, i18n: translate }
           - label: Bullets
             name: bullets
             widget: list
@@ -272,84 +284,85 @@ collections:
               name: value
               widget: string
               i18n: translate
-      - label: Story Narrative
+      - label: Story narrative
         name: story
         widget: text
         required: false
         i18n: translate
-      - label: Story Tagline
+      - label: Story tagline
         name: tagline
         widget: string
         required: false
         i18n: translate
-      - label: Clinics Header Title
+      - label: Clinics header title
         name: headerTitle
         widget: string
         required: false
         i18n: translate
-      - label: Clinics Header Subtitle
+      - label: Clinics header subtitle
         name: headerSubtitle
         widget: text
         required: false
         i18n: translate
-      - label: Clinics Section Title
+      - label: Clinics section title
         name: section1Title
         widget: string
         required: false
         i18n: translate
-      - label: Clinics Section Copy A
+      - label: Clinics section copy A
         name: section1Text1
         widget: text
         required: false
         i18n: translate
-      - label: Clinics Section Copy B
+      - label: Clinics section copy B
         name: section1Text2
         widget: text
         required: false
         i18n: translate
-      - label: Doctors Title
+      - label: Doctors title
         name: doctorsTitle
         widget: string
         required: false
         i18n: translate
-      - label: Partners Title
+      - label: Partners title
         name: partnersTitle
         widget: string
         required: false
         i18n: translate
-      - label: CTA Title
+      - label: Call-to-action title
         name: ctaTitle
         widget: string
         required: false
         i18n: translate
-      - label: CTA Subtitle
+      - label: Call-to-action subtitle
         name: ctaSubtitle
         widget: text
         required: false
         i18n: translate
-      - label: CTA Button Label
+      - label: Call-to-action button label
         name: ctaButton
         widget: string
         required: false
         i18n: translate
-      - label: Page Title (Test Page)
+      - label: Page title (test page)
         name: title
         widget: string
         required: false
         i18n: translate
-      - label: Sections
+      - label: Page sections
         name: sections
         widget: list
         collapsed: true
         types:
-          - label: Media + Copy
+          - label: Media and copy
             name: mediaCopy
             widget: object
+            collapsed: true
             summary: "{{title}}"
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
-              - { label: Body, name: body, widget: markdown, required: false, i18n: translate }
-              - label: Layout
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Body copy, name: body, widget: markdown, required: false, i18n: translate }
+              - label: Layout option
                 name: layout
                 widget: select
                 options:
@@ -357,24 +370,25 @@ collections:
                   - { label: Image Left, value: image-left }
                   - { label: Overlay, value: overlay }
                 required: false
-              - { label: Columns, name: columns, widget: number, required: false, value_type: int }
-              - label: Image
+              - { label: Column count, name: columns, widget: number, required: false, value_type: int }
+              - label: Section image
                 name: image
                 widget: image
                 required: false
+                hint: "Use a JPG or PNG at least 1200px wide."
                 i18n: duplicate
-              - { label: Alt Text, name: imageAlt, widget: string, required: false, i18n: translate }
-              - label: Overlay Settings
+              - { label: Image alt text, name: imageAlt, widget: string, required: false, i18n: translate }
+              - label: Overlay settings
                 name: overlay
                 widget: object
                 collapsed: true
                 required: false
                 fields:
-                  - { label: Column Start, name: columnStart, widget: number, required: false, value_type: int }
-                  - { label: Column Span, name: columnSpan, widget: number, required: false, value_type: int }
-                  - { label: Row Start, name: rowStart, widget: number, required: false, value_type: int }
-                  - { label: Row Span, name: rowSpan, widget: number, required: false, value_type: int }
-                  - label: Text Align
+                  - { label: Column start, name: columnStart, widget: number, required: false, value_type: int }
+                  - { label: Column span, name: columnSpan, widget: number, required: false, value_type: int }
+                  - { label: Row start, name: rowStart, widget: number, required: false, value_type: int }
+                  - { label: Row span, name: rowSpan, widget: number, required: false, value_type: int }
+                  - label: Text alignment
                     name: textAlign
                     widget: select
                     options:
@@ -382,7 +396,7 @@ collections:
                       - { label: Center, value: center }
                       - { label: Right, value: right }
                     required: false
-                  - label: Vertical Align
+                  - label: Vertical alignment
                     name: verticalAlign
                     widget: select
                     options:
@@ -397,7 +411,7 @@ collections:
                       - { label: Light, value: light }
                       - { label: Dark, value: dark }
                     required: false
-                  - label: Background
+                  - label: Background style
                     name: background
                     widget: select
                     options:
@@ -406,7 +420,7 @@ collections:
                       - { label: Dark Scrim, value: scrim-dark }
                       - { label: Panel, value: panel }
                     required: false
-                  - label: Card Width
+                  - label: Card width
                     name: cardWidth
                     widget: select
                     options:
@@ -414,90 +428,97 @@ collections:
                       - { label: Balanced, value: md }
                       - { label: Wide, value: lg }
                     required: false
-          - label: Media Showcase
+          - label: Media showcase
             name: mediaShowcase
             widget: object
+            collapsed: true
             summary: "{{title}}"
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
-              - label: Highlights
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
+              - label: Highlight cards
                 name: items
                 widget: list
                 collapsed: true
                 fields:
                   - { label: Eyebrow, name: eyebrow, widget: string, required: false, i18n: translate }
-                  - { label: Title, name: title, widget: string, required: false, i18n: translate }
-                  - { label: Body, name: body, widget: text, required: false, i18n: translate }
-                  - label: Image
+                  - { label: Card title, name: title, widget: string, required: false, i18n: translate }
+                  - { label: Body copy, name: body, widget: text, required: false, i18n: translate }
+                  - label: Card image
                     name: image
                     widget: image
                     required: false
+                    hint: "Use a JPG or PNG at least 1200px wide."
                     i18n: duplicate
-                  - { label: Alt Text, name: imageAlt, widget: string, required: false, i18n: translate }
-                  - label: CTA
+                  - { label: Image alt text, name: imageAlt, widget: string, required: false, i18n: translate }
+                  - label: Card CTA
                     name: cta
                     widget: object
                     collapsed: true
                     required: false
                     fields: *link_fields
-          - label: Feature Grid
+          - label: Feature grid
             name: featureGrid
             widget: object
+            collapsed: true
             summary: "{{title}}"
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
-              - { label: Columns, name: columns, widget: number, required: false, value_type: int }
-              - label: Items
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Column count, name: columns, widget: number, required: false, value_type: int }
+              - label: Feature items
                 name: items
                 widget: list
                 fields:
-                  - { label: Label, name: label, widget: string, required: false, i18n: translate }
-                  - { label: Description, name: description, widget: text, required: false, i18n: translate }
-          - label: Product Grid
+                  - { label: Feature title, name: label, widget: string, required: false, i18n: translate }
+                  - { label: Feature description, name: description, widget: text, required: false, i18n: translate }
+          - label: Product grid
             name: productGrid
             widget: object
+            collapsed: true
             summary: "{{title}}"
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
-              - { label: Columns, name: columns, widget: number, required: false, value_type: int }
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Column count, name: columns, widget: number, required: false, value_type: int }
               - label: Products
                 name: products
                 widget: list
                 fields:
-                  - { label: Product ID, name: id, widget: string, i18n: duplicate }
-          - label: Community Carousel
+                  - { label: Product ID, name: id, widget: string, i18n: duplicate, hint: "Use the SKU or slug from the store." }
+          - label: Community carousel
             name: communityCarousel
             widget: object
+            collapsed: true
             summary: "{{title}}"
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
               - label: Slides
                 name: slides
                 widget: list
                 collapsed: true
                 fields:
-                  - label: Image
+                  - label: Slide image
                     name: image
                     widget: image
                     required: false
+                    hint: "Use a JPG or PNG at least 1200px wide."
                     i18n: duplicate
-                  - { label: Alt Text, name: alt, widget: string, required: false, i18n: translate }
+                  - { label: Image alt text, name: alt, widget: string, required: false, i18n: translate }
                   - { label: Quote, name: quote, widget: text, required: false, i18n: translate }
                   - { label: Name, name: name, widget: string, required: false, i18n: translate }
                   - { label: Role, name: role, widget: string, required: false, i18n: translate }
-              - { label: Slide Duration (ms), name: slideDuration, widget: number, required: false, value_type: int }
-              - { label: Quote Duration (ms), name: quoteDuration, widget: number, required: false, value_type: int }
-          - label: Newsletter Signup
+              - { label: Slide duration (ms), name: slideDuration, widget: number, required: false, value_type: int }
+              - { label: Quote duration (ms), name: quoteDuration, widget: number, required: false, value_type: int }
+          - label: Newsletter signup
             name: newsletterSignup
             widget: object
+            collapsed: true
             summary: "{{title}}"
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
               - { label: Subtitle, name: subtitle, widget: text, required: false, i18n: translate }
-              - { label: Email Placeholder, name: placeholder, widget: string, required: false, i18n: translate }
-              - { label: Button Label, name: ctaLabel, widget: string, required: false, i18n: translate }
-              - { label: Confirmation Message, name: confirmation, widget: text, required: false, i18n: translate }
-              - label: Background
+              - { label: Email placeholder, name: placeholder, widget: string, required: false, i18n: translate }
+              - { label: Button label, name: ctaLabel, widget: string, required: false, i18n: translate }
+              - { label: Confirmation message, name: confirmation, widget: text, required: false, i18n: translate }
+              - label: Background style
                 name: background
                 widget: select
                 options:
@@ -505,7 +526,7 @@ collections:
                   - { label: Beige, value: beige }
                   - { label: Dark, value: dark }
                 required: false
-              - label: Alignment
+              - label: Form alignment
                 name: alignment
                 widget: select
                 options:
@@ -515,39 +536,43 @@ collections:
           - label: Testimonials
             name: testimonials
             widget: object
+            collapsed: true
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
               - label: Quotes
                 name: quotes
                 widget: list
                 fields:
                   - { label: Quote, name: text, widget: text, required: false, i18n: translate }
-                  - { label: Author, name: author, widget: string, required: false, i18n: translate }
-                  - { label: Role, name: role, widget: string, required: false, i18n: translate }
+                  - { label: Author name, name: author, widget: string, required: false, i18n: translate }
+                  - { label: Author role, name: role, widget: string, required: false, i18n: translate }
           - label: Banner
             name: banner
             widget: object
+            collapsed: true
             fields:
-              - { label: Text, name: text, widget: text, required: false, i18n: translate }
-              - label: CTA
+              - { label: Banner copy, name: text, widget: text, required: false, i18n: translate }
+              - label: Banner CTA
                 name: cta
                 widget: object
                 collapsed: true
                 required: false
                 fields: *link_fields
-              - { label: Style Variant, name: style, widget: string, required: false, i18n: translate }
+              - { label: Style variant, name: style, widget: string, required: false, i18n: translate }
           - label: Facts
             name: facts
             widget: object
+            collapsed: true
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
-              - { label: Body, name: text, widget: text, required: false, i18n: translate }
-          - label: Bullet List
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Body copy, name: text, widget: text, required: false, i18n: translate }
+          - label: Bullet list
             name: bullets
             widget: object
+            collapsed: true
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
-              - label: Items
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
+              - label: Bullet items
                 name: items
                 widget: list
                 field:
@@ -558,15 +583,16 @@ collections:
           - label: Specialties
             name: specialties
             widget: object
+            collapsed: true
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
-              - label: Specialties
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
+              - label: Specialty groups
                 name: items
                 widget: list
                 collapsed: true
                 fields:
-                  - { label: Title, name: title, widget: string, required: false, i18n: translate }
-                  - label: Bullets
+                  - { label: Group title, name: title, widget: string, required: false, i18n: translate }
+                  - label: Bullet list
                     name: bullets
                     widget: list
                     field:
@@ -574,104 +600,115 @@ collections:
                       name: value
                       widget: string
                       i18n: translate
-          - label: Video Embed
+          - label: Video embed
             name: video
             widget: object
+            collapsed: true
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
-              - { label: Video URL, name: url, widget: string, required: false, i18n: translate }
-          - label: Video Gallery
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Video URL, name: url, widget: string, required: false, i18n: translate, hint: "Paste a full YouTube or Vimeo link." }
+          - label: Video gallery
             name: videoGallery
             widget: object
+            collapsed: true
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
               - { label: Description, name: description, widget: text, required: false, i18n: translate }
-              - label: Entries
+              - label: Video entries
                 name: entries
                 widget: list
                 collapsed: true
                 fields:
-                  - { label: Title, name: title, widget: string, required: false, i18n: translate }
+                  - { label: Video title, name: title, widget: string, required: false, i18n: translate }
                   - { label: Description, name: description, widget: text, required: false, i18n: translate }
-                  - { label: Video URL, name: videoUrl, widget: string, required: false, i18n: translate }
-                  - label: Thumbnail
+                  - { label: Video URL, name: videoUrl, widget: string, required: false, i18n: translate, hint: "Paste a full YouTube or Vimeo link." }
+                  - label: Thumbnail image
                     name: thumbnail
                     widget: image
                     required: false
+                    hint: "Use a JPG or PNG at least 800px wide."
                     i18n: duplicate
-          - label: Training List
+          - label: Training list
             name: trainingList
             widget: object
+            collapsed: true
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
               - { label: Description, name: description, widget: text, required: false, i18n: translate }
-              - label: Entries
+              - label: Courses
                 name: entries
                 widget: list
                 fields:
-                  - { label: Course Title, name: courseTitle, widget: string, required: false, i18n: translate }
+                  - { label: Course title, name: courseTitle, widget: string, required: false, i18n: translate }
                   - { label: Summary, name: courseSummary, widget: text, required: false, i18n: translate }
-                  - { label: Link URL, name: linkUrl, widget: string, required: false, i18n: translate }
-          - label: FAQ Section (Legacy)
+                  - { label: Link URL, name: linkUrl, widget: string, required: false, i18n: translate, hint: "Use a full URL starting with http or https." }
+          - label: FAQ section (legacy)
             name: faq
             widget: object
+            collapsed: true
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
-              - label: Items
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
+              - label: FAQ items
                 name: items
                 widget: list
                 fields:
                   - { label: Question, name: q, widget: string, required: false, i18n: translate }
                   - { label: Answer, name: a, widget: text, required: false, i18n: translate }
-          - label: Timeline (Legacy)
+          - label: Timeline (legacy)
             name: timeline
             widget: object
+            collapsed: true
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
-              - label: Entries
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
+              - label: Timeline entries
                 name: entries
                 widget: list
                 fields:
                   - { label: Year, name: year, widget: string, required: false, i18n: translate }
-                  - { label: Title, name: title, widget: string, required: false, i18n: translate }
+                  - { label: Entry title, name: title, widget: string, required: false, i18n: translate }
                   - { label: Description, name: description, widget: text, required: false, i18n: translate }
-                  - label: Image
+                  - label: Entry image
                     name: image
                     widget: image
                     required: false
+                    hint: "Use a JPG or PNG at least 1200px wide."
                     i18n: duplicate
-          - label: Image + Text Half (Legacy)
+          - label: Image plus text half (legacy)
             name: imageTextHalf
             widget: object
+            collapsed: true
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
               - { label: Subtitle, name: subtitle, widget: string, required: false, i18n: translate }
-              - { label: Body, name: text, widget: markdown, required: false, i18n: translate }
+              - { label: Body copy, name: text, widget: markdown, required: false, i18n: translate }
               - label: Button
                 name: button
                 widget: object
                 collapsed: true
                 required: false
                 fields: *link_fields
-              - label: Image
+              - label: Section image
                 name: image
                 widget: image
                 required: false
+                hint: "Use a JPG or PNG at least 1200px wide."
                 i18n: duplicate
-          - label: Image Grid (Legacy)
+          - label: Image grid (legacy)
             name: imageGrid
             widget: object
+            collapsed: true
             fields:
-              - { label: Title, name: title, widget: string, required: false, i18n: translate }
+              - { label: Section title, name: title, widget: string, required: false, i18n: translate }
               - { label: Description, name: description, widget: text, required: false, i18n: translate }
-              - label: Items
+              - label: Gallery items
                 name: items
                 widget: list
                 fields:
-                  - label: Image
+                  - label: Gallery image
                     name: image
                     widget: image
                     required: false
+                    hint: "Use a JPG or PNG at least 1200px wide."
                     i18n: duplicate
-                  - { label: Alt Text, name: alt, widget: string, required: false, i18n: translate }
+                  - { label: Image alt text, name: alt, widget: string, required: false, i18n: translate }
                   - { label: Caption, name: caption, widget: text, required: false, i18n: translate }

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -55,3 +55,8 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 - **What changed**: Converted the hero CTA and alignment objects in `admin/config.yml` to use boolean `i18n` flags and updated nested link fields so Decap treats the widgets as valid localized objects.
 - **Impact & follow-up**: Decap CMS rebuild succeeds without schema errors for the hero editor, keeping CTA labels, URLs, and overlay tokens translatable across locales.
 - **References**: Pending PR
+
+## 2025-10-05 — Simplified pages field copy and panels
+- **What changed**: Rewrote `admin/config.yml` field labels and helper copy in sentence case, added URL/image guidance, and collapsed each section object so editors scan panels in the order they appear on the live page.
+- **Impact & follow-up**: Editors now see clearer language and grouped controls without affecting translation settings; monitor feedback to confirm the collapsed defaults match editorial expectations.
+- **References**: Pending PR


### PR DESCRIPTION
## Summary
- rewrite page collection labels in `admin/config.yml` with sentence-case copy and helper hints for URLs and imagery
- collapse each sections object so editors expand panels in live-page order and keep translations optional
- log the CMS tweaks in `docs/decap-netlify-rolling-log.md`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e00bd79b3c832080fad168af6da196