### PR TITLE
feat: use cloudinary base url for media

### DIFF
--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -5,6 +5,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import type { Article } from '../types';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { buildLocalizedPath } from '../utils/localePaths';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 interface ArticleCardProps {
   article: Article;
@@ -30,6 +31,9 @@ const ArticleCard: React.FC<ArticleCardProps> = (props) => {
   const dataSbFieldPath = props['data-sb-field-path'];
   const { translate, t, language } = useLanguage();
 
+  const imageSrc = (article.imageUrl ?? '').trim();
+  const cloudinaryUrl = imageSrc ? getCloudinaryUrl(imageSrc) ?? imageSrc : '';
+
   const translationCategoryKey = `learn.categories.${article.category}`;
   const translatedCategory = t(translationCategoryKey);
   const displayCategory = categoryLabel
@@ -52,7 +56,7 @@ const ArticleCard: React.FC<ArticleCardProps> = (props) => {
       <Link to={buildLocalizedPath(`/learn/${article.slug}`, language)} className="group block">
         <div className="overflow-hidden rounded-lg">
           <img
-            src={article.imageUrl}
+            src={cloudinaryUrl}
             alt={translate(article.title)}
             className="w-full h-56 object-cover transition-transform duration-500 group-hover:scale-105"
             {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.imageUrl` : undefined)}

--- a/components/CourseCard.tsx
+++ b/components/CourseCard.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import { useLanguage } from '../contexts/LanguageContext';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { formatCurrency } from '../utils/currency';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 import type { Course } from '../types';
 
 interface CourseCardProps {
@@ -18,6 +19,8 @@ const CourseCard: React.FC<CourseCardProps> = (props) => {
   const dataSbFieldPath = props['data-sb-field-path'];
   const { translate, t, language } = useLanguage();
   const baseFieldPath = `courses.courses.${index}`;
+  const imageSrc = (course.imageUrl ?? '').trim();
+  const cloudinaryUrl = imageSrc ? getCloudinaryUrl(imageSrc) ?? imageSrc : '';
 
   return (
     <motion.div
@@ -31,7 +34,7 @@ const CourseCard: React.FC<CourseCardProps> = (props) => {
     >
       <div className="overflow-hidden rounded-lg">
         <img
-          src={course.imageUrl}
+          src={cloudinaryUrl}
           alt={translate(course.title)}
           className="w-full h-56 object-cover transition-transform duration-500 group-hover:scale-105"
           {...getVisualEditorAttributes(`${fieldPath ?? baseFieldPath}.imageUrl`)}

--- a/components/MiniCart.tsx
+++ b/components/MiniCart.tsx
@@ -11,6 +11,7 @@ import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
 import { formatCurrency } from '../utils/currency';
 import { buildLocalizedPath } from '../utils/localePaths';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 interface ProductIndexResponse {
   items?: Product[];
@@ -28,6 +29,9 @@ const MiniCartItem: React.FC<{ item: CartItem; products: Product[]; ['data-sb-fi
   const size = product.sizes.find(s => s.id === item.sizeId);
   if (!size) return null;
 
+  const imageSrc = (product.imageUrl ?? '').trim();
+  const cloudinaryUrl = imageSrc ? getCloudinaryUrl(imageSrc) ?? imageSrc : '';
+
   const handleDecreaseQuantity = useCallback(() => {
     updateQuantity(item.productId, item.sizeId, item.quantity - 1);
   }, [updateQuantity, item.productId, item.sizeId, item.quantity]);
@@ -42,7 +46,7 @@ const MiniCartItem: React.FC<{ item: CartItem; products: Product[]; ['data-sb-fi
 
   return (
     <div className="flex items-center space-x-4 py-4" data-sb-field-path={dataSbFieldPath}>
-      <img src={product.imageUrl} alt={translate(product.name)} className="w-16 h-16 object-cover rounded" />
+      <img src={cloudinaryUrl} alt={translate(product.name)} className="w-16 h-16 object-cover rounded" />
       <div className="flex-grow">
         <h4 className="font-semibold text-sm">{translate(product.name)}</h4>
         <p className="text-xs text-stone-500">{size.size}ml</p>

--- a/components/PartnerCarousel.tsx
+++ b/components/PartnerCarousel.tsx
@@ -5,6 +5,7 @@ import type { Partner } from '../types';
 import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 interface PartnerCarouselProps {
   title?: string;
@@ -82,7 +83,11 @@ const PartnerCarousel: React.FC<PartnerCarouselProps> = ({ title, fieldPath }) =
                     viewport={{ once: true, amount: 0.5 }}
                     {...getVisualEditorAttributes('partners.partners')}
                 >
-                    {partners.map((partner, index) => (
+                    {partners.map((partner, index) => {
+                        const logoSrc = (partner.logoUrl ?? '').trim();
+                        const cloudinaryUrl = logoSrc ? getCloudinaryUrl(logoSrc) ?? logoSrc : '';
+
+                        return (
                         <motion.div
                             key={partner.id}
                             variants={itemVariants}
@@ -90,7 +95,7 @@ const PartnerCarousel: React.FC<PartnerCarouselProps> = ({ title, fieldPath }) =
                             {...getVisualEditorAttributes(`partners.partners.${index}`)}
                         >
                             <img
-                                src={partner.logoUrl}
+                                src={cloudinaryUrl}
                                 alt={partner.name}
                                 title={partner.description ?? partner.name}
                                 className="h-8 object-contain grayscale opacity-60 hover:opacity-100 hover:grayscale-0 transition-all duration-300"
@@ -105,7 +110,8 @@ const PartnerCarousel: React.FC<PartnerCarouselProps> = ({ title, fieldPath }) =
                                 </p>
                             )}
                         </motion.div>
-                    ))}
+                        );
+                    })}
                 </motion.div>
             </div>
         </div>

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -8,6 +8,7 @@ import { useUI } from '../contexts/UIContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { formatCurrency } from '../utils/currency';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 import type { Product } from '../types';
 import { buildLocalizedPath } from '../utils/localePaths';
 
@@ -53,6 +54,9 @@ const ProductCard: React.FC<ProductCardProps> = (props) => {
     }
   }, [setSelectedSizeId]);
 
+  const productImageSrc = (product.imageUrl ?? '').trim();
+  const cloudinaryUrl = productImageSrc ? getCloudinaryUrl(productImageSrc) ?? productImageSrc : '';
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -65,7 +69,7 @@ const ProductCard: React.FC<ProductCardProps> = (props) => {
       <Link to={buildLocalizedPath(`/product/${product.id}`, language)} className="block">
         <div className="relative overflow-hidden rounded-lg">
           <img
-            src={product.imageUrl}
+            src={cloudinaryUrl}
             alt={translate(product.name)}
             className="w-full h-auto aspect-[3/4] object-cover transition-transform duration-500 group-hover:scale-105"
             {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.imageUrl` : undefined)}

--- a/components/TimelineSection.tsx
+++ b/components/TimelineSection.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import type { Components } from 'react-markdown';
 import type { TimelineEntry } from '../types';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 interface TimelineSectionProps {
   title?: string;
@@ -75,6 +76,8 @@ const TimelineSection: React.FC<TimelineSectionProps> = ({ title, entries, field
           const hasImage = Boolean(entry.image && entry.image.trim().length > 0);
           const isEven = index % 2 === 0;
           const entryFieldPath = entriesFieldPath ? `${entriesFieldPath}.${index}` : undefined;
+          const imageSrc = entry.image?.trim() ?? '';
+          const cloudinaryUrl = imageSrc ? getCloudinaryUrl(imageSrc) ?? imageSrc : '';
 
           const imageWrapperClassName = isEven ? 'order-1 md:order-1' : 'order-1 md:order-2';
           const contentWrapperClassName = hasImage
@@ -97,7 +100,7 @@ const TimelineSection: React.FC<TimelineSectionProps> = ({ title, entries, field
                   transition={{ duration: 0.6 }}
                 >
                   <img
-                    src={entry.image}
+                    src={cloudinaryUrl}
                     alt={entry.title}
                     className="rounded-lg shadow-lg w-full object-cover"
                     {...getVisualEditorAttributes(entryFieldPath ? `${entryFieldPath}.image` : undefined)}

--- a/components/VideoGallery.tsx
+++ b/components/VideoGallery.tsx
@@ -6,6 +6,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 interface VideoGalleryProps {
   title?: string;
@@ -122,6 +123,8 @@ const VideoGallery: React.FC<VideoGalleryProps> = ({ title, description, entries
               const key = `${item.title ?? 'video'}-${index}`;
               const itemFieldPath = fieldPath ? `${fieldPath}.entries.${index}` : undefined;
               const hasThumbnail = typeof item.thumbnail === 'string' && item.thumbnail.trim().length > 0;
+              const thumbnailSrc = item.thumbnail?.trim() ?? '';
+              const cloudinaryUrl = thumbnailSrc ? getCloudinaryUrl(thumbnailSrc) ?? thumbnailSrc : '';
 
               return (
                 <motion.article
@@ -137,7 +140,7 @@ const VideoGallery: React.FC<VideoGalleryProps> = ({ title, description, entries
                 <div className="relative overflow-hidden rounded-xl">
                   {hasThumbnail ? (
                     <img
-                      src={item.thumbnail}
+                      src={cloudinaryUrl}
                       alt={item.title ?? 'Video thumbnail'}
                       className="h-48 w-full object-cover"
                       loading="lazy"

--- a/components/sections/CommunityCarousel.tsx
+++ b/components/sections/CommunityCarousel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import { getCloudinaryUrl } from '../../utils/imageUrl';
 
 export interface CommunityCarouselSlideProps {
   image?: string;
@@ -145,7 +146,11 @@ const CommunityCarousel: React.FC<CommunityCarouselProps> = ({
                   className="flex items-center gap-6 animate-carousel-scroll"
                   style={{ animationDuration: `${loopDuration}ms` }}
                 >
-                  {marqueeSlides.map((slide, index) => (
+                  {marqueeSlides.map((slide, index) => {
+                    const slideImageSrc = slide.image?.trim() ?? '';
+                    const cloudinaryUrl = slideImageSrc ? getCloudinaryUrl(slideImageSrc) ?? slideImageSrc : '';
+
+                    return (
                     <figure
                       key={buildSlideKey(slide, `marquee-slide-${index}`)}
                       className="group relative flex-shrink-0 w-40 h-40 sm:w-48 sm:h-48 lg:w-56 lg:h-56 overflow-hidden bg-stone-100"
@@ -154,7 +159,7 @@ const CommunityCarousel: React.FC<CommunityCarouselProps> = ({
                     >
                       {slide.image ? (
                         <img
-                          src={slide.image}
+                          src={cloudinaryUrl}
                           alt={slide.alt ?? 'Kapunka ritual in our community'}
                           className="h-full w-full object-cover"
                           {...getVisualEditorAttributes(slide.imageFieldPath)}
@@ -178,7 +183,8 @@ const CommunityCarousel: React.FC<CommunityCarouselProps> = ({
                         {slide.alt ?? 'Community carousel image'}
                       </span>
                     </figure>
-                  ))}
+                  );
+                  })}
                 </div>
               ) : (
                 <div className="flex h-48 items-center justify-center text-sm text-stone-400">

--- a/components/sections/ImageGrid.tsx
+++ b/components/sections/ImageGrid.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import { getCloudinaryUrl } from '../../utils/imageUrl';
 
 interface ImageGridItemProps {
   image?: string;
@@ -30,6 +31,8 @@ const ImageGrid: React.FC<ImageGridProps> = ({ items, fieldPath }) => {
               ?? item.title
               ?? item.subtitle
               ?? JSON.stringify(item ?? {});
+            const imageSrc = item.image?.trim();
+            const cloudinaryUrl = imageSrc ? getCloudinaryUrl(imageSrc) ?? imageSrc : '';
 
             return (
               <div
@@ -41,8 +44,8 @@ const ImageGrid: React.FC<ImageGridProps> = ({ items, fieldPath }) => {
                   className="w-full aspect-[4/3] bg-stone-100 flex items-center justify-center"
                   {...(itemFieldPath ? getVisualEditorAttributes(`${itemFieldPath}.image`) : {})}
                 >
-                  {item.image ? (
-                    <img src={item.image} alt={item.title ?? ''} className="w-full h-full object-cover" />
+                  {imageSrc ? (
+                    <img src={cloudinaryUrl} alt={item.title ?? ''} className="w-full h-full object-cover" />
                   ) : (
                     <span className="text-sm text-stone-400">Image coming soon</span>
                   )}

--- a/components/sections/ImageTextHalf.tsx
+++ b/components/sections/ImageTextHalf.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import { getCloudinaryUrl } from '../../utils/imageUrl';
 
 interface ImageTextHalfProps {
   image?: string;
@@ -15,6 +16,8 @@ const ImageTextHalf: React.FC<ImageTextHalfProps> = ({ image, title, text, field
   }
 
   const markdownSource = text?.trim();
+  const trimmedImage = image?.trim();
+  const cloudinaryUrl = trimmedImage ? getCloudinaryUrl(trimmedImage) ?? trimmedImage : '';
 
   return (
     <section
@@ -42,9 +45,9 @@ const ImageTextHalf: React.FC<ImageTextHalfProps> = ({ image, title, text, field
             )}
           </div>
           <div className="order-1 lg:order-2">
-            {image ? (
+            {trimmedImage ? (
               <img
-                src={image}
+                src={cloudinaryUrl}
                 alt={title ?? ''}
                 className="w-full h-full object-cover rounded-lg shadow-sm"
                 {...(fieldPath ? getVisualEditorAttributes(`${fieldPath}.image`) : {})}

--- a/components/sections/MediaShowcase.tsx
+++ b/components/sections/MediaShowcase.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { buildLocalizedPath } from '../../utils/localePaths';
+import { getCloudinaryUrl } from '../../utils/imageUrl';
 
 export interface MediaShowcaseItem {
   eyebrow?: string;
@@ -59,7 +60,8 @@ const MediaShowcase: React.FC<MediaShowcaseProps> = ({ title, items, fieldPath }
         )}
         <div className="grid auto-rows-[minmax(640px,1fr)] gap-y-0 md:grid-cols-4 md:gap-x-0">
           {items.map((item, index) => {
-            const imageSrc = item.image;
+            const imageSrc = item.image?.trim();
+            const cloudinaryUrl = imageSrc ? getCloudinaryUrl(imageSrc) ?? imageSrc : '';
             const eyebrow = item.eyebrow?.trim();
             const itemTitle = item.title?.trim();
             const body = item.body?.trim();
@@ -98,7 +100,7 @@ const MediaShowcase: React.FC<MediaShowcaseProps> = ({ title, items, fieldPath }
               >
                 {imageSrc ? (
                   <img
-                    src={imageSrc}
+                    src={cloudinaryUrl}
                     alt={item.alt ?? itemTitle ?? 'Kapunka highlight'}
                     className="absolute inset-0 h-full w-full object-cover"
                     {...getVisualEditorAttributes(item.imageFieldPath)}

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet-async';
 import { motion } from 'framer-motion';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 import SectionRenderer from '../components/_legacy/SectionRenderer';
 import type { PageContent, PageSection, TimelineEntry, TimelineSectionContent } from '../types';
 import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
@@ -176,8 +177,12 @@ const About: React.FC = () => {
     const aboutFieldPath = `pages.about_${language}`;
     const defaultStoryImage = 'https://images.unsplash.com/photo-1598555769781-8714b14a293f?q=80&w=1974&auto=format&fit=crop';
     const defaultSourcingImage = 'https://images.unsplash.com/photo-1616893904984-7a57a3b35338?q=80&w=1964&auto=format&fit=crop';
-    const storyImage = settings.about?.storyImage || defaultStoryImage;
-    const sourcingImage = settings.about?.sourcingImage || defaultSourcingImage;
+    const storyImageSourceRaw = settings.about?.storyImage || defaultStoryImage;
+    const sourcingImageSourceRaw = settings.about?.sourcingImage || defaultSourcingImage;
+    const storyImageSource = storyImageSourceRaw ? storyImageSourceRaw.trim() : '';
+    const sourcingImageSource = sourcingImageSourceRaw ? sourcingImageSourceRaw.trim() : '';
+    const storyImage = storyImageSource ? getCloudinaryUrl(storyImageSource) ?? storyImageSource : '';
+    const sourcingImage = sourcingImageSource ? getCloudinaryUrl(sourcingImageSource) ?? sourcingImageSource : '';
     const storyAlt = translate(settings.about?.storyAlt ?? 'Brand story');
     const sourcingAlt = translate(settings.about?.sourcingAlt ?? t('about.sourcingImageAlt'));
     const [aboutContent, setAboutContent] = useState<AboutPageContent | null>(null);
@@ -329,7 +334,8 @@ const About: React.FC = () => {
             <>
               <div className="space-y-16">
                 {aboutStoryBlocks.map((block, index) => {
-                    const imageUrl = block.imageUrl ?? undefined;
+                    const rawImageUrl = block.imageUrl?.trim() ?? '';
+                    const imageUrl = rawImageUrl ? getCloudinaryUrl(rawImageUrl) ?? rawImageUrl : '';
                     const hasImage = Boolean(imageUrl);
                     const imageFirst = hasImage && index % 2 === 0;
                     const storyBlockFieldPath = `${aboutFieldPath}.story.${index}`;

--- a/pages/Article.tsx
+++ b/pages/Article.tsx
@@ -19,6 +19,7 @@ import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
 import { buildLocalizedPath } from '../utils/localePaths';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 interface ArticlesResponse {
     items?: Article[];
@@ -240,6 +241,8 @@ const ArticlePage: React.FC = () => {
         ? learnCategories.get(article.category)?.fieldPath
             ?? `translations.${language}.learn.categories.${article.category}`
         : undefined;
+    const articleImageSrc = (article.imageUrl ?? '').trim();
+    const articleImageUrl = articleImageSrc ? getCloudinaryUrl(articleImageSrc) ?? articleImageSrc : '';
 
     return (
         <div>
@@ -277,14 +280,14 @@ const ArticlePage: React.FC = () => {
                     </h1>
                 </motion.header>
                 
-                <motion.div 
-                    initial={{ opacity: 0 }} 
-                    animate={{ opacity: 1 }} 
+                <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
                     transition={{ duration: 0.6, delay: 0.2 }}
                     className="my-8"
                 >
                     <img
-                        src={article.imageUrl}
+                        src={articleImageUrl}
                         alt={translate(article.title)}
                         className="w-full h-auto max-h-[500px] object-cover rounded-lg shadow-lg"
                         {...getVisualEditorAttributes(articleFieldPath ? `${articleFieldPath}.imageUrl` : undefined)}

--- a/pages/CartPage.tsx
+++ b/pages/CartPage.tsx
@@ -12,6 +12,7 @@ import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
 import { formatCurrency } from '../utils/currency';
 import { buildLocalizedPath } from '../utils/localePaths';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 interface ProductsResponse {
   items?: Product[];
@@ -23,6 +24,8 @@ const CartItemRow: React.FC<{ item: CartItem; product?: Product; productFieldPat
 
   const size = product?.sizes.find(s => s.id === item.sizeId);
   const sizeIndex = product?.sizes.findIndex(s => s.id === item.sizeId) ?? -1;
+  const imageSrc = (product?.imageUrl ?? '').trim();
+  const cloudinaryUrl = imageSrc ? getCloudinaryUrl(imageSrc) ?? imageSrc : '';
 
   const handleDecreaseQuantity = useCallback(() => {
     updateQuantity(item.productId, item.sizeId, item.quantity - 1);
@@ -42,7 +45,7 @@ const CartItemRow: React.FC<{ item: CartItem; product?: Product; productFieldPat
     <div className="grid grid-cols-12 gap-4 items-center py-4 border-b border-stone-200" {...getVisualEditorAttributes(productFieldPath)}>
       <div className="col-span-2">
         <img
-          src={product.imageUrl}
+          src={cloudinaryUrl}
           alt={translate(product.name)}
           className="w-20 h-20 object-cover rounded-md"
           {...getVisualEditorAttributes(productFieldPath ? `${productFieldPath}.imageUrl` : undefined)}

--- a/pages/ForClinics.tsx
+++ b/pages/ForClinics.tsx
@@ -13,6 +13,7 @@ import {
 } from '../utils/loadClinicsPageContent';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
 import { fetchTestimonialsByRefs } from '../utils/fetchTestimonialsByRefs';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 interface ClinicProtocol {
   title: string;
@@ -573,6 +574,8 @@ const ForClinics: React.FC = () => {
                       const testimonialFieldPath = `${clinicsFieldPath}.referencesSection.testimonials.${index}`;
                       const testimonialKey = testimonial.testimonialRef
                         ?? `${testimonial.quote}-${testimonial.name ?? index}`;
+                      const avatarSrc = (testimonial.avatar ?? '').trim();
+                      const cloudinaryAvatar = avatarSrc ? getCloudinaryUrl(avatarSrc) ?? avatarSrc : '';
 
                       return (
                         <blockquote
@@ -582,7 +585,7 @@ const ForClinics: React.FC = () => {
                         >
                           {testimonial.avatar && (
                             <img
-                              src={testimonial.avatar}
+                              src={cloudinaryAvatar}
                               alt={testimonial.name ?? t('clinics.testimonialAvatarAlt')}
                               className="h-12 w-12 rounded-full object-cover mb-4"
                               {...getVisualEditorAttributes(`${testimonialFieldPath}.avatar`)}
@@ -633,7 +636,11 @@ const ForClinics: React.FC = () => {
           </h2>
           {doctors.length > 0 ? (
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-8 text-center">
-              {doctors.map((doctor, index) => (
+              {doctors.map((doctor, index) => {
+                const doctorImageSrc = (doctor.imageUrl ?? '').trim();
+                const doctorImageUrl = doctorImageSrc ? getCloudinaryUrl(doctorImageSrc) ?? doctorImageSrc : '';
+
+                return (
                 <motion.div
                   key={doctor.id}
                   initial={{ opacity: 0, y: 20 }}
@@ -643,7 +650,7 @@ const ForClinics: React.FC = () => {
                   {...getVisualEditorAttributes(`doctors.doctors.${index}`)}
                 >
                   <img
-                    src={doctor.imageUrl}
+                    src={doctorImageUrl}
                     alt={doctor.name}
                     className="w-24 h-24 rounded-full mx-auto object-cover shadow-md"
                     {...getVisualEditorAttributes(`doctors.doctors.${index}.imageUrl`)}
@@ -655,7 +662,8 @@ const ForClinics: React.FC = () => {
                     {doctor.name}
                   </p>
                 </motion.div>
-              ))}
+              );
+              })}
             </div>
           ) : (
             <p className="text-center" {...getVisualEditorAttributes(`${commonFieldPath}.loadingProfessionals`)}>

--- a/pages/ProductDetail.tsx
+++ b/pages/ProductDetail.tsx
@@ -14,6 +14,7 @@ import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { formatCurrency } from '../utils/currency';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 interface ProductsResponse {
     items?: Product[];
@@ -74,6 +75,9 @@ const ProductDetail: React.FC = () => {
         if (!product || !selectedSizeId) return null;
         return product.sizes.find(s => s.id === selectedSizeId);
     }, [product, selectedSizeId]);
+
+    const productImageSrc = (product?.imageUrl ?? '').trim();
+    const productImageUrl = productImageSrc ? getCloudinaryUrl(productImageSrc) ?? productImageSrc : '';
 
     const handleAddToCart = () => {
         if (product && selectedSizeId) {
@@ -326,7 +330,7 @@ const ProductDetail: React.FC = () => {
                 <div className="grid md:grid-cols-2 gap-12 items-start">
                     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.6 }}>
                         <img
-                            src={product.imageUrl}
+                            src={productImageUrl}
                             alt={translate(product.name)}
                             className="w-full rounded-lg shadow-lg aspect-[3/4] object-cover"
                             {...getVisualEditorAttributes(productFieldPath ? `${productFieldPath}.imageUrl` : undefined)}

--- a/pages/Story.tsx
+++ b/pages/Story.tsx
@@ -7,6 +7,7 @@ import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
 import type { PageSection } from '../types';
 import { fetchVisualEditorMarkdown } from '../utils/fetchVisualEditorMarkdown';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
   'timeline',
@@ -241,7 +242,8 @@ const Story: React.FC = () => {
               data-sb-field-path={`${storyFieldPath}.story`}
             >
               {storyBlocks.map(({ block, index }) => {
-                const imageUrl = block.imageUrl ?? undefined;
+                const rawImageUrl = block.imageUrl?.trim() ?? '';
+                const imageUrl = rawImageUrl ? getCloudinaryUrl(rawImageUrl) ?? rawImageUrl : undefined;
                 const hasImage = Boolean(imageUrl);
                 const imageFirst = hasImage && index % 2 === 0;
                 const storyBlockFieldPath = `${storyFieldPath}.story.${index}`;

--- a/utils/imageUrl.ts
+++ b/utils/imageUrl.ts
@@ -1,0 +1,25 @@
+export const isAbsoluteUrl = (value: string): boolean => /^([a-z]+:)?\/\//i.test(value);
+
+export const getCloudinaryUrl = (src?: string | null): string | undefined => {
+  if (!src) {
+    return undefined;
+  }
+
+  const trimmedSrc = src.trim();
+  if (!trimmedSrc) {
+    return undefined;
+  }
+
+  if (!process.env.CLOUDINARY_BASE_URL) {
+    return trimmedSrc;
+  }
+
+  if (isAbsoluteUrl(trimmedSrc)) {
+    return trimmedSrc;
+  }
+
+  const normalizedSrc = trimmedSrc.replace(/^\/?content\/[^/]+\/uploads\/?/, '');
+  const sanitizedNormalizedSrc = normalizedSrc.replace(/^\/+/, '');
+
+  return `${process.env.CLOUDINARY_BASE_URL}/${sanitizedNormalizedSrc}`;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,8 @@ export default defineConfig(({ mode }) => {
     plugins: [react()],
     define: {
       "process.env.API_KEY": JSON.stringify(env.GEMINI_API_KEY),
-      "process.env.GEMINI_API_KEY": JSON.stringify(env.GEMINI_API_KEY)
+      "process.env.GEMINI_API_KEY": JSON.stringify(env.GEMINI_API_KEY),
+      "process.env.CLOUDINARY_BASE_URL": JSON.stringify(env.CLOUDINARY_BASE_URL)
     },
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary
- define `CLOUDINARY_BASE_URL` for the build and add a shared helper that converts CMS asset paths to Cloudinary URLs
- update product, article, course, timeline, and other image-rendering components/pages to serve uploads from Cloudinary while preserving alt text and editor bindings
- trim/sanitize CMS image paths so Cloudinary URLs are generated consistently across mapped content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e293568a888320b8ed4bc122cf4b24