### PR TITLE
Update header navigation manifesto link

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -85,12 +85,10 @@ const Header: React.FC = () => {
   const NAV_LINK_CONFIG: Array<{ path: string; key: string }> = [
     { path: '/shop', key: 'shop' },
     { path: '/learn', key: 'learn' },
-    { path: '/story', key: 'story' },
+    { path: '/story', key: 'manifesto' },
     { path: '/videos', key: 'videos' },
     { path: '/training-program', key: 'training' },
     { path: '/method-kapunka', key: 'method' },
-    { path: '/product-education', key: 'productEducation' },
-    { path: '/founder-story', key: 'founderStory' },
     { path: '/for-clinics', key: 'forClinics' },
     { path: '/about', key: 'about' },
     { path: '/contact', key: 'contact' },

--- a/content/translations/nav.json
+++ b/content/translations/nav.json
@@ -7,11 +7,9 @@
     "training": "Training",
     "method": "Method Kapunka",
     "forClinics": "For Clinics",
-    "story": "Manifesto",
+    "manifesto": "Manifesto & Story",
     "about": "About",
-    "contact": "Contact",
-    "productEducation": "Product Education",
-    "founderStory": "Founder's Story"
+    "contact": "Contact"
   },
   "pt": {
     "shop": "Loja",
@@ -20,11 +18,9 @@
     "training": "Treinamento",
     "method": "Método Kapunka",
     "forClinics": "Para Clínicas",
-    "story": "Manifesto",
+    "manifesto": "Manifesto & História",
     "about": "Sobre",
-    "contact": "Contato",
-    "productEducation": "Educação de Produto",
-    "founderStory": "História da Fundadora"
+    "contact": "Contato"
   },
   "es": {
     "shop": "Tienda",
@@ -33,10 +29,8 @@
     "training": "Formación",
     "method": "Método Kapunka",
     "forClinics": "Para Clínicas",
-    "story": "Manifiesto",
+    "manifesto": "Manifiesto e Historia",
     "about": "Nosotros",
-    "contact": "Contacto",
-    "productEducation": "Educación de Producto",
-    "founderStory": "Historia de la Fundadora"
+    "contact": "Contacto"
   }
 }

--- a/pages/Story.tsx
+++ b/pages/Story.tsx
@@ -194,7 +194,7 @@ const Story: React.FC = () => {
   }, [pageContent?.sections]);
 
   const computedTitle = useMemo(() => {
-    const baseTitle = pageContent?.metaTitle ?? t('nav.story');
+    const baseTitle = pageContent?.metaTitle ?? t('nav.manifesto');
     return baseTitle.includes('Kapunka') ? baseTitle : `${baseTitle} | Kapunka Skincare`;
   }, [pageContent?.metaTitle, t]);
 
@@ -214,9 +214,9 @@ const Story: React.FC = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
             className="text-4xl sm:text-5xl font-semibold tracking-tight"
-            {...getVisualEditorAttributes(`translations.${language}.nav.story`)}
+            {...getVisualEditorAttributes(`translations.${language}.nav.manifesto`)}
           >
-            {t('nav.story')}
+            {t('nav.manifesto')}
           </motion.h1>
           {pageContent?.tagline ? (
             <motion.p

--- a/pages/story.tsx
+++ b/pages/story.tsx
@@ -270,7 +270,7 @@ const StoryManifestoPage: React.FC = () => {
   }, [pageContent?.closing]);
 
   const computedTitle = useMemo(() => {
-    const baseTitle = pageContent?.metaTitle ?? t('nav.story');
+    const baseTitle = pageContent?.metaTitle ?? t('nav.manifesto');
     return baseTitle.includes('Kapunka') ? baseTitle : `${baseTitle} | Kapunka Skincare`;
   }, [pageContent?.metaTitle, t]);
 
@@ -294,7 +294,7 @@ const StoryManifestoPage: React.FC = () => {
             className="text-4xl sm:text-5xl font-semibold tracking-tight"
             {...getVisualEditorAttributes(`${storyFieldPath}.heroTitle`)}
           >
-            {pageContent?.heroTitle ?? t('nav.story')}
+            {pageContent?.heroTitle ?? t('nav.manifesto')}
           </motion.h1>
           {isNonEmptyString(pageContent?.heroSubtitle) ? (
             <motion.p


### PR DESCRIPTION
## Summary
- rename the story navigation entry to manifesto and drop unused product and founder links from the header
- update nav translations to provide manifesto labels across locales
- align story pages with the new manifesto translation key usage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e28ab3d8d0832096c0b446d69a649d