### PR TITLE
feat(nav): implement mega-menu and search

### DIFF
--- a/components/MegaMenu.tsx
+++ b/components/MegaMenu.tsx
@@ -1,0 +1,106 @@
+import React, { useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { toCld } from '@/src/lib/images';
+import { getVisualEditorAttributes } from '../utils/stackbitBindings';
+
+export type MegaMenuItem = {
+  title: string;
+  href: string;
+  icon: string;
+  description: string;
+  titleFieldPath?: string;
+  titleSbFieldPath?: string;
+  descriptionFieldPath?: string;
+  descriptionSbFieldPath?: string;
+};
+
+type MegaMenuProps = {
+  items: MegaMenuItem[];
+  onClose: () => void;
+  labelledBy?: string;
+  menuId?: string;
+  menuRef?: (node: HTMLDivElement | null) => void;
+  sbObjectId?: string;
+  onEscape?: () => void;
+};
+
+const MegaMenu: React.FC<MegaMenuProps> = ({
+  items,
+  onClose,
+  labelledBy,
+  menuId,
+  menuRef,
+  sbObjectId,
+  onEscape,
+}) => {
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        onEscape?.();
+      }
+    },
+    [onClose, onEscape],
+  );
+
+  return (
+    <motion.div
+      id={menuId}
+      role="menu"
+      aria-labelledby={labelledBy}
+      ref={menuRef}
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 8 }}
+      transition={{ duration: 0.15, ease: 'easeOut' }}
+      className="pointer-events-auto absolute left-1/2 top-full z-50 mt-6 w-[min(90vw,640px)] -translate-x-1/2 rounded-2xl bg-stone-50 p-6 shadow-xl ring-1 ring-stone-200/60"
+      onKeyDown={handleKeyDown}
+      data-sb-object-id={sbObjectId}
+    >
+      <div className="grid gap-4 sm:grid-cols-2">
+        {items.map((item) => {
+          const cloudinaryUrl = toCld(item.icon);
+
+          return (
+            <Link
+              key={item.href}
+              to={item.href}
+              role="menuitem"
+              className="group flex items-start gap-4 rounded-xl p-4 transition-colors duration-200 hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-400"
+              onClick={onClose}
+            >
+              <div className="h-14 w-14 flex-shrink-0 overflow-hidden rounded-lg bg-stone-100 shadow-sm">
+                <img
+                  src={cloudinaryUrl}
+                  alt={item.title}
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                />
+              </div>
+              <div className="flex-1">
+                <h3
+                  className="text-base font-semibold text-stone-900"
+                  {...getVisualEditorAttributes(item.titleFieldPath ?? undefined)}
+                  data-sb-field-path={item.titleSbFieldPath}
+                >
+                  {item.title}
+                </h3>
+                <p
+                  className="mt-2 text-sm text-stone-500"
+                  {...getVisualEditorAttributes(item.descriptionFieldPath ?? undefined)}
+                  data-sb-field-path={item.descriptionSbFieldPath}
+                >
+                  {item.description}
+                </p>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </motion.div>
+  );
+};
+
+export default MegaMenu;

--- a/content/translations/nav.json
+++ b/content/translations/nav.json
@@ -11,7 +11,19 @@
     "training": "Training",
     "clinics": "Clinics",
     "about": "About",
-    "contact": "Contact"
+    "contact": "Contact",
+    "navDescriptions": {
+      "learn": {
+        "manifesto": "Discover the origins of Kapunka and the values that guide our craft.",
+        "videos": "Watch tutorials and stories to see our rituals in motion.",
+        "productEducation": "Learn how to choose and use argan-based products for every routine.",
+        "method": "Explore the Kapunka method with step-by-step techniques."
+      },
+      "forProfessionals": {
+        "training": "Join certified programs designed for therapists and wellness experts.",
+        "clinics": "Partner with clinics bringing Kapunka treatments to their clients."
+      }
+    }
   },
   "pt": {
     "shop": "Loja",
@@ -24,7 +36,19 @@
     "training": "Treinamento",
     "clinics": "Clínicas",
     "about": "Sobre",
-    "contact": "Contato"
+    "contact": "Contato",
+    "navDescriptions": {
+      "learn": {
+        "manifesto": "Descubra as origens da Kapunka e os valores que orientam o nosso ofício.",
+        "videos": "Assista a tutoriais e histórias para ver os nossos rituais em ação.",
+        "productEducation": "Aprenda a escolher e usar produtos à base de argan em cada rotina.",
+        "method": "Explore o método Kapunka com técnicas passo a passo."
+      },
+      "forProfessionals": {
+        "training": "Participe em programas certificados para terapeutas e especialistas em bem-estar.",
+        "clinics": "Associe-se a clínicas que oferecem tratamentos Kapunka aos seus clientes."
+      }
+    }
   },
   "es": {
     "shop": "Tienda",
@@ -37,6 +61,18 @@
     "training": "Formación",
     "clinics": "Clínicas",
     "about": "Nosotros",
-    "contact": "Contacto"
+    "contact": "Contacto",
+    "navDescriptions": {
+      "learn": {
+        "manifesto": "Descubre los orígenes de Kapunka y los valores que guían nuestro oficio.",
+        "videos": "Mira tutoriales e historias para ver nuestros rituales en acción.",
+        "productEducation": "Aprende a elegir y usar productos a base de argán en cada rutina.",
+        "method": "Explora el método Kapunka con técnicas paso a paso."
+      },
+      "forProfessionals": {
+        "training": "Únete a programas certificados pensados para terapeutas y expertos en bienestar.",
+        "clinics": "Colabora con clínicas que llevan los tratamientos Kapunka a sus clientes."
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a reusable MegaMenu component with Cloudinary-backed imagery and Stackbit bindings for menu content
- replace the desktop Learn and For Professionals dropdowns with the new mega menu and wire up keyboard/escape handling
- extend navigation translations with localized descriptions and surface the search shortcut beside the language selector

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2e818f1f48320a80daff71132bce0