### PR TITLE
Add localized For Clinics page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -28,7 +28,7 @@ const Shop = lazy(() => import('./pages/Shop'));
 const ProductDetail = lazy(() => import('./pages/ProductDetail'));
 const Learn = lazy(() => import('./pages/Learn'));
 const ArticlePage = lazy(() => import('./pages/Article'));
-const ForClinics = lazy(() => import('./pages/ForClinics'));
+const ForClinics = lazy(() => import('./pages/for-clinics'));
 const About = lazy(() => import('./pages/About'));
 const StoryManifestoPage = lazy(() => import('./pages/story'));
 const Contact = lazy(() => import('./pages/Contact'));

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -925,6 +925,18 @@ collections:
         fields:
           - *meta_title_field
           - *meta_description_field
+          - label: "Hero Title"
+            name: "heroTitle"
+            widget: "string"
+            i18n: true
+            required: false
+            hint: "Primary hero heading introducing the Clinics page (≤80 characters)."
+          - label: "Hero Subtitle"
+            name: "heroSubtitle"
+            widget: "text"
+            i18n: true
+            required: false
+            hint: "Supporting hero paragraph for clinics (≤200 characters)."
           - label: "Header Title"
             name: "headerTitle"
             widget: "string"

--- a/content/pages/en/clinics.md
+++ b/content/pages/en/clinics.md
@@ -5,6 +5,11 @@ metaDescription: >-
   B2B skincare supply for post-treatment skin care. Access
   dermatologist-approved argan oil, clinical protocols, and training for your
   clinic.
+heroTitle: Professional Clinic Partnership Program
+heroSubtitle: >-
+  Deliver consistent post-treatment skin care with dermatologist-approved argan
+  oil and minimalist, clinic-tested formulas tailored for recovery and hormonal
+  hydration.
 sections:
   - type: mediaCopy
     title: From operating room to everyday routine

--- a/content/pages/es/clinics.md
+++ b/content/pages/es/clinics.md
@@ -5,6 +5,11 @@ metaDescription: >-
   Suministro B2B de cuidado de la piel para el post-tratamiento. Accede a aceite
   de argán aprobado por dermatólogos, protocolos clínicos y capacitación para tu
   clínica.
+heroTitle: Programa Profesional Kapunka
+heroSubtitle: >-
+  Ofrece un cuidado post-tratamiento coherente con aceite de argán aprobado por
+  dermatólogos y fórmulas minimalistas probadas en clínica para la recuperación
+  y la hidratación hormonal.
 sections:
   - type: mediaCopy
     title: Del quirófano a la rutina diaria

--- a/content/pages/pt/clinics.md
+++ b/content/pages/pt/clinics.md
@@ -5,6 +5,11 @@ metaDescription: >-
   Fornecimento B2B de skincare para cuidados pós-tratamento. Acesse óleo de
   argan aprovado por dermatologistas, protocolos clínicos e treinamento para a
   sua clínica.
+heroTitle: Programa Profissional Kapunka
+heroSubtitle: >-
+  Ofereça cuidados pós-tratamento consistentes com óleo de argan aprovado por
+  dermatologistas e fórmulas minimalistas testadas em clínica para recuperação e
+  hidratação hormonal.
 sections:
   - type: mediaCopy
     title: Do centro cirúrgico à rotina diária

--- a/content/translations/clinics.json
+++ b/content/translations/clinics.json
@@ -2,7 +2,10 @@
   "type": "translations_clinics",
   "en": {
     "title": "Professional Clinic Partnerships",
+    "metaTitle": "For Clinics — Trusted, simple, teachable",
     "metaDescription": "B2B skincare supply for post-treatment skin care. Access dermatologist-approved argan oil, clinical protocols, and training for your clinic.",
+    "heroTitle": "Professional Clinic Partnership Program",
+    "heroSubtitle": "Deliver consistent post-treatment skin care with dermatologist-approved argan oil and minimalist, clinic-tested formulas tailored for recovery and hormonal hydration.",
     "headerTitle": "Professional Clinic Partnership Program",
     "headerSubtitle": "Deliver consistent post-treatment skin care with dermatologist-approved argan oil and minimalist, clinic-tested formulas tailored for recovery and hormonal hydration.",
     "section1Title": "Evidence-Led Support for Every Treatment Room",
@@ -121,7 +124,10 @@
   },
   "pt": {
     "title": "Parcerias Profissionais para Clínicas",
+    "metaTitle": "Para clínicas — Confiável, simples, ensinável",
     "metaDescription": "Fornecimento B2B de skincare para cuidados pós-tratamento. Acesse óleo de argan aprovado por dermatologistas, protocolos clínicos e treinamento para a sua clínica.",
+    "heroTitle": "Programa Profissional Kapunka",
+    "heroSubtitle": "Ofereça cuidados pós-tratamento consistentes com óleo de argan aprovado por dermatologistas e fórmulas minimalistas testadas em clínica para recuperação e hidratação hormonal.",
     "headerTitle": "Programa Profissional Kapunka",
     "headerSubtitle": "Ofereça cuidados pós-tratamento consistentes com óleo de argan aprovado por dermatologistas e fórmulas minimalistas testadas em clínica para recuperação e hidratação hormonal.",
     "section1Title": "Suporte baseado em evidências para cada sala de tratamento",
@@ -240,7 +246,10 @@
   },
   "es": {
     "title": "Alianzas Profesionales para Clínicas",
+    "metaTitle": "Para clínicas — Confiable, sencillo, enseñable",
     "metaDescription": "Suministro B2B de cuidado de la piel para el post-tratamiento. Accede a aceite de argán aprobado por dermatólogos, protocolos clínicos y capacitación para tu clínica.",
+    "heroTitle": "Programa Profesional Kapunka",
+    "heroSubtitle": "Ofrece un cuidado post-tratamiento coherente con aceite de argán aprobado por dermatólogos y fórmulas minimalistas probadas en clínica para la recuperación y la hidratación hormonal.",
     "headerTitle": "Programa Profesional Kapunka",
     "headerSubtitle": "Ofrece un post-treatment skin care coherente con aceite de argán aprobado por dermatólogos y fórmulas minimalistas, probadas en clínica para la recuperación y la hidratación hormonal.",
     "section1Title": "Soporte basado en evidencia para cada sala de tratamiento",

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -95,3 +95,8 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 - **What changed**: Added dedicated `testimonials` and updated `partners` collections in Decap, introduced reusable testimonial entries with language metadata, and rewired the Clinics/Home pages plus Stackbit bindings to consume relation-selected testimonials and richer partner descriptions.
 - **Impact & follow-up**: Editors can now reuse quotes across locales without copy/paste while enriching the “Trusted by clinicians” carousel. Monitor new testimonial entries to confirm relation widgets save the expected `fileRelativePath` values.
 - **References**: Pending PR
+
+## 2025-10-06 — Added simplified For Clinics hero and section overrides
+- **What changed**: Introduced a new `pages/for-clinics.tsx` layout that pulls meta, hero, and section copy from translations with Markdown overrides. Added `heroTitle`/`heroSubtitle` fields to the clinics Markdown entries plus matching translation keys, and exposed the hero controls in `admin/config.yml` so editors can manage the new page.
+- **Impact & follow-up**: The For Clinics experience now loads faster with a streamlined hero and curated sections while remaining fully editable in the Visual Editor and Decap. Verify Stackbit bindings continue to resolve correctly when switching locales in the Visual Editor.
+- **References**: Pending PR

--- a/pages/for-clinics.tsx
+++ b/pages/for-clinics.tsx
@@ -1,0 +1,555 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import Head from 'next/head';
+import { motion } from 'framer-motion';
+import { useLanguage } from '../contexts/LanguageContext';
+import { useSiteSettings } from '../contexts/SiteSettingsContext';
+import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
+import { getVisualEditorAttributes } from '../utils/stackbitBindings';
+import {
+  loadClinicsPageContent,
+  type ClinicsPageContentResult,
+} from '../utils/loadClinicsPageContent';
+
+interface ProtocolCard {
+  title?: string;
+  focus?: string;
+  steps?: string[];
+  evidence?: string;
+}
+
+interface ProtocolSection {
+  title?: string;
+  subtitle?: string;
+  cards?: ProtocolCard[];
+}
+
+interface TextWithFieldPath {
+  value: string;
+  fieldPath: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+);
+
+const isStringArray = (value: unknown): value is string[] => (
+  Array.isArray(value) && value.every((item) => typeof item === 'string')
+);
+
+const isProtocolCard = (value: unknown): value is ProtocolCard => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { title, focus, steps, evidence } = value as Record<string, unknown>;
+
+  const titleValid = title === undefined || typeof title === 'string';
+  const focusValid = focus === undefined || typeof focus === 'string';
+  const stepsValid = steps === undefined || isStringArray(steps);
+  const evidenceValid = evidence === undefined || typeof evidence === 'string';
+
+  return titleValid && focusValid && stepsValid && evidenceValid;
+};
+
+const isProtocolSection = (value: unknown): value is ProtocolSection => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { title, subtitle, cards } = value as Record<string, unknown>;
+
+  const titleValid = title === undefined || typeof title === 'string';
+  const subtitleValid = subtitle === undefined || typeof subtitle === 'string';
+  const cardsValid = cards === undefined || (
+    Array.isArray(cards) && cards.every(isProtocolCard)
+  );
+
+  return titleValid && subtitleValid && cardsValid;
+};
+
+const hasContent = (value: unknown): value is string => (
+  typeof value === 'string' && value.trim().length > 0
+);
+
+const ForClinics: React.FC = () => {
+  const { t, language } = useLanguage();
+  const { settings } = useSiteSettings();
+  const { contentVersion } = useVisualEditorSync();
+  const [pageContent, setPageContent] = useState<ClinicsPageContentResult | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    setPageContent(null);
+
+    loadClinicsPageContent(language)
+      .then((result) => {
+        if (!isMounted) {
+          return;
+        }
+
+        setPageContent(result);
+      })
+      .catch((error) => {
+        console.error('Failed to load clinics page content', error);
+        if (isMounted) {
+          setPageContent(null);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [language, contentVersion]);
+
+  const clinicsFieldPath = useMemo(() => {
+    if (!pageContent) {
+      return `pages.clinics_${language}`;
+    }
+
+    return pageContent.source === 'visual-editor'
+      ? `site.content.${pageContent.locale}.pages.clinics`
+      : `pages.clinics_${pageContent.locale}`;
+  }, [language, pageContent]);
+
+  const translationsFieldPath = `translations.${language}.clinics`;
+
+  const baseMetaTitle = hasContent(pageContent?.data.metaTitle)
+    ? pageContent?.data.metaTitle ?? ''
+    : hasContent(t<string>('clinics.metaTitle'))
+      ? t<string>('clinics.metaTitle')
+      : t<string>('clinics.title');
+
+  const pageTitle = baseMetaTitle.includes('Kapunka')
+    ? baseMetaTitle
+    : `${baseMetaTitle} | Kapunka Skincare`;
+
+  const metaDescription = hasContent(pageContent?.data.metaDescription)
+    ? pageContent?.data.metaDescription
+    : t<string>('clinics.metaDescription');
+
+  const heroTitleSource = (() => {
+    if (hasContent(pageContent?.data.heroTitle)) {
+      return {
+        value: pageContent?.data.heroTitle ?? '',
+        fieldPath: `${clinicsFieldPath}.heroTitle`,
+      };
+    }
+
+    if (hasContent(pageContent?.data.headerTitle)) {
+      return {
+        value: pageContent?.data.headerTitle ?? '',
+        fieldPath: `${clinicsFieldPath}.headerTitle`,
+      };
+    }
+
+    if (hasContent(t<string>('clinics.heroTitle'))) {
+      return {
+        value: t<string>('clinics.heroTitle'),
+        fieldPath: `${translationsFieldPath}.heroTitle`,
+      };
+    }
+
+    return {
+      value: t<string>('clinics.headerTitle'),
+      fieldPath: `${translationsFieldPath}.headerTitle`,
+    };
+  })();
+
+  const heroSubtitleSource = (() => {
+    if (hasContent(pageContent?.data.heroSubtitle)) {
+      return {
+        value: pageContent?.data.heroSubtitle ?? '',
+        fieldPath: `${clinicsFieldPath}.heroSubtitle`,
+      };
+    }
+
+    if (hasContent(pageContent?.data.headerSubtitle)) {
+      return {
+        value: pageContent?.data.headerSubtitle ?? '',
+        fieldPath: `${clinicsFieldPath}.headerSubtitle`,
+      };
+    }
+
+    if (hasContent(t<string>('clinics.heroSubtitle'))) {
+      return {
+        value: t<string>('clinics.heroSubtitle'),
+        fieldPath: `${translationsFieldPath}.heroSubtitle`,
+      };
+    }
+
+    return {
+      value: t<string>('clinics.headerSubtitle'),
+      fieldPath: `${translationsFieldPath}.headerSubtitle`,
+    };
+  })();
+
+  const protocolSectionSource = (() => {
+    if (isProtocolSection(pageContent?.data.protocolSection)) {
+      return {
+        data: pageContent?.data.protocolSection as ProtocolSection,
+        fieldPath: `${clinicsFieldPath}.protocolSection`,
+      };
+    }
+
+    const translationProtocolSection = t<unknown>('clinics.protocolSection');
+    if (isProtocolSection(translationProtocolSection)) {
+      return {
+        data: translationProtocolSection,
+        fieldPath: `${translationsFieldPath}.protocolSection`,
+      };
+    }
+
+    return null;
+  })();
+
+  const protocolCards = protocolSectionSource?.data.cards?.filter((card) => (
+    hasContent(card.title) || hasContent(card.focus) || isStringArray(card.steps) || hasContent(card.evidence)
+  )) ?? [];
+
+  const benefitsTitleSource = hasContent(pageContent?.data.section1Title)
+    ? {
+        value: pageContent?.data.section1Title ?? '',
+        fieldPath: `${clinicsFieldPath}.section1Title`,
+      }
+    : {
+        value: t<string>('clinics.section1Title'),
+        fieldPath: `${translationsFieldPath}.section1Title`,
+      };
+
+  const section1Text1Source: TextWithFieldPath = hasContent(pageContent?.data.section1Text1)
+    ? {
+        value: pageContent?.data.section1Text1 ?? '',
+        fieldPath: `${clinicsFieldPath}.section1Text1`,
+      }
+    : {
+        value: t<string>('clinics.section1Text1'),
+        fieldPath: `${translationsFieldPath}.section1Text1`,
+      };
+
+  const section1Text2Source: TextWithFieldPath = hasContent(pageContent?.data.section1Text2)
+    ? {
+        value: pageContent?.data.section1Text2 ?? '',
+        fieldPath: `${clinicsFieldPath}.section1Text2`,
+      }
+    : {
+        value: t<string>('clinics.section1Text2'),
+        fieldPath: `${translationsFieldPath}.section1Text2`,
+      };
+
+  const benefitsParagraphs: TextWithFieldPath[] = [];
+  if (hasContent(section1Text1Source.value)) {
+    benefitsParagraphs.push(section1Text1Source);
+  }
+  if (
+    hasContent(section1Text2Source.value)
+    && section1Text2Source.value !== section1Text1Source.value
+  ) {
+    benefitsParagraphs.push(section1Text2Source);
+  }
+
+  const introContent = pageContent?.data.intro;
+  const curriculumTitleSource = hasContent(introContent?.title)
+    ? {
+        value: introContent?.title ?? '',
+        fieldPath: `${clinicsFieldPath}.intro.title`,
+      }
+    : benefitsTitleSource;
+
+  const introText1Source: TextWithFieldPath = hasContent(introContent?.text1)
+    ? {
+        value: introContent?.text1 ?? '',
+        fieldPath: `${clinicsFieldPath}.intro.text1`,
+      }
+    : section1Text1Source;
+
+  const introText2Source: TextWithFieldPath = hasContent(introContent?.text2)
+    ? {
+        value: introContent?.text2 ?? '',
+        fieldPath: `${clinicsFieldPath}.intro.text2`,
+      }
+    : section1Text2Source;
+
+  const curriculumParagraphs: TextWithFieldPath[] = [];
+  if (hasContent(introText1Source.value)) {
+    curriculumParagraphs.push(introText1Source);
+  }
+  if (
+    hasContent(introText2Source.value)
+    && introText2Source.value !== introText1Source.value
+  ) {
+    curriculumParagraphs.push(introText2Source);
+  }
+
+  const ctaTitleSource = hasContent(pageContent?.data.ctaTitle)
+    ? {
+        value: pageContent?.data.ctaTitle ?? '',
+        fieldPath: `${clinicsFieldPath}.ctaTitle`,
+      }
+    : {
+        value: t<string>('clinics.ctaTitle'),
+        fieldPath: `${translationsFieldPath}.ctaTitle`,
+      };
+
+  const ctaSubtitleSource = hasContent(pageContent?.data.ctaSubtitle)
+    ? {
+        value: pageContent?.data.ctaSubtitle ?? '',
+        fieldPath: `${clinicsFieldPath}.ctaSubtitle`,
+      }
+    : {
+        value: t<string>('clinics.ctaSubtitle'),
+        fieldPath: `${translationsFieldPath}.ctaSubtitle`,
+      };
+
+  const ctaButtonSource = hasContent(pageContent?.data.ctaButton)
+    ? {
+        value: pageContent?.data.ctaButton ?? '',
+        fieldPath: `${clinicsFieldPath}.ctaButton`,
+      }
+    : {
+        value: t<string>('clinics.ctaButton'),
+        fieldPath: `${translationsFieldPath}.ctaButton`,
+      };
+
+  const ctaLink = settings.clinics?.ctaLink ?? '#/contact';
+  const socialImage = settings.home?.heroImage;
+  const rootObjectId = getVisualEditorAttributes(clinicsFieldPath)['data-sb-object-id'];
+
+  return (
+    <div className="bg-white text-stone-900" data-sb-object-id={rootObjectId}>
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name="description" content={metaDescription} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={metaDescription} />
+        {socialImage ? <meta property="og:image" content={socialImage} /> : null}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={metaDescription} />
+        {socialImage ? <meta name="twitter:image" content={socialImage} /> : null}
+      </Head>
+
+      <main>
+        <section className="bg-stone-100 py-20 sm:py-28">
+          <div className="mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8">
+            <motion.h1
+              className="text-4xl font-semibold tracking-tight text-stone-900 sm:text-5xl"
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6 }}
+              {...getVisualEditorAttributes(heroTitleSource.fieldPath)}
+            >
+              {heroTitleSource.value}
+            </motion.h1>
+            <motion.p
+              className="mt-5 text-lg text-stone-600 sm:text-xl"
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.1 }}
+              {...getVisualEditorAttributes(heroSubtitleSource.fieldPath)}
+            >
+              {heroSubtitleSource.value}
+            </motion.p>
+            <motion.div
+              className="mt-8"
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.2 }}
+            >
+              <a
+                href={ctaLink}
+                className="inline-flex items-center justify-center rounded-full bg-stone-900 px-6 py-3 text-base font-semibold text-white transition hover:bg-stone-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2"
+                {...getVisualEditorAttributes(ctaButtonSource.fieldPath)}
+              >
+                {ctaButtonSource.value}
+              </a>
+            </motion.div>
+          </div>
+        </section>
+
+        <section className="py-16 sm:py-20">
+          <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+            <motion.h2
+              className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl"
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+              {...getVisualEditorAttributes(benefitsTitleSource.fieldPath)}
+            >
+              {benefitsTitleSource.value}
+            </motion.h2>
+            <div className="mt-6 space-y-4 text-base text-stone-600 sm:text-lg">
+              {benefitsParagraphs.map((paragraph, index) => (
+                <motion.p
+                  key={`${paragraph.fieldPath}-${index}`}
+                  initial={{ opacity: 0, y: 16 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.5, delay: 0.1 * (index + 1) }}
+                  {...getVisualEditorAttributes(paragraph.fieldPath)}
+                >
+                  {paragraph.value}
+                </motion.p>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {protocolSectionSource ? (
+          <section className="bg-stone-50 py-16 sm:py-20">
+            <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+              <motion.div
+                initial={{ opacity: 0, y: 16 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5 }}
+              >
+                {hasContent(protocolSectionSource.data.title) ? (
+                  <h2
+                    className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl"
+                    {...getVisualEditorAttributes(`${protocolSectionSource.fieldPath}.title`)}
+                  >
+                    {protocolSectionSource.data.title}
+                  </h2>
+                ) : null}
+                {hasContent(protocolSectionSource.data.subtitle) ? (
+                  <p
+                    className="mt-4 max-w-3xl text-base text-stone-600 sm:text-lg"
+                    {...getVisualEditorAttributes(`${protocolSectionSource.fieldPath}.subtitle`)}
+                  >
+                    {protocolSectionSource.data.subtitle}
+                  </p>
+                ) : null}
+              </motion.div>
+
+              {protocolCards.length > 0 ? (
+                <div className="mt-10 grid gap-6 sm:grid-cols-2">
+                  {protocolCards.map((card, index) => {
+                    const cardFieldPath = `${protocolSectionSource.fieldPath}.cards.${index}`;
+                    const steps = Array.isArray(card.steps)
+                      ? card.steps.filter((step) => hasContent(step))
+                      : [];
+
+                    return (
+                      <motion.article
+                        key={cardFieldPath}
+                        className="rounded-3xl bg-white p-8 shadow-sm ring-1 ring-stone-200"
+                        initial={{ opacity: 0, y: 16 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ duration: 0.5, delay: 0.1 * index }}
+                        {...getVisualEditorAttributes(cardFieldPath)}
+                      >
+                        {hasContent(card.title) ? (
+                          <h3
+                            className="text-2xl font-semibold text-stone-900"
+                            {...getVisualEditorAttributes(`${cardFieldPath}.title`)}
+                          >
+                            {card.title}
+                          </h3>
+                        ) : null}
+                        {hasContent(card.focus) ? (
+                          <p
+                            className="mt-2 text-sm font-medium uppercase tracking-wide text-stone-500"
+                            {...getVisualEditorAttributes(`${cardFieldPath}.focus`)}
+                          >
+                            {card.focus}
+                          </p>
+                        ) : null}
+                        {steps.length > 0 ? (
+                          <ul className="mt-4 space-y-3 text-sm text-stone-600">
+                            {steps.map((step, stepIndex) => (
+                              <li
+                                key={`${cardFieldPath}.steps.${stepIndex}`}
+                                className="flex gap-3"
+                                {...getVisualEditorAttributes(`${cardFieldPath}.steps.${stepIndex}`)}
+                              >
+                                <span className="mt-1 inline-flex h-2 w-2 flex-none rounded-full bg-stone-900" aria-hidden="true" />
+                                <span>{step}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        ) : null}
+                        {hasContent(card.evidence) ? (
+                          <p
+                            className="mt-4 text-sm text-stone-500"
+                            {...getVisualEditorAttributes(`${cardFieldPath}.evidence`)}
+                          >
+                            {card.evidence}
+                          </p>
+                        ) : null}
+                      </motion.article>
+                    );
+                  })}
+                </div>
+              ) : null}
+            </div>
+          </section>
+        ) : null}
+
+        <section className="py-16 sm:py-20">
+          <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+            <motion.h2
+              className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl"
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+              {...getVisualEditorAttributes(curriculumTitleSource.fieldPath)}
+            >
+              {curriculumTitleSource.value}
+            </motion.h2>
+            <div className="mt-6 space-y-4 text-base text-stone-600 sm:text-lg">
+              {curriculumParagraphs.map((paragraph, index) => (
+                <motion.p
+                  key={`${paragraph.fieldPath}-${index}`}
+                  initial={{ opacity: 0, y: 16 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.5, delay: 0.1 * (index + 1) }}
+                  {...getVisualEditorAttributes(paragraph.fieldPath)}
+                >
+                  {paragraph.value}
+                </motion.p>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="bg-stone-900 py-16 text-white sm:py-20">
+          <div className="mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8">
+            <motion.h2
+              className="text-3xl font-semibold tracking-tight sm:text-4xl"
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+              {...getVisualEditorAttributes(ctaTitleSource.fieldPath)}
+            >
+              {ctaTitleSource.value}
+            </motion.h2>
+            <motion.p
+              className="mt-4 text-base text-stone-200 sm:text-lg"
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.1 }}
+              {...getVisualEditorAttributes(ctaSubtitleSource.fieldPath)}
+            >
+              {ctaSubtitleSource.value}
+            </motion.p>
+            <motion.div
+              className="mt-8"
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.2 }}
+            >
+              <a
+                href={ctaLink}
+                className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-stone-900 transition hover:bg-stone-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-stone-900"
+                {...getVisualEditorAttributes(ctaButtonSource.fieldPath)}
+              >
+                {ctaButtonSource.value}
+              </a>
+            </motion.div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default ForClinics;


### PR DESCRIPTION
## Summary
- add a new `pages/for-clinics.tsx` layout that reads translations with Markdown overrides for meta, hero, benefits, protocol, curriculum, and CTA content
- expose hero title/subtitle overrides in the clinics front matter and translations for English, Portuguese, and Spanish
- update the CMS config and Decap rolling log to surface the new hero fields and document the change

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e28d46ffc08320ae47224238658560