### PR TITLE
Add reduced-motion aware section animations

### DIFF
--- a/components/sections/ImageTextHalf.tsx
+++ b/components/sections/ImageTextHalf.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 import ReactMarkdown from 'react-markdown';
 import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
 import { getCloudinaryUrl } from '../../utils/imageUrl';
+import { usePrefersReducedMotion } from '../../src/hooks/useReducedMotion';
 
 interface ImageTextHalfProps {
   image?: string;
@@ -12,6 +14,8 @@ interface ImageTextHalfProps {
 }
 
 const ImageTextHalf: React.FC<ImageTextHalfProps> = ({ image, title, text, imageAlt, fieldPath }) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
   if (!title && !text && !image) {
     return null;
   }
@@ -24,6 +28,70 @@ const ImageTextHalf: React.FC<ImageTextHalfProps> = ({ image, title, text, image
     .find((value): value is string => Boolean(value))
     ?? 'Featured illustration';
 
+  const revealProps = {
+    initial: { opacity: 0, y: 20 },
+    whileInView: { opacity: 1, y: 0 },
+    viewport: { once: true, amount: 0.2 },
+    transition: { duration: 0.6, delay: 0.1 },
+  } as const;
+
+  const textContent = (
+    <>
+      {title && (
+        <h2
+          className="text-3xl font-semibold text-stone-900 mb-6"
+          {...(fieldPath ? getVisualEditorAttributes(`${fieldPath}.title`) : {})}
+        >
+          {title}
+        </h2>
+      )}
+      {markdownSource && (
+        <div
+          className="prose prose-stone max-w-none text-stone-700"
+          {...(fieldPath ? getVisualEditorAttributes(`${fieldPath}.text`) : {})}
+        >
+          <ReactMarkdown>{markdownSource}</ReactMarkdown>
+        </div>
+      )}
+    </>
+  );
+
+  const textWrapper = prefersReducedMotion ? (
+    <div className="order-2 lg:order-1">
+      {textContent}
+    </div>
+  ) : (
+    <motion.div className="order-2 lg:order-1" {...revealProps}>
+      {textContent}
+    </motion.div>
+  );
+
+  const imageContent = trimmedImage ? (
+    <img
+      src={cloudinaryUrl}
+      alt={altText}
+      className="w-full h-full object-cover rounded-lg shadow-sm"
+      {...(fieldPath ? getVisualEditorAttributes(`${fieldPath}.image`) : {})}
+    />
+  ) : (
+    <div
+      className="w-full aspect-[4/3] rounded-lg border border-dashed border-stone-300 bg-stone-100 flex items-center justify-center text-sm text-stone-400"
+      {...(fieldPath ? getVisualEditorAttributes(`${fieldPath}.image`) : {})}
+    >
+      Image coming soon
+    </div>
+  );
+
+  const imageWrapper = prefersReducedMotion ? (
+    <div className="order-1 lg:order-2">
+      {imageContent}
+    </div>
+  ) : (
+    <motion.div className="order-1 lg:order-2" {...revealProps}>
+      {imageContent}
+    </motion.div>
+  );
+
   return (
     <section
       className="py-16 sm:py-24 bg-white"
@@ -31,41 +99,8 @@ const ImageTextHalf: React.FC<ImageTextHalfProps> = ({ image, title, text, image
     >
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-          <div className="order-2 lg:order-1">
-            {title && (
-              <h2
-                className="text-3xl font-semibold text-stone-900 mb-6"
-                {...(fieldPath ? getVisualEditorAttributes(`${fieldPath}.title`) : {})}
-              >
-                {title}
-              </h2>
-            )}
-            {markdownSource && (
-              <div
-                className="prose prose-stone max-w-none text-stone-700"
-                {...(fieldPath ? getVisualEditorAttributes(`${fieldPath}.text`) : {})}
-              >
-                <ReactMarkdown>{markdownSource}</ReactMarkdown>
-              </div>
-            )}
-          </div>
-          <div className="order-1 lg:order-2">
-            {trimmedImage ? (
-              <img
-                src={cloudinaryUrl}
-                alt={altText}
-                className="w-full h-full object-cover rounded-lg shadow-sm"
-                {...(fieldPath ? getVisualEditorAttributes(`${fieldPath}.image`) : {})}
-              />
-            ) : (
-              <div
-                className="w-full aspect-[4/3] rounded-lg border border-dashed border-stone-300 bg-stone-100 flex items-center justify-center text-sm text-stone-400"
-                {...(fieldPath ? getVisualEditorAttributes(`${fieldPath}.image`) : {})}
-              >
-                Image coming soon
-              </div>
-            )}
-          </div>
+          {textWrapper}
+          {imageWrapper}
         </div>
       </div>
     </section>

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,7 @@
+export function usePrefersReducedMotion(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}


### PR DESCRIPTION
## Summary
- add a reusable hook for checking the reduced-motion preference
- animate the home hero, product grid, and ImageTextHalf section groups with viewport-triggered reveals guarded by the preference
- add gentle transform hover affordances to hero CTAs without altering existing colors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2cef4777083209fa071bc148e7438