### PR TITLE
chore: document Cloudinary workflow and CMS editing model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,27 @@ To ensure high-quality, non-breaking changes, the agent must employ detailed spe
 * **Deliver Minimal Diff and Tests:** The final deliverable must be a minimal diff containing only necessary code additions and corrections.
 * **Risk Mitigation:** Require a rollback strategy for critical changes.
 * **Final Check:** Confirm Visual Editor bindings are intact and running successfully locally after applying changes.
+
+---
+
+# VI. Media Delivery, CMS Editing Model, and Git Hygiene
+
+## A. Cloudinary Image Pipeline
+
+* `CLOUDINARY_BASE_URL` is injected by Vite (`vite.config.ts`) and must remain the single source for the Cloudinary cloud name + upload root.
+* Always wrap CMS-provided image paths with `toCld()` from `src/lib/images.ts` before rendering. The helper strips legacy upload prefixes and safely concatenates the base URL.
+* Skip `toCld()` only when you can prove the source is already an absolute `https://` URL (the helper performs this guard, so it is typically safe to call unconditionally).
+* Never inline hard-coded Cloudinary domains; rely on the environment variable so staging and production share the same transformation pipeline.
+
+## B. CMS Editing Model (Single-File Pages)
+
+* Page content is consolidated inside `content/pages_v2/index.json`. Each entry represents a full page and must stay self-contained.
+* The `sections` arrays inside each page are mirrored by collapsible groups in the Netlify Visual Editor. Preserve these group boundaries when adding, reordering, or deleting blocks so editors retain predictable collapse behaviour.
+* Localised copy and metadata values are stored as objects keyed by locale (`en`, `pt`, `es`). New fields must follow the same shape and include all supported locales.
+* When introducing new schema fields, update `metadata.json` and the Visual Editor mirror in a single commit to prevent drift.
+
+## C. Branch and Commit Conventions
+
+* Stay on the branch provided in the task (no new branches, no rebasing onto `main`).
+* Use focused commits with imperative, conventional messages. Do not bypass pre-existing instructions (e.g., never run `git commit -am`, avoid force-pushing).
+* Run required checks before committing, document the results, and prefer minimal diffs that keep rollbacks trivial.

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -103,6 +103,13 @@ To keep the editor experience predictable and efficient, every CMS enhancement m
 - **Feature leverage:** Prefer built-in Decap capabilities (collections, widgets, i18n, previews) over bespoke workarounds that fragment the experience.
 - **Accessibility:** Ensure the authoring surface supports inclusive practices (alt text prompts, clear instructions, keyboard-friendly forms).
 
+### Single-File Page Model
+
+- Unified pages now live in `content/pages_v2/index.json`. Each object in the `pages` array represents one page, consolidating hero copy, metadata, and section blocks in a single location.
+- Keep the `sections` arrays intact. The Visual Editor maps these arrays to collapsible groups, so regrouping or flattening them breaks the editor's collapse/expand affordances.
+- Every textual field is an object keyed by locale (`en`, `pt`, `es`). Populate all locales whenever you add fields, and keep translations synchronised to avoid mixed-language renders.
+- When you introduce or rename fields, mirror the change in `metadata.json` and regenerate the Visual Editor mirror so editors see the new schema immediately.
+
 ### Netlify Visual Editor Workflow
 
 - The project is wired for the **Netlify Visual Editor**. The integration relies on `netlify.toml` (see the `[visual_editor]` section), the page model map in `stackbit.config.js`, the editing schema in `metadata.json`, and the generated content mirror under `.netlify/visual-editor/content/`.
@@ -144,9 +151,21 @@ While a formal testing suite is not yet implemented, the following principles sh
   - The `importmap` in `index.html` has been carefully configured. Do not add or change entries for `react` or `react-dom`.
   - Adding conflicting entries (especially those pointing to React 19) will cause a fatal `"Minified React error #31"` and break the entire application. This is a known, critical issue in this environment.
 
+### Cloudinary Media Pipeline
+
+- The Netlify runtime injects `process.env.CLOUDINARY_BASE_URL`; Vite exposes it to the client bundle. Treat it as the single source of truth for Cloudinary delivery URLs.
+- Always pass CMS-provided image paths through `toCld()` (`src/lib/images.ts`) before rendering images or backgrounds. The helper strips legacy upload prefixes and skips transformation for absolute URLs.
+- Do not hardcode Cloudinary domains or transformations. Keep configuration in environment variables so staging and production share the same media settings.
+
+## 10. Branch & Commit Workflow
+
+- Stay on the branch provided in the task/issue and avoid creating additional branches unless explicitly required.
+- Use focused, conventional commits with imperative subjects. Never rely on `git commit -am`; stage files explicitly so you review the diff before committing.
+- Run required build or lint commands before committing, document the results, and keep diffs minimal to simplify reviews and rollbacks.
+
 ---
 
-## 10. Deployment
+## 11. Deployment
 
 - **Hosting:** The site is configured for deployment on **Netlify**.
 - **CMS Integration:** The Decap CMS relies on **Netlify Identity** for user authentication and **Netlify Git Gateway** to write content back to the GitHub repository. Both must be enabled in the Netlify dashboard for the CMS to function.


### PR DESCRIPTION
## Summary
- add Cloudinary base URL and `toCld()` usage guidance to the contributor docs
- document the single-file page CMS model, collapsible sections, and locale-specific fields
- capture the expected branch and commit workflow for contributors

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68e2d355dc2c8320b082b907f7d7451a