### PR TITLE
Add SEO metadata and social tags for primary pages

### DIFF
--- a/next/head.tsx
+++ b/next/head.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+
+interface HeadProps {
+  children?: React.ReactNode;
+}
+
+const Head: React.FC<HeadProps> = ({ children }) => {
+  return <Helmet>{children}</Helmet>;
+};
+
+export default Head;
+export { Head };

--- a/pages/ForClinics.tsx
+++ b/pages/ForClinics.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Helmet } from 'react-helmet-async';
+import Head from 'next/head';
 import { motion } from 'framer-motion';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
@@ -186,6 +186,36 @@ const ForClinics: React.FC = () => {
 
   const metaTitle = pageContent?.data.metaTitle ?? t('clinics.title');
   const metaDescription = pageContent?.data.metaDescription ?? t('clinics.metaDescription');
+  const firstSectionImage = useMemo(() => {
+    const sections = pageContent?.data.sections;
+    if (!Array.isArray(sections)) {
+      return undefined;
+    }
+
+    for (const section of sections) {
+      if (!section || typeof section !== 'object') {
+        continue;
+      }
+
+      const sectionRecord = section as Record<string, unknown>;
+      const imageValue = sectionRecord.image;
+
+      if (typeof imageValue === 'string' && imageValue.trim().length > 0) {
+        return imageValue;
+      }
+
+      if (imageValue && typeof imageValue === 'object') {
+        const imageRecord = imageValue as Record<string, unknown>;
+        const srcValue = imageRecord.src;
+        if (typeof srcValue === 'string' && srcValue.trim().length > 0) {
+          return srcValue;
+        }
+      }
+    }
+
+    return undefined;
+  }, [pageContent?.data.sections]);
+  const socialImage = firstSectionImage ?? siteSettings.home?.heroImage;
 
   const headerTitle = pageContent?.data.headerTitle ?? t('clinics.headerTitle');
   const headerSubtitle = pageContent?.data.headerSubtitle ?? t('clinics.headerSubtitle');
@@ -363,10 +393,17 @@ const ForClinics: React.FC = () => {
 
   return (
     <div>
-      <Helmet>
+      <Head>
         <title>{metaTitle} | Kapunka Skincare</title>
         <meta name="description" content={metaDescription} />
-      </Helmet>
+        <meta property="og:title" content={`${metaTitle} | Kapunka Skincare`} />
+        <meta property="og:description" content={metaDescription} />
+        {socialImage ? <meta property="og:image" content={socialImage} /> : null}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={`${metaTitle} | Kapunka Skincare`} />
+        <meta name="twitter:description" content={metaDescription} />
+        {socialImage ? <meta name="twitter:image" content={socialImage} /> : null}
+      </Head>
       <header className="py-20 sm:py-32 bg-stone-100 text-center">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <motion.h1

--- a/pages/FounderStory.tsx
+++ b/pages/FounderStory.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Helmet } from 'react-helmet-async';
+import Head from 'next/head';
 import { motion } from 'framer-motion';
 import { fetchVisualEditorMarkdown } from '../utils/fetchVisualEditorMarkdown';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
+import { useSiteSettings } from '../contexts/SiteSettingsContext';
 
 interface MicroStory {
   quote?: string;
@@ -149,6 +150,7 @@ const FounderStory: React.FC = () => {
   const [content, setContent] = useState<FounderStoryContent | null>(null);
   const [error, setError] = useState<string | null>(null);
   const { contentVersion } = useVisualEditorSync();
+  const { settings: siteSettings } = useSiteSettings();
 
   useEffect(() => {
     let isMounted = true;
@@ -206,21 +208,31 @@ const FounderStory: React.FC = () => {
   }, [content?.body]);
 
   const pageTitle = content?.headline ?? 'Founder Story';
-  const pageDescription = content?.subheadline ?? 'Discover the story behind Kapunka.';
+  const pageDescription =
+    content?.subheadline
+    ?? 'Discover the Kapunka founder story rooted in Berber argan traditions and clinical skincare innovation.';
+  const socialImage = content?.images?.hero?.src ?? siteSettings.home?.heroImage;
 
   return (
     <div className="bg-stone-50 text-stone-800" data-sb-object-id={FOUNDER_STORY_OBJECT_ID}>
-      <Helmet>
+      <Head>
         <title>{pageTitle} | Kapunka Skincare</title>
         <meta name="description" content={pageDescription} />
-      </Helmet>
+        <meta property="og:title" content={`${pageTitle} | Kapunka Skincare`} />
+        <meta property="og:description" content={pageDescription} />
+        {socialImage ? <meta property="og:image" content={socialImage} /> : null}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={`${pageTitle} | Kapunka Skincare`} />
+        <meta name="twitter:description" content={pageDescription} />
+        {socialImage ? <meta name="twitter:image" content={socialImage} /> : null}
+      </Head>
 
       <section className="relative overflow-hidden bg-stone-100">
         {heroImage?.src ? (
           <div className="absolute inset-0">
             <img
               src={heroImage.src}
-              alt={heroImage.alt ?? 'Founder story hero'}
+              alt={heroImage.alt ?? pageTitle}
               className="h-full w-full object-cover opacity-40"
               data-sb-field-path="images.hero.src#@src images.hero.alt#@alt"
             />
@@ -354,7 +366,7 @@ const FounderStory: React.FC = () => {
                   {image.src ? (
                     <img
                       src={image.src}
-                      alt={image.alt ?? 'Founder gallery'}
+                      alt={image.alt ?? pageTitle}
                       className="h-56 w-full object-cover"
                       data-sb-field-path="src#@src alt#@alt"
                     />

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import ReactMarkdown from 'react-markdown';
 import type { Components as MarkdownComponents } from 'react-markdown';
-import { Helmet } from 'react-helmet-async';
+import Head from 'next/head';
 import { z } from 'zod';
 import ProductCard from '../components/ProductCard';
 import TimelineSection from '../components/TimelineSection';
@@ -1271,7 +1271,7 @@ const ClinicsBlock: React.FC<ClinicsBlockProps> = ({ data, fieldPath, fallbackCt
                         >
                             <img
                                 src={clinicsImage}
-                                alt={clinicsTitle ?? 'Clinics highlight'}
+                                alt={clinicsTitle ?? clinicsBody ?? fallbackCtaLabel}
                                 className="w-full rounded-lg shadow-lg object-cover"
                                 {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.clinicsImage` : undefined)}
                             />
@@ -1342,7 +1342,7 @@ const GalleryRows: React.FC<GalleryRowsProps> = ({ rows, fieldPath }) => {
 
                                 const imageSrc = item.image?.trim();
                                 const caption = item.caption?.trim();
-                                const altText = item.alt?.trim() ?? caption ?? 'Gallery highlight';
+                                const altText = item.alt?.trim() ?? caption ?? computedTitle;
                                 const hasContent = Boolean(imageSrc);
 
                                 if (!hasContent) {
@@ -2462,7 +2462,7 @@ const Home: React.FC = () => {
                       {item.icon && (
                         <img
                           src={item.icon}
-                          alt={item.label ?? 'Feature icon'}
+                          alt={item.label ?? sectionTitle ?? computedTitle}
                           className="h-12 w-12 object-contain"
                           {...getVisualEditorAttributes(`${sectionFieldPath}.items.${itemIndex}.icon`)}
                         />
@@ -2552,9 +2552,9 @@ const Home: React.FC = () => {
         const title = sanitizeString((mediaContent?.heading ?? section.title) ?? null);
         const body = sanitizeString((mediaContent?.body ?? section.body) ?? null);
         const mediaImage = sanitizeString(pickImage(mediaContent?.image ?? section.image));
-        const imageAlt = sanitizeString(
-          (mediaContent?.image?.alt ?? section.imageAlt ?? title) ?? null,
-        ) ?? 'Media highlight';
+        const imageAlt =
+          sanitizeString((mediaContent?.image?.alt ?? section.imageAlt ?? title) ?? null)
+          ?? computedTitle;
         if (!title && !body && !mediaImage) {
           return null;
         }
@@ -3018,7 +3018,7 @@ const Home: React.FC = () => {
                       {item.icon && (
                         <img
                           src={item.icon}
-                          alt={item.label ?? 'Feature icon'}
+                          alt={item.label ?? sectionTitle ?? computedTitle}
                           className="h-12 w-12 object-contain"
                           {...getVisualEditorAttributes(`${sectionFieldPath}.items.${itemIndex}.icon`)}
                         />
@@ -3051,7 +3051,7 @@ const Home: React.FC = () => {
         const title = sanitizeString(section.title ?? null);
         const body = sanitizeString(section.body ?? null);
         const mediaImage = sanitizeString(pickImage(section.image));
-        const imageAlt = sanitizeString(section.imageAlt ?? null) ?? title ?? 'Media highlight';
+        const imageAlt = sanitizeString(section.imageAlt ?? null) ?? title ?? computedTitle;
         if (!title && !body && !mediaImage) {
           return null;
         }
@@ -3607,12 +3607,26 @@ const Home: React.FC = () => {
     .map((section, index) => renderSection(section, index))
     .filter(Boolean) as React.ReactNode[];
 
+  const socialImage = heroBackgroundImage
+    ?? heroInlineImage
+    ?? heroImageLeft
+    ?? heroImageRight
+    ?? siteSettings.home?.heroImage
+    ?? undefined;
+
   return (
     <div>
-      <Helmet>
+      <Head>
         <title>{computedTitle}</title>
         <meta name="description" content={computedDescription} />
-      </Helmet>
+        <meta property="og:title" content={computedTitle} />
+        <meta property="og:description" content={computedDescription} />
+        {socialImage ? <meta property="og:image" content={socialImage} /> : null}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={computedTitle} />
+        <meta name="twitter:description" content={computedDescription} />
+        {socialImage ? <meta name="twitter:image" content={socialImage} /> : null}
+      </Head>
       {shouldRenderLocalSections ? (
         renderedLocalSections
       ) : (

--- a/pages/Method.tsx
+++ b/pages/Method.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet-async';
+import Head from 'next/head';
 import { motion } from 'framer-motion';
 import { useLanguage } from '../contexts/LanguageContext';
 import type { Language } from '../types';
 import { fetchVisualEditorMarkdown } from '../utils/fetchVisualEditorMarkdown';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
+import { useSiteSettings } from '../contexts/SiteSettingsContext';
 
 interface SpecialtyItem {
   title: string;
@@ -132,6 +133,7 @@ const Method: React.FC = () => {
   const { language, t } = useLanguage();
   const [content, setContent] = useState<MethodPageContent | null>(null);
   const { contentVersion } = useVisualEditorSync();
+  const { settings: siteSettings } = useSiteSettings();
 
   useEffect(() => {
     let isMounted = true;
@@ -181,6 +183,8 @@ const Method: React.FC = () => {
   const heroSubtitle = content?.heroSubtitle ?? fallbackMetaDescriptions[language];
   const metaTitle = content?.metaTitle ?? heroTitle;
   const metaDescription = content?.metaDescription ?? fallbackMetaDescriptions[language];
+  const pageTitle = `${metaTitle} | Kapunka Skincare`;
+  const socialImage = siteSettings.home?.heroImage;
   const sections = content?.sections ?? [];
   const clinicalNotes = content?.clinicalNotes?.filter((note) => {
     const hasTitle = note.title.trim().length > 0;
@@ -323,10 +327,17 @@ const Method: React.FC = () => {
 
   return (
     <div>
-      <Helmet>
-        <title>{`${metaTitle} | Kapunka Skincare`}</title>
+      <Head>
+        <title>{pageTitle}</title>
         <meta name="description" content={metaDescription} />
-      </Helmet>
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={metaDescription} />
+        {socialImage ? <meta property="og:image" content={socialImage} /> : null}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={metaDescription} />
+        {socialImage ? <meta name="twitter:image" content={socialImage} /> : null}
+      </Head>
 
       <header className="py-20 sm:py-32 bg-stone-100 text-center">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">

--- a/pages/ProductEducation.tsx
+++ b/pages/ProductEducation.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Helmet } from 'react-helmet-async';
+import Head from 'next/head';
 import { motion } from 'framer-motion';
 import { fetchVisualEditorMarkdown } from '../utils/fetchVisualEditorMarkdown';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
+import { useSiteSettings } from '../contexts/SiteSettingsContext';
 
 interface BenefitItem {
   title?: string;
@@ -114,6 +115,7 @@ const ProductEducation: React.FC = () => {
   const [content, setContent] = useState<ProductEducationContent | null>(null);
   const [error, setError] = useState<string | null>(null);
   const { contentVersion } = useVisualEditorSync();
+  const { settings: siteSettings } = useSiteSettings();
 
   useEffect(() => {
     let isMounted = true;
@@ -157,8 +159,10 @@ const ProductEducation: React.FC = () => {
   const faqs = content?.faqs?.filter((faq) => faq && (faq.question?.trim() || faq.answer?.trim())) ?? [];
   const certifications = content?.certifications?.filter((cert) => cert.trim().length > 0) ?? [];
 
-  const metaTitle = content?.headline ?? 'Product Education';
-  const metaDescription = content?.subheadline ?? 'Learn how Kapunka products are composed, certified, and used.';
+  const metaTitle = content?.headline ?? 'Kapunka Product Education';
+  const metaDescription = content?.subheadline ?? 'Learn how Kapunka argan skincare is composed, certified, and used in clinical rituals.';
+  const pageTitle = `${metaTitle} | Kapunka Skincare`;
+  const socialImage = siteSettings.home?.heroImage;
 
   const compositionParagraphs = useMemo(() => {
     if (!content?.composition) {
@@ -173,10 +177,17 @@ const ProductEducation: React.FC = () => {
 
   return (
     <div className="bg-white text-stone-900" data-sb-object-id={PRODUCT_EDUCATION_OBJECT_ID}>
-      <Helmet>
-        <title>{metaTitle} | Kapunka Skincare</title>
+      <Head>
+        <title>{pageTitle}</title>
         <meta name="description" content={metaDescription} />
-      </Helmet>
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={metaDescription} />
+        {socialImage ? <meta property="og:image" content={socialImage} /> : null}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={metaDescription} />
+        {socialImage ? <meta name="twitter:image" content={socialImage} /> : null}
+      </Head>
 
       <section className="bg-stone-100 py-20 sm:py-28">
         <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 text-center">

--- a/pages/Training.tsx
+++ b/pages/Training.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet-async';
+import Head from 'next/head';
 import { motion } from 'framer-motion';
 import SectionRenderer from '../components/_legacy/SectionRenderer';
 import { useLanguage } from '../contexts/LanguageContext';
@@ -7,6 +7,7 @@ import type { PageContent, PageSection } from '../types';
 import { fetchVisualEditorMarkdown } from '../utils/fetchVisualEditorMarkdown';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
+import { useSiteSettings } from '../contexts/SiteSettingsContext';
 
 const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
   'timeline',
@@ -68,6 +69,7 @@ const Training: React.FC = () => {
   const { t, language } = useLanguage();
   const [pageContent, setPageContent] = useState<PageContent | null>(null);
   const { contentVersion } = useVisualEditorSync();
+  const { settings: siteSettings } = useSiteSettings();
 
   useEffect(() => {
     let isMounted = true;
@@ -115,13 +117,21 @@ const Training: React.FC = () => {
   const sectionsFieldPath = `pages.training_${language}.sections`;
   const computedTitle = pageContent?.metaTitle ?? `${t('training.metaTitle')} | Kapunka Skincare`;
   const computedDescription = pageContent?.metaDescription ?? t('training.metaDescription');
+  const socialImage = siteSettings.home?.heroImage;
 
   return (
     <div>
-      <Helmet>
+      <Head>
         <title>{computedTitle}</title>
         <meta name="description" content={computedDescription} />
-      </Helmet>
+        <meta property="og:title" content={computedTitle} />
+        <meta property="og:description" content={computedDescription} />
+        {socialImage ? <meta property="og:image" content={socialImage} /> : null}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={computedTitle} />
+        <meta name="twitter:description" content={computedDescription} />
+        {socialImage ? <meta name="twitter:image" content={socialImage} /> : null}
+      </Head>
 
       <header className="py-20 sm:py-28 bg-stone-100">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,9 @@
     "paths": {
       "@/*": [
         "./*"
+      ],
+      "next/*": [
+        "./next/*"
       ]
     },
     "resolveJsonModule": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,10 @@ export default defineConfig(({ mode }) => {
       "process.env.GEMINI_API_KEY": JSON.stringify(env.GEMINI_API_KEY)
     },
     resolve: {
-      alias: { "@": path.resolve(__dirname, ".") }
+      alias: {
+        "@": path.resolve(__dirname, "."),
+        "next": path.resolve(__dirname, "next")
+      }
     },
     server: {
       host: true,                 // accept requests from Netlify's proxy


### PR DESCRIPTION
## Summary
- add a Next-style Head shim and configure Vite/TypeScript to resolve it
- inject SEO, Open Graph, and Twitter metadata across Home, Method, Training, Product Education, Founder Story, and For Clinics pages
- ensure page imagery uses CMS-driven alt text for accessible descriptions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68e25fd10c4c83209ea4893cbacfbe0d