### PR TITLE
Disable Decap preview for homepage builder

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -56,6 +56,8 @@ commit_messages:
 collections:
   - name: home
     label: "Homepage Builder"
+    editor:
+      preview: false
     files:
       - file: content/pages/home.json
         name: home

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-14 — Disabled homepage builder preview pane
+- **What changed**: Set `editor.preview` to `false` for the `home` collection in `admin/config.yml` so Decap opens the Homepage Builder without the live preview sidebar.
+- **Impact & follow-up**: Editors get a distraction-free, full-width form when editing the homepage; monitor feedback before applying the same treatment to other collections.
+- **References**: Pending PR · [`admin/config.yml`](../admin/config.yml)
+
 ## 2025-10-03 — Added standard pages folder collection
 - **What changed**: Introduced a repeatable `pages` folder collection in `admin/config.yml` for localized standard pages with title, hero image, body, and shared SEO metadata fields.
 - **Impact & follow-up**: Editors can now create new marketing and utility pages without schema work; ensure future content syncing keeps `content/pages/` mirrored into `site/content/pages/`.


### PR DESCRIPTION
## Summary
- disable the live preview pane for the Homepage Builder collection by setting `editor.preview` to false
- document the Decap configuration change in the rolling log for future reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e0cfebd4e88320aefc6e7f77e42c4f