### PR TITLE
Render homepage builder sections dynamically

### DIFF
--- a/components/homepage/ContactBanner.tsx
+++ b/components/homepage/ContactBanner.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import type { HomeContactBannerSection, SectionWithMeta } from '../../homePageBuilderTypes';
+import { resolveCtaClassName, resolveLocalizedText } from './utils';
+
+interface ContactBannerProps extends SectionWithMeta<HomeContactBannerSection> {}
+
+const ContactBanner: React.FC<ContactBannerProps> = ({ headline, cta, language, fieldPath }) => {
+  const resolvedHeadline = resolveLocalizedText(headline, language);
+  const resolvedCtaLabel = resolveLocalizedText(cta?.label, language);
+  const hasCta = Boolean(resolvedCtaLabel && cta?.url);
+
+  if (!resolvedHeadline && !hasCta) {
+    return null;
+  }
+
+  return (
+    <section className="bg-stone-900 py-16 text-white sm:py-20" {...getVisualEditorAttributes(fieldPath)}>
+      <div className="container mx-auto flex max-w-4xl flex-col items-center justify-between gap-6 px-4 text-center sm:flex-row sm:text-left">
+        {resolvedHeadline ? (
+          <h2 className="text-2xl font-semibold sm:text-3xl" {...getVisualEditorAttributes(`${fieldPath}.headline`)}>
+            {resolvedHeadline}
+          </h2>
+        ) : null}
+        {hasCta ? (
+          <a
+            href={cta?.url ?? '#'}
+            className={resolveCtaClassName(cta?.style)}
+            {...getVisualEditorAttributes(`${fieldPath}.cta`)}
+          >
+            {resolvedCtaLabel}
+          </a>
+        ) : null}
+      </div>
+    </section>
+  );
+};
+
+export default ContactBanner;

--- a/components/homepage/Hero.tsx
+++ b/components/homepage/Hero.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import type { HomeHeroSection, SectionWithMeta } from '../../homePageBuilderTypes';
+import { resolveLocalizedText, resolveCtaClassName } from './utils';
+
+interface HeroProps extends SectionWithMeta<HomeHeroSection> {}
+
+const Hero: React.FC<HeroProps> = ({
+  headline,
+  subtext,
+  background_image,
+  cta,
+  language,
+  fieldPath,
+}) => {
+  const resolvedHeadline = resolveLocalizedText(headline, language);
+  const resolvedSubtext = resolveLocalizedText(subtext, language);
+  const resolvedCtaLabel = resolveLocalizedText(cta?.label, language);
+  const hasCta = Boolean(resolvedCtaLabel && cta?.url);
+
+  if (!resolvedHeadline && !resolvedSubtext) {
+    return null;
+  }
+
+  const backgroundImage = background_image?.trim();
+
+  return (
+    <section
+      className="relative isolate overflow-hidden bg-stone-900 text-white"
+      {...getVisualEditorAttributes(fieldPath)}
+    >
+      {backgroundImage ? (
+        <img
+          src={backgroundImage}
+          alt={resolvedHeadline ?? resolvedSubtext ?? 'Hero background'}
+          className="absolute inset-0 h-full w-full object-cover"
+          {...getVisualEditorAttributes(`${fieldPath}.background_image`)}
+        />
+      ) : null}
+      <div className="absolute inset-0 bg-stone-950/60" aria-hidden="true" />
+      <div className="relative mx-auto flex min-h-[70vh] w-full max-w-5xl flex-col items-center justify-center px-4 py-24 text-center sm:px-6 lg:px-8">
+        {resolvedHeadline ? (
+          <h1
+            className="text-4xl font-semibold tracking-tight sm:text-5xl"
+            {...getVisualEditorAttributes(`${fieldPath}.headline`)}
+          >
+            {resolvedHeadline}
+          </h1>
+        ) : null}
+        {resolvedSubtext ? (
+          <p
+            className="mt-6 max-w-2xl text-base text-stone-200 sm:text-lg"
+            {...getVisualEditorAttributes(`${fieldPath}.subtext`)}
+          >
+            {resolvedSubtext}
+          </p>
+        ) : null}
+        {hasCta ? (
+          <div className="mt-10">
+            <a
+              href={cta?.url ?? '#'}
+              className={resolveCtaClassName(cta?.style)}
+              {...getVisualEditorAttributes(`${fieldPath}.cta`)}
+            >
+              {resolvedCtaLabel}
+            </a>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+};
+
+export default Hero;

--- a/components/homepage/Showcase.tsx
+++ b/components/homepage/Showcase.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import type { HomeShowcaseSection, SectionWithMeta } from '../../homePageBuilderTypes';
+import { resolveLocalizedText } from './utils';
+
+interface ShowcaseProps extends SectionWithMeta<HomeShowcaseSection> {}
+
+const Showcase: React.FC<ShowcaseProps> = ({
+  eyebrow,
+  headline,
+  text_content,
+  media_gallery,
+  language,
+  fieldPath,
+}) => {
+  const resolvedEyebrow = resolveLocalizedText(eyebrow, language);
+  const resolvedHeadline = resolveLocalizedText(headline, language);
+  const resolvedText = resolveLocalizedText(text_content, language);
+  const galleryItems = Array.isArray(media_gallery) ? media_gallery.filter(Boolean) : [];
+
+  if (!resolvedHeadline && galleryItems.length === 0 && !resolvedText) {
+    return null;
+  }
+
+  return (
+    <section className="bg-white py-16 sm:py-24" {...getVisualEditorAttributes(fieldPath)}>
+      <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+        {resolvedEyebrow ? (
+          <p
+            className="text-sm uppercase tracking-[0.3em] text-stone-500"
+            {...getVisualEditorAttributes(`${fieldPath}.eyebrow`)}
+          >
+            {resolvedEyebrow}
+          </p>
+        ) : null}
+        {resolvedHeadline ? (
+          <h2
+            className="mt-4 text-3xl font-semibold text-stone-900 sm:text-4xl"
+            {...getVisualEditorAttributes(`${fieldPath}.headline`)}
+          >
+            {resolvedHeadline}
+          </h2>
+        ) : null}
+        {resolvedText ? (
+          <p
+            className="mt-6 text-base text-stone-600 sm:text-lg"
+            {...getVisualEditorAttributes(`${fieldPath}.text_content`)}
+          >
+            {resolvedText}
+          </p>
+        ) : null}
+        {galleryItems.length > 0 ? (
+          <div
+            className="mt-10 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+            {...getVisualEditorAttributes(`${fieldPath}.media_gallery`)}
+          >
+            {galleryItems.map((item, index) => (
+              <div
+                key={`${item}-${index}`}
+                className="overflow-hidden rounded-2xl border border-stone-200 bg-stone-50"
+                {...getVisualEditorAttributes(`${fieldPath}.media_gallery.${index}`)}
+              >
+                <img src={item} alt={resolvedHeadline ?? 'Showcase'} className="h-60 w-full object-cover" />
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+};
+
+export default Showcase;

--- a/components/homepage/utils.ts
+++ b/components/homepage/utils.ts
@@ -1,0 +1,44 @@
+import type { LocalizedText, Language } from '../../types';
+
+const LANGUAGE_FALLBACK_ORDER: Language[] = ['en', 'pt', 'es'];
+
+export const resolveLocalizedText = (
+  value: LocalizedText | undefined,
+  language: Language,
+): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  const candidates: Language[] = [language, ...LANGUAGE_FALLBACK_ORDER.filter((item) => item !== language)];
+  for (const candidate of candidates) {
+    const localized = value[candidate];
+    if (!localized) {
+      continue;
+    }
+
+    const trimmed = localized.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+
+  return undefined;
+};
+
+export const resolveCtaClassName = (style: string | undefined): string => {
+  switch (style) {
+    case 'secondary':
+      return 'inline-flex items-center justify-center rounded-full border border-stone-900 bg-transparent px-6 py-3 text-sm font-semibold text-stone-900 transition hover:bg-stone-900 hover:text-white';
+    case 'link':
+      return 'inline-flex items-center justify-center text-sm font-semibold text-stone-900 underline-offset-4 transition hover:underline';
+    case 'primary':
+    default:
+      return 'inline-flex items-center justify-center rounded-full bg-stone-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-stone-700';
+  }
+};

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-15 — Rendered homepage builder sections in React
+- **What changed**: Introduced a section component map in `pages/Home.tsx` that renders the hero, showcase, and contact banner blocks from `content/pages/home.json` through dedicated React components. Added lightweight presentation components for each section and shared localization helpers to keep Stackbit bindings intact.
+- **Impact & follow-up**: Homepage edits made in Decap now appear in the live preview without manual code updates; extend the component map as new section types are added to the builder schema.
+- **References**: Pending PR · [`pages/Home.tsx`](../pages/Home.tsx) · [`components/homepage/Hero.tsx`](../components/homepage/Hero.tsx) · [`components/homepage/Showcase.tsx`](../components/homepage/Showcase.tsx) · [`components/homepage/ContactBanner.tsx`](../components/homepage/ContactBanner.tsx)
+
 ## 2025-10-15 — Rebuilt homepage sections to match live layout
 - **What changed**: Replaced the Homepage Builder section types in `admin/config.yml` with hero, commitment, product carousel, testimonial carousel, and newsletter CTA groups, including relation-powered pickers for featured products and testimonials.
 - **Impact & follow-up**: Editors now manage the live homepage structure directly in Decap without affecting the front-end rendering; verify initial entries save correctly before wiring additional section types.

--- a/homePageBuilderTypes.ts
+++ b/homePageBuilderTypes.ts
@@ -1,0 +1,44 @@
+import type { LocalizedText, Language } from './types';
+
+export type HomeSectionCtaStyle = 'primary' | 'secondary' | 'link';
+
+export interface HomeSectionCta {
+  label?: LocalizedText;
+  url?: string;
+  style?: HomeSectionCtaStyle;
+}
+
+export interface HomeHeroSection {
+  type: 'hero';
+  headline?: LocalizedText;
+  subtext?: LocalizedText;
+  background_image?: string | null;
+  cta?: HomeSectionCta;
+}
+
+export interface HomeShowcaseSection {
+  type: 'showcase';
+  eyebrow?: LocalizedText;
+  headline?: LocalizedText;
+  text_content?: LocalizedText;
+  media_gallery?: string[];
+}
+
+export interface HomeContactBannerSection {
+  type: 'contact_banner';
+  headline?: LocalizedText;
+  cta?: HomeSectionCta;
+}
+
+export type HomeBuilderSection =
+  | HomeHeroSection
+  | HomeShowcaseSection
+  | HomeContactBannerSection;
+
+export type HomeSectionType = HomeBuilderSection['type'];
+
+export type SectionWithMeta<TSection extends HomeBuilderSection> = TSection & {
+  language: Language;
+  fieldPath: string;
+  index: number;
+};

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -12,6 +12,9 @@ import ImageTextHalf from '../components/sections/ImageTextHalf';
 import ImageGrid from '../components/sections/ImageGrid';
 import CommunityCarousel from '../components/sections/CommunityCarousel';
 import MediaShowcase from '../components/sections/MediaShowcase';
+import Hero from '../components/homepage/Hero';
+import Showcase from '../components/homepage/Showcase';
+import ContactBanner from '../components/homepage/ContactBanner';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
@@ -28,6 +31,14 @@ import type {
 } from '../types';
 import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
+import type {
+  HomeBuilderSection,
+  HomeContactBannerSection,
+  HomeHeroSection,
+  HomeSectionType,
+  HomeShowcaseSection,
+  SectionWithMeta,
+} from '../homePageBuilderTypes';
 
 interface ProductsResponse {
   items?: Product[];
@@ -150,6 +161,20 @@ type HomeSection =
         cta?: CmsCtaShape;
       }>;
     };
+
+type SectionComponentPropsMap = {
+  hero: SectionWithMeta<HomeHeroSection>;
+  showcase: SectionWithMeta<HomeShowcaseSection>;
+  contact_banner: SectionWithMeta<HomeContactBannerSection>;
+};
+
+const sectionComponents: {
+  [Key in keyof SectionComponentPropsMap]: React.ComponentType<SectionComponentPropsMap[Key]>;
+} = {
+  hero: Hero,
+  showcase: Showcase,
+  contact_banner: ContactBanner,
+};
 
 const heroAlignmentSchema = z
   .object({
@@ -1617,19 +1642,16 @@ const Home: React.FC = () => {
   })();
   const [pageContent, setPageContent] = useState<HomePageContent | null>(null);
   const [products, setProducts] = useState<Product[]>([]);
-  const [homeJsonSections, setHomeJsonSections] = useState<unknown[]>([]);
+  const [homeBuilderSections, setHomeBuilderSections] = useState<HomeBuilderSection[]>([]);
 
   useEffect(() => {
     if (Array.isArray(homeContentJson?.sections)) {
-      setHomeJsonSections(homeContentJson.sections as unknown[]);
+      setHomeBuilderSections(homeContentJson.sections as HomeBuilderSection[]);
     } else {
-      setHomeJsonSections([]);
+      setHomeBuilderSections([]);
     }
   }, []);
 
-  useEffect(() => {
-    console.log('Home JSON sections', homeJsonSections);
-  }, [homeJsonSections]);
 
   useEffect(() => {
     let isMounted = true;
@@ -3504,6 +3526,37 @@ const Home: React.FC = () => {
     .map((section, index) => renderSection(section, index))
     .filter(Boolean) as React.ReactNode[];
 
+  const builderFieldPathBase = 'pages.home.sections';
+  const builderSections = homeBuilderSections.filter(
+    (section): section is HomeBuilderSection => {
+      if (!section || typeof section !== 'object') {
+        return false;
+      }
+
+      return Boolean(sectionComponents[section.type as HomeSectionType]);
+    },
+  );
+
+  const renderedBuilderSections = builderSections
+    .map((section, index) => {
+      const type = section.type as HomeSectionType;
+      const Component = sectionComponents[type];
+
+      if (!Component) {
+        return null;
+      }
+
+      const componentProps = {
+        ...section,
+        language,
+        fieldPath: `${builderFieldPathBase}.${index}`,
+        index,
+      } as SectionComponentPropsMap[typeof type];
+
+      return <Component key={`${type}-${index}`} {...componentProps} />;
+    })
+    .filter(Boolean) as React.ReactNode[];
+
   return (
     <div>
       <Helmet>
@@ -3512,6 +3565,8 @@ const Home: React.FC = () => {
       </Helmet>
       {shouldRenderLocalSections ? (
         renderedLocalSections
+      ) : renderedBuilderSections.length > 0 ? (
+        renderedBuilderSections
       ) : (
         <>
           {heroBackgroundImage ? (


### PR DESCRIPTION
## Summary
- render homepage builder sections via a sectionComponents map that feeds the new Hero, Showcase, and Contact Banner blocks
- add localized helper components and shared types for homepage builder data while preserving Stackbit bindings
- document the runtime change in the Decap/Netlify rolling log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e1236c7f5c832080edaf7a6257cf95