### PR TITLE
Add SEO metadata and alt fallbacks across pages

### DIFF
--- a/content/translations/methodKapunka.json
+++ b/content/translations/methodKapunka.json
@@ -1,0 +1,15 @@
+{
+  "type": "translations_method_kapunka",
+  "en": {
+    "metaTitle": "Method Kapunka",
+    "metaDescription": "Discover the Method Kapunka philosophy, pillars, and clinical rituals that bridge ancestral argan care with modern recovery."
+  },
+  "pt": {
+    "metaTitle": "Método Kapunka",
+    "metaDescription": "Descubra a filosofia, os pilares e os rituais clínicos do Método Kapunka, unindo o cuidado ancestral com argan à recuperação moderna."
+  },
+  "es": {
+    "metaTitle": "Método Kapunka",
+    "metaDescription": "Descubre la filosofía, los pilares y los rituales clínicos del Método Kapunka que unen el cuidado ancestral con argán y la recuperación moderna."
+  }
+}

--- a/content/translations/productEducation.json
+++ b/content/translations/productEducation.json
@@ -1,0 +1,15 @@
+{
+  "type": "translations_productEducation",
+  "en": {
+    "metaTitle": "Product Education",
+    "metaDescription": "Understand Kapunka formulations, certifications, and the rituals that unlock each benefit."
+  },
+  "pt": {
+    "metaTitle": "Educação sobre Produtos",
+    "metaDescription": "Compreenda as formulações, certificações e rituais Kapunka que ativam cada benefício."
+  },
+  "es": {
+    "metaTitle": "Educación sobre Productos",
+    "metaDescription": "Comprende las formulaciones, certificaciones y rituales de Kapunka que potencian cada beneficio."
+  }
+}

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -298,12 +298,24 @@ const About: React.FC = () => {
         ?? storyContent?.metaDescription
         ?? t('about.metaDescription');
     const computedTitle = metaTitleBase.includes('Kapunka') ? metaTitleBase : `${metaTitleBase} | Kapunka Skincare`;
+    const fallbackSocialImage = settings.home?.heroImage?.trim() ?? '';
+    const socialImageCandidate = storyImage || sourcingImage || fallbackSocialImage;
+    const socialImage = socialImageCandidate
+        ? getCloudinaryUrl(socialImageCandidate) ?? socialImageCandidate
+        : undefined;
 
   return (
     <div>
         <Helmet>
             <title>{computedTitle}</title>
             <meta name="description" content={computedDescription} />
+            <meta property="og:title" content={computedTitle} />
+            <meta property="og:description" content={computedDescription} />
+            {socialImage ? <meta property="og:image" content={socialImage} /> : null}
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:title" content={computedTitle} />
+            <meta name="twitter:description" content={computedDescription} />
+            {socialImage ? <meta name="twitter:image" content={socialImage} /> : null}
         </Helmet>
       <header className="py-20 sm:py-32 bg-stone-100 text-center">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
@@ -386,9 +398,9 @@ const About: React.FC = () => {
                             className={imageOrderClass}
                             {...getVisualEditorAttributes(imageFieldPath)}
                         >
-                            <img
-                                src={imageUrl}
-                                alt={block.imageAlt ?? block.heading ?? 'Story visual'}
+                    <img
+                        src={imageUrl}
+                        alt={block.imageAlt ?? block.heading ?? t('about.headerTitle')}
                                 className="rounded-lg shadow-lg"
                             />
                         </motion.div>

--- a/pages/Contact.tsx
+++ b/pages/Contact.tsx
@@ -6,6 +6,7 @@ import { Mail, Phone, MessageSquare } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 const ContactForm: React.FC = () => {
     const { t, language } = useLanguage();
@@ -88,12 +89,21 @@ const Contact: React.FC = () => {
     const phoneLink = contactSettings.phone ? `tel:${contactSettings.phone.replace(/[^+\d]/g, '')}` : '#';
     const whatsappLink = contactSettings.whatsapp || '#';
     const contactFieldPath = `translations.${language}.contact`;
+    const rawSocialImage = settings.home?.heroImage?.trim() ?? '';
+    const socialImage = rawSocialImage ? getCloudinaryUrl(rawSocialImage) ?? rawSocialImage : undefined;
 
     return (
         <div className="py-16 sm:py-24">
             <Helmet>
                 <title>{t('contact.title')} | Kapunka Skincare</title>
                 <meta name="description" content={t('contact.metaDescription')} />
+                <meta property="og:title" content={`${t('contact.title')} | Kapunka Skincare`} />
+                <meta property="og:description" content={t('contact.metaDescription')} />
+                {socialImage ? <meta property="og:image" content={socialImage} /> : null}
+                <meta name="twitter:card" content="summary_large_image" />
+                <meta name="twitter:title" content={`${t('contact.title')} | Kapunka Skincare`} />
+                <meta name="twitter:description" content={t('contact.metaDescription')} />
+                {socialImage ? <meta name="twitter:image" content={socialImage} /> : null}
             </Helmet>
             <div className="container mx-auto px-4 sm:px-6 lg:px-8">
                 <header className="text-center mb-16">

--- a/pages/ForClinics.tsx
+++ b/pages/ForClinics.tsx
@@ -134,9 +134,8 @@ const isKeywordSection = (value: unknown): value is ClinicKeywordSection => {
 
 const ForClinics: React.FC = () => {
   const { t, language } = useLanguage();
-  const {
-    settings: { clinics },
-  } = useSiteSettings();
+  const { settings } = useSiteSettings();
+  const clinics = settings.clinics;
   const [doctors, setDoctors] = useState<Doctor[]>([]);
   const [pageContent, setPageContent] = useState<ClinicsPageContentResult | null>(null);
   const { contentVersion } = useVisualEditorSync();
@@ -185,8 +184,8 @@ const ForClinics: React.FC = () => {
   const translationFaqSection = t<unknown>('clinics.faqSection');
   const translationKeywordSection = t<unknown>('clinics.keywordSection');
 
-  const metaTitle = pageContent?.data.metaTitle ?? t('clinics.title');
-  const metaDescription = pageContent?.data.metaDescription ?? t('clinics.metaDescription');
+  const metaTitle = (pageContent?.data.metaTitle ?? t('clinics.metaTitle'))?.trim();
+  const metaDescription = (pageContent?.data.metaDescription ?? t('clinics.metaDescription'))?.trim();
   const firstSectionImage = useMemo(() => {
     const sections = pageContent?.data.sections;
     if (!Array.isArray(sections)) {
@@ -216,7 +215,11 @@ const ForClinics: React.FC = () => {
 
     return undefined;
   }, [pageContent?.data.sections]);
-  const socialImage = firstSectionImage ?? siteSettings.home?.heroImage;
+  const fallbackSocialImage = settings.home?.heroImage?.trim() ?? '';
+  const socialImageSource = firstSectionImage ?? fallbackSocialImage;
+  const socialImage = socialImageSource
+    ? getCloudinaryUrl(socialImageSource) ?? socialImageSource
+    : undefined;
 
   const headerTitle = pageContent?.data.headerTitle ?? t('clinics.headerTitle');
   const headerSubtitle = pageContent?.data.headerSubtitle ?? t('clinics.headerSubtitle');

--- a/pages/FounderStory.tsx
+++ b/pages/FounderStory.tsx
@@ -5,6 +5,7 @@ import { fetchVisualEditorMarkdown } from '../utils/fetchVisualEditorMarkdown';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
 import { getCloudinaryUrl } from '../utils/imageUrl';
+import { useLanguage } from '../contexts/LanguageContext';
 
 interface MicroStory {
   quote?: string;
@@ -37,6 +38,8 @@ interface HeroImage {
 interface FounderStoryContent {
   headline?: string;
   subheadline?: string;
+  metaTitle?: string;
+  metaDescription?: string;
   body?: string;
   microStories?: MicroStory[];
   keyMilestones?: Milestone[];
@@ -136,11 +139,13 @@ const isFounderStoryContent = (value: unknown): value is FounderStoryContent => 
     }
   }
 
-  const { headline, subheadline, body } = value;
+  const { headline, subheadline, body, metaTitle, metaDescription } = value;
   return (
     (headline === undefined || typeof headline === 'string')
     && (subheadline === undefined || typeof subheadline === 'string')
     && (body === undefined || typeof body === 'string')
+    && (metaTitle === undefined || typeof metaTitle === 'string')
+    && (metaDescription === undefined || typeof metaDescription === 'string')
   );
 };
 
@@ -152,6 +157,7 @@ const FounderStory: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const { contentVersion } = useVisualEditorSync();
   const { settings: siteSettings } = useSiteSettings();
+  const { t } = useLanguage();
 
   useEffect(() => {
     let isMounted = true;
@@ -242,10 +248,13 @@ const FounderStory: React.FC = () => {
       .filter((paragraph) => paragraph.length > 0);
   }, [content?.body]);
 
-  const pageTitle = content?.headline ?? 'Founder Story';
-  const pageDescription =
-    content?.subheadline
-    ?? 'Discover the Kapunka founder story rooted in Berber argan traditions and clinical skincare innovation.';
+  const metaTitle = (content?.metaTitle ?? content?.headline ?? t('nav.about'))?.trim();
+  const pageDescription = (
+    content?.metaDescription
+    ?? content?.subheadline
+    ?? t('about.metaDescription')
+  )?.trim();
+  const pageTitle = `${metaTitle} | Kapunka Skincare`;
   const fallbackHeroImage = siteSettings.home?.heroImage?.trim() ?? '';
   const socialImageSource = heroImageSrc || fallbackHeroImage;
   const socialImage = socialImageSource ? getCloudinaryUrl(socialImageSource) ?? socialImageSource : undefined;
@@ -253,13 +262,13 @@ const FounderStory: React.FC = () => {
   return (
     <div className="bg-stone-50 text-stone-800" data-sb-object-id={FOUNDER_STORY_OBJECT_ID}>
       <Head>
-        <title>{pageTitle} | Kapunka Skincare</title>
+        <title>{pageTitle}</title>
         <meta name="description" content={pageDescription} />
-        <meta property="og:title" content={`${pageTitle} | Kapunka Skincare`} />
+        <meta property="og:title" content={pageTitle} />
         <meta property="og:description" content={pageDescription} />
         {socialImage ? <meta property="og:image" content={socialImage} /> : null}
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={`${pageTitle} | Kapunka Skincare`} />
+        <meta name="twitter:title" content={pageTitle} />
         <meta name="twitter:description" content={pageDescription} />
         {socialImage ? <meta name="twitter:image" content={socialImage} /> : null}
       </Head>
@@ -269,7 +278,7 @@ const FounderStory: React.FC = () => {
           <div className="absolute inset-0">
             <img
               src={heroImageUrl}
-              alt={heroImage.alt ?? pageTitle}
+              alt={heroImage.alt ?? metaTitle}
               className="h-full w-full object-cover opacity-40"
               data-sb-field-path="images.hero.src#@src images.hero.alt#@alt"
             />
@@ -372,7 +381,7 @@ const FounderStory: React.FC = () => {
                     <div className="overflow-hidden rounded-xl border border-stone-100 shadow-sm">
                       <img
                         src={milestone.image.src}
-                        alt={milestone.image.alt ?? milestone.title ?? 'Milestone'}
+                        alt={milestone.image.alt ?? milestone.title ?? milestone.year ?? metaTitle}
                         className="h-full w-full object-cover"
                         data-sb-field-path={`image.src#@src image.alt#@alt`}
                       />
@@ -403,7 +412,7 @@ const FounderStory: React.FC = () => {
                   {image.src ? (
                     <img
                       src={image.src}
-                      alt={image.alt ?? pageTitle}
+                      alt={image.alt ?? metaTitle}
                       className="h-56 w-full object-cover"
                       data-sb-field-path="src#@src alt#@alt"
                     />

--- a/pages/Learn.tsx
+++ b/pages/Learn.tsx
@@ -8,6 +8,7 @@ import { Helmet } from 'react-helmet-async';
 import { motion } from 'framer-motion';
 import ArticleCard from '../components/ArticleCard';
 import { useLanguage } from '../contexts/LanguageContext';
+import { useSiteSettings } from '../contexts/SiteSettingsContext';
 import type { Article } from '../types';
 import {
   loadLearnPageContent,
@@ -17,6 +18,7 @@ import {
 import { fetchVisualEditorJson } from '../utils/fetchVisualEditorJson';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 interface ArticlesResponse {
   items?: Article[];
@@ -32,6 +34,7 @@ const Learn: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [pageContent, setPageContent] = useState<LearnPageContentResult | null>(null);
   const { t, language } = useLanguage();
+  const { settings } = useSiteSettings();
   const { contentVersion } = useVisualEditorSync();
 
   useEffect(() => {
@@ -190,18 +193,28 @@ const Learn: React.FC = () => {
     return articles.filter(article => article.category === activeCategory);
   }, [activeCategory, articles]);
 
-  const metaTitle = pageContent?.data.metaTitle ?? t('learn.metaTitle');
-  const metaDescription = pageContent?.data.metaDescription ?? t('learn.metaDescription');
+  const metaTitle = (pageContent?.data.metaTitle ?? t('learn.metaTitle'))?.trim();
+  const metaDescription = (pageContent?.data.metaDescription ?? t('learn.metaDescription'))?.trim();
   const heroTitle = pageContent?.data.heroTitle ?? t('learn.title');
   const heroSubtitle = pageContent?.data.heroSubtitle ?? t('learn.subtitle');
   const heroTitleFieldPath = `${learnFieldPath}.heroTitle`;
   const heroSubtitleFieldPath = `${learnFieldPath}.heroSubtitle`;
+  const rawSocialImage = settings.home?.heroImage?.trim() ?? '';
+  const socialImage = rawSocialImage ? getCloudinaryUrl(rawSocialImage) ?? rawSocialImage : undefined;
+  const pageTitle = `${metaTitle} | Kapunka Skincare`;
 
   return (
     <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
       <Helmet>
-        <title>{metaTitle} | Kapunka Skincare</title>
+        <title>{pageTitle}</title>
         <meta name="description" content={metaDescription} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={metaDescription} />
+        {socialImage ? <meta property="og:image" content={socialImage} /> : null}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={metaDescription} />
+        {socialImage ? <meta name="twitter:image" content={socialImage} /> : null}
       </Helmet>
 
       <motion.header

--- a/pages/ProductEducation.tsx
+++ b/pages/ProductEducation.tsx
@@ -4,6 +4,8 @@ import { motion } from 'framer-motion';
 import { fetchVisualEditorMarkdown } from '../utils/fetchVisualEditorMarkdown';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
+import { useLanguage } from '../contexts/LanguageContext';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 interface BenefitItem {
   title?: string;
@@ -24,6 +26,8 @@ interface FaqItem {
 interface ProductEducationContent {
   headline?: string;
   subheadline?: string;
+  metaTitle?: string;
+  metaDescription?: string;
   composition?: string;
   certifications?: string[];
   benefits?: BenefitItem[];
@@ -80,7 +84,17 @@ const isProductEducationContent = (value: unknown): value is ProductEducationCon
     return false;
   }
 
-  const { certifications, benefits, usageInstructions, faqs, headline, subheadline, composition } = value;
+  const {
+    certifications,
+    benefits,
+    usageInstructions,
+    faqs,
+    headline,
+    subheadline,
+    composition,
+    metaTitle,
+    metaDescription,
+  } = value;
 
   if (certifications !== undefined && !isStringArray(certifications)) {
     return false;
@@ -108,12 +122,15 @@ const isProductEducationContent = (value: unknown): value is ProductEducationCon
     (headline === undefined || typeof headline === 'string')
     && (subheadline === undefined || typeof subheadline === 'string')
     && (composition === undefined || typeof composition === 'string')
+    && (metaTitle === undefined || typeof metaTitle === 'string')
+    && (metaDescription === undefined || typeof metaDescription === 'string')
   );
 };
 
 const ProductEducation: React.FC = () => {
   const [content, setContent] = useState<ProductEducationContent | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const { t } = useLanguage();
   const { contentVersion } = useVisualEditorSync();
   const { settings: siteSettings } = useSiteSettings();
 
@@ -159,10 +176,15 @@ const ProductEducation: React.FC = () => {
   const faqs = content?.faqs?.filter((faq) => faq && (faq.question?.trim() || faq.answer?.trim())) ?? [];
   const certifications = content?.certifications?.filter((cert) => cert.trim().length > 0) ?? [];
 
-  const metaTitle = content?.headline ?? 'Kapunka Product Education';
-  const metaDescription = content?.subheadline ?? 'Learn how Kapunka argan skincare is composed, certified, and used in clinical rituals.';
+  const metaTitle = (content?.metaTitle ?? content?.headline ?? t('productEducation.metaTitle'))?.trim();
+  const metaDescription = (
+    content?.metaDescription
+    ?? content?.subheadline
+    ?? t('productEducation.metaDescription')
+  )?.trim();
   const pageTitle = `${metaTitle} | Kapunka Skincare`;
-  const socialImage = siteSettings.home?.heroImage;
+  const rawSocialImage = siteSettings.home?.heroImage?.trim() ?? '';
+  const socialImage = rawSocialImage ? getCloudinaryUrl(rawSocialImage) ?? rawSocialImage : undefined;
 
   const compositionParagraphs = useMemo(() => {
     if (!content?.composition) {

--- a/pages/Videos.tsx
+++ b/pages/Videos.tsx
@@ -7,6 +7,8 @@ import type { PageContent, PageSection } from '../types';
 import { fetchVisualEditorMarkdown } from '../utils/fetchVisualEditorMarkdown';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
+import { useSiteSettings } from '../contexts/SiteSettingsContext';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 
 const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
   'timeline',
@@ -68,6 +70,7 @@ const Videos: React.FC = () => {
   const { t, language } = useLanguage();
   const [pageContent, setPageContent] = useState<PageContent | null>(null);
   const { contentVersion } = useVisualEditorSync();
+  const { settings } = useSiteSettings();
 
   useEffect(() => {
     let isMounted = true;
@@ -113,14 +116,24 @@ const Videos: React.FC = () => {
 
   const sections = pageContent?.sections ?? [];
   const sectionsFieldPath = `pages.videos_${language}.sections`;
-  const computedTitle = pageContent?.metaTitle ?? `${t('videos.metaTitle')} | Kapunka Skincare`;
-  const computedDescription = pageContent?.metaDescription ?? t('videos.metaDescription');
+  const metaTitle = (pageContent?.metaTitle ?? t('videos.metaTitle'))?.trim();
+  const metaDescription = (pageContent?.metaDescription ?? t('videos.metaDescription'))?.trim();
+  const pageTitle = `${metaTitle} | Kapunka Skincare`;
+  const rawSocialImage = settings.home?.heroImage?.trim() ?? '';
+  const socialImage = rawSocialImage ? getCloudinaryUrl(rawSocialImage) ?? rawSocialImage : undefined;
 
   return (
     <div>
       <Helmet>
-        <title>{computedTitle}</title>
-        <meta name="description" content={computedDescription} />
+        <title>{pageTitle}</title>
+        <meta name="description" content={metaDescription} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={metaDescription} />
+        {socialImage ? <meta property="og:image" content={socialImage} /> : null}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={metaDescription} />
+        {socialImage ? <meta name="twitter:image" content={socialImage} /> : null}
       </Helmet>
 
       <header className="py-20 sm:py-28 bg-stone-100">

--- a/pages/for-clinics.tsx
+++ b/pages/for-clinics.tsx
@@ -5,6 +5,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
+import { getCloudinaryUrl } from '../utils/imageUrl';
 import {
   loadClinicsPageContent,
   type ClinicsPageContentResult,
@@ -312,7 +313,8 @@ const ForClinics: React.FC = () => {
       };
 
   const ctaLink = settings.clinics?.ctaLink ?? '#/contact';
-  const socialImage = settings.home?.heroImage;
+  const rawSocialImage = settings.home?.heroImage?.trim() ?? '';
+  const socialImage = rawSocialImage ? getCloudinaryUrl(rawSocialImage) ?? rawSocialImage : undefined;
   const rootObjectId = getVisualEditorAttributes(clinicsFieldPath)['data-sb-object-id'];
 
   return (


### PR DESCRIPTION
## Summary
- add og/twitter meta tags and translation-aware fallbacks to marketing and clinic pages
- ensure learn, videos, training, and product education pages read CMS meta titles and descriptions with localized fallbacks
- update image alt text fallbacks and provide shared social preview images plus translation resources

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2982b47e88320b1418f96e2ad2377