### PR TITLE
Add homepage builder schema and seed content

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -53,4 +53,73 @@ commit_messages:
   deleteMedia: "Delete asset {{path}} · {{author-login}}"
   openAuthoring: "{{message}} (Open Authoring)"
 
-collections: []
+collections:
+  - name: home
+    label: "Homepage Builder"
+    files:
+      - file: content/pages/home.json
+        name: home
+        label: "Homepage"
+        fields:
+          - label: "Page Sections"
+            name: sections
+            widget: list
+            types:
+              - label: Hero
+                name: hero
+                widget: object
+                fields:
+                  - label: Headline
+                    name: headline
+                    widget: string
+                    i18n: true
+                  - label: Subtext
+                    name: subtext
+                    widget: text
+                    i18n: true
+                  - label: Background Image
+                    name: background_image
+                    widget: image
+                  - label: CTA
+                    name: cta
+                    widget: object
+                    fields: *cta_fields
+              - label: Showcase
+                name: showcase
+                widget: object
+                fields:
+                  - label: Eyebrow
+                    name: eyebrow
+                    widget: string
+                    i18n: true
+                  - label: Headline
+                    name: headline
+                    widget: string
+                    i18n: true
+                  - label: Text Content
+                    name: text_content
+                    widget: markdown
+                    i18n: true
+                  - label: Media Gallery
+                    name: media_gallery
+                    widget: list
+                    field:
+                      label: Image
+                      name: image
+                      widget: image
+              - label: Contact Banner
+                name: contact_banner
+                widget: object
+                fields:
+                  - label: Headline
+                    name: headline
+                    widget: string
+                    i18n: true
+                  - label: CTA
+                    name: cta
+                    widget: object
+                    fields: *cta_fields
+          - label: SEO
+            name: seo
+            widget: object
+            fields: *seo_fields

--- a/content/pages/home.json
+++ b/content/pages/home.json
@@ -1,0 +1,79 @@
+{
+  "sections": [
+    {
+      "type": "hero",
+      "headline": {
+        "en": "Glow with confidence",
+        "pt": "Brilhe com confiança",
+        "es": "Brilla con confianza"
+      },
+      "subtext": {
+        "en": "Crafting radiant skin rituals with science-backed care.",
+        "pt": "Criamos rituais de pele radiantes com cuidado baseado em ciência.",
+        "es": "Creamos rituales de piel radiantes con cuidado respaldado por la ciencia."
+      },
+      "background_image": "/content/uploads/home-hero-placeholder.jpg",
+      "cta": {
+        "label": {
+          "en": "Explore the method",
+          "pt": "Explore o método",
+          "es": "Explora el método"
+        },
+        "url": "/method",
+        "style": "primary"
+      }
+    },
+    {
+      "type": "showcase",
+      "eyebrow": {
+        "en": "Our signature approach",
+        "pt": "Nossa abordagem exclusiva",
+        "es": "Nuestro enfoque exclusivo"
+      },
+      "headline": {
+        "en": "Designed for every complexion",
+        "pt": "Pensado para cada tipo de pele",
+        "es": "Diseñado para cada tipo de piel"
+      },
+      "text_content": {
+        "en": "Experience layered treatments that respect the skin barrier while restoring balance and glow.",
+        "pt": "Vivencie tratamentos em camadas que respeitam a barreira cutânea enquanto restauram o equilíbrio e o brilho.",
+        "es": "Experimenta tratamientos en capas que respetan la barrera cutánea mientras restauran el equilibrio y el brillo."
+      },
+      "media_gallery": [
+        "/content/uploads/showcase-1.jpg",
+        "/content/uploads/showcase-2.jpg",
+        "/content/uploads/showcase-3.jpg"
+      ]
+    },
+    {
+      "type": "contact_banner",
+      "headline": {
+        "en": "Ready to book your ritual?",
+        "pt": "Pronto para agendar o seu ritual?",
+        "es": "¿Listo para agendar tu ritual?"
+      },
+      "cta": {
+        "label": {
+          "en": "Contact us",
+          "pt": "Fale conosco",
+          "es": "Contáctanos"
+        },
+        "url": "/contact",
+        "style": "secondary"
+      }
+    }
+  ],
+  "seo": {
+    "meta_title": {
+      "en": "Kapunka Home",
+      "pt": "Kapunka Início",
+      "es": "Kapunka Inicio"
+    },
+    "meta_description": {
+      "en": "Discover spa-inspired rituals, curated skincare, and training designed to brighten every complexion.",
+      "pt": "Descubra rituais inspirados em spa, skincare curado e formações pensadas para iluminar cada pele.",
+      "es": "Descubre rituales inspirados en spa, cuidado de la piel curado y formaciones diseñadas para iluminar cada piel."
+    }
+  }
+}

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-13 — Created homepage builder schema
+- **What changed**: Added a new single-file `home` collection in `admin/config.yml` using variable section types and seeded the matching `content/pages/home.json` entry (mirrored in `site/content/`) to support hero, showcase, and contact banner sections plus SEO metadata.
+- **Impact & follow-up**: Editors can now assemble the homepage from reusable sections; add additional section types as the design system grows and keep `site/content/` synced when updating the JSON source.
+- **References**: Pending PR · [`admin/config.yml`](../admin/config.yml) · [`content/pages/home.json`](../content/pages/home.json) · [`site/content/pages/home.json`](../site/content/pages/home.json)
+
 ## 2025-10-12 — Added reusable CTA and SEO anchors
 - **What changed**: Defined `cta_fields` and `seo_fields` YAML anchors in `admin/config.yml` so future object widgets can reuse consistent CTA and SEO field groups.
 - **Impact & follow-up**: Streamlines upcoming schema work by centralising shared field definitions; incorporate the anchors when rebuilding collections.

--- a/site/content/pages/home.json
+++ b/site/content/pages/home.json
@@ -1,0 +1,79 @@
+{
+  "sections": [
+    {
+      "type": "hero",
+      "headline": {
+        "en": "Glow with confidence",
+        "pt": "Brilhe com confiança",
+        "es": "Brilla con confianza"
+      },
+      "subtext": {
+        "en": "Crafting radiant skin rituals with science-backed care.",
+        "pt": "Criamos rituais de pele radiantes com cuidado baseado em ciência.",
+        "es": "Creamos rituales de piel radiantes con cuidado respaldado por la ciencia."
+      },
+      "background_image": "/content/uploads/home-hero-placeholder.jpg",
+      "cta": {
+        "label": {
+          "en": "Explore the method",
+          "pt": "Explore o método",
+          "es": "Explora el método"
+        },
+        "url": "/method",
+        "style": "primary"
+      }
+    },
+    {
+      "type": "showcase",
+      "eyebrow": {
+        "en": "Our signature approach",
+        "pt": "Nossa abordagem exclusiva",
+        "es": "Nuestro enfoque exclusivo"
+      },
+      "headline": {
+        "en": "Designed for every complexion",
+        "pt": "Pensado para cada tipo de pele",
+        "es": "Diseñado para cada tipo de piel"
+      },
+      "text_content": {
+        "en": "Experience layered treatments that respect the skin barrier while restoring balance and glow.",
+        "pt": "Vivencie tratamentos em camadas que respeitam a barreira cutânea enquanto restauram o equilíbrio e o brilho.",
+        "es": "Experimenta tratamientos en capas que respetan la barrera cutánea mientras restauran el equilibrio y el brillo."
+      },
+      "media_gallery": [
+        "/content/uploads/showcase-1.jpg",
+        "/content/uploads/showcase-2.jpg",
+        "/content/uploads/showcase-3.jpg"
+      ]
+    },
+    {
+      "type": "contact_banner",
+      "headline": {
+        "en": "Ready to book your ritual?",
+        "pt": "Pronto para agendar o seu ritual?",
+        "es": "¿Listo para agendar tu ritual?"
+      },
+      "cta": {
+        "label": {
+          "en": "Contact us",
+          "pt": "Fale conosco",
+          "es": "Contáctanos"
+        },
+        "url": "/contact",
+        "style": "secondary"
+      }
+    }
+  ],
+  "seo": {
+    "meta_title": {
+      "en": "Kapunka Home",
+      "pt": "Kapunka Início",
+      "es": "Kapunka Inicio"
+    },
+    "meta_description": {
+      "en": "Discover spa-inspired rituals, curated skincare, and training designed to brighten every complexion.",
+      "pt": "Descubra rituais inspirados em spa, skincare curado e formações pensadas para iluminar cada pele.",
+      "es": "Descubre rituales inspirados en spa, cuidado de la piel curado y formaciones diseñadas para iluminar cada piel."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a home single-file collection in Decap with variable section types and shared CTA/SEO anchors
- seed the new homepage JSON entry with hero, showcase, and contact banner examples and mirror it to site/content
- document the homepage builder addition in the Decap/Netlify rolling log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e0427da7f483208539c96d9d66b297