### PR TITLE
Add CTA and SEO field anchors to Decap config

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,3 +1,28 @@
+cta_fields: &cta_fields
+  - label: Label
+    name: label
+    widget: string
+    i18n: true
+  - label: URL
+    name: url
+    widget: string
+  - label: Style
+    name: style
+    widget: select
+    options:
+      - primary
+      - secondary
+
+seo_fields: &seo_fields
+  - label: Meta Title
+    name: meta_title
+    widget: string
+    i18n: true
+  - label: Meta Description
+    name: meta_description
+    widget: text
+    i18n: true
+
 backend:
   name: git-gateway
   branch: main

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-12 — Added reusable CTA and SEO anchors
+- **What changed**: Defined `cta_fields` and `seo_fields` YAML anchors in `admin/config.yml` so future object widgets can reuse consistent CTA and SEO field groups.
+- **Impact & follow-up**: Streamlines upcoming schema work by centralising shared field definitions; incorporate the anchors when rebuilding collections.
+- **References**: Pending PR · [`admin/config.yml`](../admin/config.yml)
+
 ## 2025-10-11 — Decap CMS baseline reset
 - **What changed**: Replaced the previous schema-heavy `admin/config.yml` with a minimal setup that keeps the git-gateway backend on `main`, preserves Cloudinary via environment variables, and restores the custom commit templates while clearing all collections.
 - **Impact & follow-up**: CMS now boots with a clean slate and no editor-facing collections; define new collections before inviting editors back in.


### PR DESCRIPTION
## Summary
- define reusable `cta_fields` and `seo_fields` anchors in `admin/config.yml`
- document the Decap configuration change in the rolling log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e040a1b0308320abda27f67d6817b3