### PR TITLE
Add Decap standard pages collection

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -123,3 +123,25 @@ collections:
             name: seo
             widget: object
             fields: *seo_fields
+  - name: pages
+    label: "Standard Pages"
+    folder: content/pages/
+    create: true
+    slug: "{{slug}}"
+    fields:
+      - label: Title
+        name: title
+        widget: string
+        i18n: true
+      - label: Hero Image
+        name: hero_image
+        widget: image
+        required: false
+      - label: Body
+        name: body
+        widget: markdown
+        i18n: true
+      - label: SEO
+        name: seo
+        widget: object
+        fields: *seo_fields

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-03 — Added standard pages folder collection
+- **What changed**: Introduced a repeatable `pages` folder collection in `admin/config.yml` for localized standard pages with title, hero image, body, and shared SEO metadata fields.
+- **Impact & follow-up**: Editors can now create new marketing and utility pages without schema work; ensure future content syncing keeps `content/pages/` mirrored into `site/content/pages/`.
+- **References**: Pending PR · [`admin/config.yml`](../admin/config.yml)
+
 ## 2025-10-13 — Created homepage builder schema
 - **What changed**: Added a new single-file `home` collection in `admin/config.yml` using variable section types and seeded the matching `content/pages/home.json` entry (mirrored in `site/content/`) to support hero, showcase, and contact banner sections plus SEO metadata.
 - **Impact & follow-up**: Editors can now assemble the homepage from reusable sections; add additional section types as the design system grows and keep `site/content/` synced when updating the JSON source.


### PR DESCRIPTION
## Summary
- add a Standard Pages folder collection to Decap that reuses the shared SEO fields
- document the new repeatable pages schema in the Decap/Netlify rolling log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e0452e3c3c8320b181c3eb84f8bee8