### PR TITLE
feat: add Cloudinary wrapper for image delivery

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -630,8 +630,8 @@ display_url: https://kapunka-new.netlify.app
 media_library:
   name: cloudinary
   config:
-    cloud_name: "du6xl727e"
-    api_key: "_LAI3fKbumFxgclHTtbAuC-0_co"
+    cloud_name: "<your_cloud_name>"
+    api_key: "<NETLIFY_ENV_CLOUDINARY_API_KEY>"
 
 collections:
   - name: site

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -5,7 +5,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import type { Article } from '../types';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { buildLocalizedPath } from '../utils/localePaths';
-import { getCloudinaryUrl } from '../utils/imageUrl';
+import { toCld } from '@/src/lib/images';
 
 interface ArticleCardProps {
   article: Article;
@@ -32,7 +32,7 @@ const ArticleCard: React.FC<ArticleCardProps> = (props) => {
   const { translate, t, language } = useLanguage();
 
   const imageSrc = (article.imageUrl ?? '').trim();
-  const cloudinaryUrl = imageSrc ? getCloudinaryUrl(imageSrc) ?? imageSrc : '';
+  const cloudinaryUrl = toCld(imageSrc);
 
   const translationCategoryKey = `learn.categories.${article.category}`;
   const translatedCategory = t(translationCategoryKey);

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -8,7 +8,7 @@ import { useUI } from '../contexts/UIContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { formatCurrency } from '../utils/currency';
-import { getCloudinaryUrl } from '../utils/imageUrl';
+import { toCld } from '@/src/lib/images';
 import type { Product } from '../types';
 import { buildLocalizedPath } from '../utils/localePaths';
 
@@ -55,7 +55,7 @@ const ProductCard: React.FC<ProductCardProps> = (props) => {
   }, [setSelectedSizeId]);
 
   const productImageSrc = (product.imageUrl ?? '').trim();
-  const cloudinaryUrl = productImageSrc ? getCloudinaryUrl(productImageSrc) ?? productImageSrc : '';
+  const cloudinaryUrl = toCld(productImageSrc);
 
   return (
     <motion.div

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-11 — Swapped Decap media library to Cloudinary env placeholders
+- **What changed**: Updated `admin/config.yml` to point the Decap media library at Cloudinary with placeholder env references so builds read credentials from Netlify. No runtime keys remain hardcoded in the repo.
+- **Impact & follow-up**: Keeps editorial uploads routed through Cloudinary without exposing secrets. Ensure Netlify env vars `CLOUDINARY_BASE_URL` and `NETLIFY_ENV_CLOUDINARY_API_KEY` stay configured across deploy contexts.
+- **References**: Pending PR
+
 ## 2025-10-10 — Localized site settings refinements
 - **What changed**: Updated `admin/config.yml` so brand name, alt text, footer legal copy, social labels, and SEO defaults use explicit locale fields instead of raw maps, added validation patterns for contact links, and introduced descriptive hints to guide editors.
 - **Impact & follow-up**: Editors now see one input per language for shared site settings and get immediate validation for contact URLs, reducing content errors in Decap. Monitor upcoming edits to ensure the new patterns do not block legitimate international phone formats.

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,0 +1,12 @@
+export function toCld(src?: string) {
+  if (!src) return src || '';
+  const isAbsolute = /^https?:\/\//i.test(src);
+  if (isAbsolute) return src;
+  const base = process.env.CLOUDINARY_BASE_URL || '';
+  // strip common repo upload roots
+  const clean = src
+    .replace(/^\/?content\/[a-z]{2}\/uploads\//, '')
+    .replace(/^\/?static\/images\/uploads\//, '')
+    .replace(/^\/?images\/uploads\//, '');
+  return base ? `${base}/${clean}` : src;
+}


### PR DESCRIPTION
## Summary
- add a shared `toCld` helper to normalize relative image sources against the Cloudinary base URL
- update ProductCard and ArticleCard to consume the helper so catalogue images use CDN delivery
- point the Decap media library at Cloudinary env placeholders and record the configuration change in the rolling log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2c5012c0c8320a2c8592b6415f6ff