### PR TITLE
Configure Decap to use Cloudinary media library

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -546,10 +546,16 @@ editorial:
       - { widget: dashboard }
 local_backend: true
 
-media_folder: "content/uploads"
-public_folder: "/content/uploads"
+media_folder: "/uploads"
+public_folder: "/uploads"
 site_url: https://kapunka-new.netlify.app
 display_url: https://kapunka-new.netlify.app
+
+media_library:
+  name: cloudinary
+  config:
+    cloud_name: "du6xl727e"
+    api_key: "_LAI3fKbumFxgclHTtbAuC-0_co"
 
 collections:
   - name: site

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-07 — Switched Decap media library to Cloudinary
+- **What changed**: Pointed `admin/config.yml` at Cloudinary via the `media_library` block, updated the global media/public folders to `/uploads`, and documented that the API secret must be supplied through the `CLOUDINARY_API_SECRET` environment variable.
+- **Impact & follow-up**: Editors now browse Cloudinary assets from the media picker while existing uploads keep their URLs. Confirm the secret is added to Netlify before enabling production edits.
+- **References**: Pending PR
+
 ## 2025-10-06 — Clarified CMS field guidance & reusable sections
 - **What changed**: Expanded `admin/config.yml` with reusable hero/section anchors, converted relation and list fields to include descriptive hints with character limits, and ensured multilingual inputs are surfaced per locale across site, page, and translation collections.
 - **Impact & follow-up**: Editors now see consistent instructions when updating content, reducing guesswork around limits and localization. Monitor Decap UI to confirm the new hints render cleanly in nested objects and adjust copy if any fields remain ambiguous.


### PR DESCRIPTION
## Summary
- configure Decap CMS to use Cloudinary for asset management and point uploads to the shared /uploads path
- document the Cloudinary migration and environment variable requirements in the rolling log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e25d401de48320b4cf626aac95d498