### PR TITLE
Remove legacy test page slug from CMS configuration

### DIFF
--- a/content/pages/en/test.md
+++ b/content/pages/en/test.md
@@ -1,4 +1,0 @@
----
-type: TestPage
-title: This is a test page
----

--- a/content/pages_v2/index.json
+++ b/content/pages_v2/index.json
@@ -2723,19 +2723,6 @@
       ]
     },
     {
-      "id": "test",
-      "label": "Test",
-      "slug": "/test",
-      "fields": [
-        {
-          "key": "title",
-          "value": {
-            "en": "This is a test page"
-          }
-        }
-      ]
-    },
-    {
       "id": "training",
       "label": "Training Hub",
       "slug": "/training",

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-05 — Retired legacy test page from CMS
+- **What changed**: Removed the unused `TestPage` model from `stackbit.config.ts`, dropped the `/test` entry from the unified pages index, and deleted the lone English markdown file so every published page now has matching `en`, `es`, and `pt` sources.
+- **Impact & follow-up**: Editors no longer see the orphaned test entry in Decap/Stackbit, eliminating a source of partial translations. Confirm Netlify previews rebuild without referencing the retired slug and watch for any lingering `/test` links in future content audits.
+- **References**: Pending PR
+
 ## 2025-10-09 — Added manifesto content model for Story page
 - **What changed**: Extended `admin/config.yml` with dedicated fields for the Story/Manifesto page (hero text, manifesto statements, values grid, and closing copy), translated the new UI strings, and rewrote the localized `content/pages/*/story.md` entries to match the schema.
 - **Impact & follow-up**: Editors can now manage the manifesto narrative and value pillars directly from Decap and the Visual Editor. Monitor upcoming edits to ensure the new list and markdown fields save correctly across locales.

--- a/stackbit.config.ts
+++ b/stackbit.config.ts
@@ -15,7 +15,6 @@ const localizedPageRoutes = [
   { slug: 'story', urlPath: '/story' },
   { slug: 'training', urlPath: '/training' },
   { slug: 'videos', urlPath: '/videos' },
-  { slug: 'test', urlPath: '/test' },
   { slug: 'method', urlPath: '/method' },
 ];
 
@@ -2067,20 +2066,6 @@ const customModels = [
           type: 'model',
           models: ['Policy'],
         },
-      },
-    ],
-  },
-  {
-    name: 'TestPage',
-    type: 'page',
-    label: 'Test Page',
-    filePath: 'content/pages/{lang}/test.md',
-    urlPath: '/test',
-    fields: [
-      {
-        type: 'string',
-        name: 'title',
-        label: 'Title',
       },
     ],
   },

--- a/utils/stackbitBindings.ts
+++ b/utils/stackbitBindings.ts
@@ -129,7 +129,6 @@ const LEGACY_PAGE_MODEL_BY_SLUG: Record<string, string> = {
   learn: 'LearnPage',
   videos: 'VideosPage',
   training: 'TrainingPage',
-  test: 'TestPage',
   'founder-story': 'FoundersStoryPage',
   'method-kapunka': 'MethodKapunkaPage',
   'training-program': 'TrainingProgramPage',


### PR DESCRIPTION
## Summary
- remove the obsolete TestPage route/model from the Stackbit config and legacy binding map so only real locales are surfaced
- delete the leftover /test entry from the unified pages index and drop the unused markdown stub to keep locale coverage consistent
- record the cleanup in the Decap/Netlify rolling log for editorial visibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e26dd4971483208e587cf7f43d8ff3