### PR TITLE
Complete contact, training and founder story pages

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -72,6 +72,7 @@ const NAVIGATION_CONFIG: NavConfigItem[] = [
     fallback: 'Learn',
     items: [
       { key: 'manifesto', path: '/story', fallback: 'Manifesto & Story' },
+      { key: 'founderStory', path: '/founder-story', fallback: 'Founder Story' },
       { key: 'videos', path: '/videos', fallback: 'Videos' },
       { key: 'productEducation', path: '/product-education', fallback: 'Product Education' },
       { key: 'method', path: '/method', fallback: 'Method' },
@@ -97,6 +98,10 @@ const MEGA_MENU_METADATA = {
     manifesto: {
       icon: 'content/uploads/shared/kapunka-origem.jpg',
       descriptionFallback: 'Discover the origins of Kapunka and the values that guide our craft.',
+    },
+    founderStory: {
+      icon: 'content/uploads/site/monica-argan-.jpg',
+      descriptionFallback: 'Meet the founder bringing Moroccan argan rituals into modern clinical care.',
     },
     videos: {
       icon: 'content/uploads/shared/kapunka-instagrammer.jpg',

--- a/content/site.json
+++ b/content/site.json
@@ -1,8 +1,8 @@
 {
   "contact": {
     "email": "global@kapunka.com",
-    "phone": "+1 (234) 567-890",
-    "whatsapp": "https://wa.me/1234567890"
+    "phone": "+34 637 520 704",
+    "whatsapp": "https://wa.me/34637520704"
   },
   "brand": {
     "name": {

--- a/content/translations/contact.json
+++ b/content/translations/contact.json
@@ -20,7 +20,13 @@
     "emailTitle": "Email",
     "phoneTitle": "Phone",
     "whatsappTitle": "WhatsApp",
-    "whatsappAction": "Chat with us"
+    "whatsappAction": "Chat with us",
+    "addressTitle": "Visit our atelier",
+    "addressLines": [
+      "Els Alamús (25221) Lleida",
+      "Carrer de la Plaça la Placeta, 2, 2º",
+      "Spain"
+    ]
   },
   "pt": {
     "metaTitle": "Contato Kapunka",
@@ -42,7 +48,13 @@
     "emailTitle": "E-mail",
     "phoneTitle": "Telefone",
     "whatsappTitle": "WhatsApp",
-    "whatsappAction": "Converse conosco"
+    "whatsappAction": "Converse conosco",
+    "addressTitle": "Visite nosso ateliê",
+    "addressLines": [
+      "Els Alamús (25221) Lleida",
+      "Carrer de la Plaça la Placeta, 2, 2º",
+      "Espanha"
+    ]
   },
   "es": {
     "metaTitle": "Contacto Kapunka",
@@ -64,6 +76,12 @@
     "emailTitle": "Correo electrónico",
     "phoneTitle": "Teléfono",
     "whatsappTitle": "WhatsApp",
-    "whatsappAction": "Chatea con nosotros"
+    "whatsappAction": "Chatea con nosotros",
+    "addressTitle": "Visita nuestro atelier",
+    "addressLines": [
+      "Els Alamús (25221) Lleida",
+      "Carrer de la Plaça la Placeta, 2, 2º",
+      "España"
+    ]
   }
 }

--- a/content/translations/nav.json
+++ b/content/translations/nav.json
@@ -5,6 +5,7 @@
     "learn": "Learn",
     "forProfessionals": "For Professionals",
     "manifesto": "Manifesto & Story",
+    "founderStory": "Founder Story",
     "videos": "Videos",
     "productEducation": "Product Education",
     "method": "Method Kapunka",
@@ -15,6 +16,7 @@
     "navDescriptions": {
       "learn": {
         "manifesto": "Discover the origins of Kapunka and the values that guide our craft.",
+        "founderStory": "Learn how Monica bridged Moroccan cooperatives with today’s clinical rituals.",
         "videos": "Watch tutorials and stories to see our rituals in motion.",
         "productEducation": "Learn how to choose and use argan-based products for every routine.",
         "method": "Explore the Kapunka method with step-by-step techniques."
@@ -30,6 +32,7 @@
     "learn": "Aprender",
     "forProfessionals": "Para Profissionais",
     "manifesto": "Manifesto & História",
+    "founderStory": "História da Fundadora",
     "videos": "Vídeos",
     "productEducation": "Educação sobre Produtos",
     "method": "Método Kapunka",
@@ -40,6 +43,7 @@
     "navDescriptions": {
       "learn": {
         "manifesto": "Descubra as origens da Kapunka e os valores que orientam o nosso ofício.",
+        "founderStory": "Conheça como Monica conectou cooperativas marroquinas às rotinas clínicas atuais.",
         "videos": "Assista a tutoriais e histórias para ver os nossos rituais em ação.",
         "productEducation": "Aprenda a escolher e usar produtos à base de argan em cada rotina.",
         "method": "Explore o método Kapunka com técnicas passo a passo."
@@ -55,6 +59,7 @@
     "learn": "Aprender",
     "forProfessionals": "Para Profesionales",
     "manifesto": "Manifiesto e Historia",
+    "founderStory": "Historia de la Fundadora",
     "videos": "Videos",
     "productEducation": "Educación sobre Productos",
     "method": "Método Kapunka",
@@ -65,6 +70,7 @@
     "navDescriptions": {
       "learn": {
         "manifesto": "Descubre los orígenes de Kapunka y los valores que guían nuestro oficio.",
+        "founderStory": "Conoce cómo Monica unió cooperativas marroquíes con los rituales clínicos actuales.",
         "videos": "Mira tutoriales e historias para ver nuestros rituales en acción.",
         "productEducation": "Aprende a elegir y usar productos a base de argán en cada rutina.",
         "method": "Explora el método Kapunka con técnicas paso a paso."

--- a/content/translations/training.json
+++ b/content/translations/training.json
@@ -5,6 +5,9 @@
     "subtitle": "Stay ahead with courses and professional content curated for practitioners and partners.",
     "metaTitle": "Training Hub",
     "metaDescription": "Browse Kapunka's training catalog featuring professional development, product education, and partner resources.",
+    "objectivesHeading": "What you'll master",
+    "modulesHeading": "Inside the program",
+    "ctaHeading": "Secure your place",
     "emptyState": "Training resources are coming soon.",
     "learnMore": "Learn More"
   },
@@ -13,6 +16,9 @@
     "subtitle": "Atualize-se com cursos e conteúdos profissionais selecionados para praticantes e parceiros.",
     "metaTitle": "Centro de Treinamento",
     "metaDescription": "Conheça o catálogo de treinamentos Kapunka com desenvolvimento profissional, educação sobre produtos e recursos para parceiros.",
+    "objectivesHeading": "O que você vai dominar",
+    "modulesHeading": "Dentro do programa",
+    "ctaHeading": "Garanta sua vaga",
     "emptyState": "Os recursos de treinamento estarão disponíveis em breve.",
     "learnMore": "Saiba mais"
   },
@@ -21,6 +27,9 @@
     "subtitle": "Mantente al día con cursos y contenidos profesionales creados para practicantes y socios.",
     "metaTitle": "Centro de Formación",
     "metaDescription": "Explora el catálogo de formación de Kapunka con desarrollo profesional, educación sobre productos y recursos para socios.",
+    "objectivesHeading": "Lo que dominarás",
+    "modulesHeading": "Dentro del programa",
+    "ctaHeading": "Reserva tu plaza",
     "emptyState": "Los recursos de formación estarán disponibles pronto.",
     "learnMore": "Más información"
   }

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-16 — Enabled Netlify contact form submissions
+- **What changed**: Wired the `/contact` form to Netlify Forms with the required hidden inputs, honeypot, and encoded POST handler. Updated contact translations to include the studio address and refreshed the site config phone/WhatsApp numbers.
+- **Impact & follow-up**: Messages now deliver to Netlify instead of the previous in-memory mock. Confirm the Netlify dashboard lists the new "kapunka-contact" form after deployment and set up notifications if needed.
+- **References**: Pending PR
+
 ## 2025-10-12 — Realigned nav translations with header IA
 - **What changed**: Added the missing navigation keys (For Professionals, Product Education, Clinics, Story) to `content/translations/nav.json` and exposed the matching fields in `admin/config.yml` so editors can localize every header label.
 - **Impact & follow-up**: Restores full localization coverage for the live six-item navigation across locales, preventing English fallbacks in Portuguese and Spanish. Confirm Decap saves the new fields and that Visual Editor bindings surface the updated labels when switching languages.

--- a/pages/Contact.tsx
+++ b/pages/Contact.tsx
@@ -1,220 +1,280 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Mail, Phone, MessageSquare } from 'lucide-react';
+import { Mail, Phone, MessageSquare, MapPin } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { getCloudinaryUrl } from '../utils/imageUrl';
 import Seo from '../components/Seo';
 
+const FORM_NAME = 'kapunka-contact';
+
 const ContactForm: React.FC = () => {
-    const { t, language } = useLanguage();
-    const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const { t, language } = useLanguage();
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const contactFormFieldPath = `translations.${language}.contact.form`;
 
-    const contactFormFieldPath = `translations.${language}.contact.form`;
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus('submitting');
 
-    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-        setStatus('submitting');
-        // Simulate form submission
-        await new Promise(resolve => setTimeout(resolve, 1500));
-        setStatus('success');
-    };
-    
-    return (
-        <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-                <input
-                    type="text"
-                    name="name"
-                    placeholder={t('contact.form.name')}
-                    required
-                    className="p-3 border border-stone-300 rounded-md focus:ring-stone-500 focus:border-stone-500"
-                    {...getVisualEditorAttributes(`${contactFormFieldPath}.name`)}
-                />
-                <input
-                    type="email"
-                    name="email"
-                    placeholder={t('contact.form.email')}
-                    required
-                    className="p-3 border border-stone-300 rounded-md focus:ring-stone-500 focus:border-stone-500"
-                    {...getVisualEditorAttributes(`${contactFormFieldPath}.email`)}
-                />
-            </div>
-            <textarea
-                name="message"
-                placeholder={t('contact.form.message')}
-                rows={5}
-                required
-                className="w-full p-3 border border-stone-300 rounded-md focus:ring-stone-500 focus:border-stone-500"
-                {...getVisualEditorAttributes(`${contactFormFieldPath}.message`)}
-            ></textarea>
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    formData.append('form-name', FORM_NAME);
 
-            <button
-                type="submit"
-                disabled={status === 'submitting'}
-                className="w-full bg-stone-900 text-white py-3 rounded-md font-semibold hover:bg-stone-700 transition-colors duration-300 disabled:bg-stone-400"
-            >
-                {status === 'submitting' ? (
-                    <span {...getVisualEditorAttributes(`${contactFormFieldPath}.sending`)}>
-                        {t('contact.form.sending')}
-                    </span>
-                ) : (
-                    <span {...getVisualEditorAttributes(`${contactFormFieldPath}.submit`)}>
-                        {t('contact.form.submit')}
-                    </span>
-                )}
-            </button>
+    try {
+      const response = await fetch('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(Array.from(formData.entries()) as [string, string][]).toString(),
+      });
 
-            {status === 'success' && (
-                <p className="text-center text-green-600" {...getVisualEditorAttributes(`${contactFormFieldPath}.success`)}>
-                    {t('contact.form.success')}
-                </p>
-            )}
-            {status === 'error' && (
-                <p className="text-center text-red-600" {...getVisualEditorAttributes(`${contactFormFieldPath}.error`)}>
-                    {t('contact.form.error')}
-                </p>
-            )}
-        </form>
-    );
+      if (!response.ok) {
+        throw new Error('Network error');
+      }
+
+      form.reset();
+      setStatus('success');
+    } catch (error) {
+      console.error('Failed to submit contact form', error);
+      setStatus('error');
+    }
+  };
+
+  return (
+    <form
+      name={FORM_NAME}
+      method="POST"
+      data-netlify="true"
+      data-netlify-honeypot="bot-field"
+      onSubmit={handleSubmit}
+      className="space-y-6"
+    >
+      <input type="hidden" name="form-name" value={FORM_NAME} />
+      <div hidden aria-hidden="true">
+        <label htmlFor="bot-field" className="block text-sm text-stone-500">
+          Do not fill this field
+        </label>
+        <input id="bot-field" name="bot-field" className="mt-1 w-full rounded-md border border-stone-300 p-2" />
+      </div>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        <input
+          type="text"
+          name="name"
+          placeholder={t('contact.form.name')}
+          required
+          className="rounded-md border border-stone-300 p-3 focus:border-stone-500 focus:ring-stone-500"
+          {...getVisualEditorAttributes(`${contactFormFieldPath}.name`)}
+        />
+        <input
+          type="email"
+          name="email"
+          placeholder={t('contact.form.email')}
+          required
+          className="rounded-md border border-stone-300 p-3 focus:border-stone-500 focus:ring-stone-500"
+          {...getVisualEditorAttributes(`${contactFormFieldPath}.email`)}
+        />
+      </div>
+      <textarea
+        name="message"
+        placeholder={t('contact.form.message')}
+        rows={5}
+        required
+        className="w-full rounded-md border border-stone-300 p-3 focus:border-stone-500 focus:ring-stone-500"
+        {...getVisualEditorAttributes(`${contactFormFieldPath}.message`)}
+      />
+      <button
+        type="submit"
+        disabled={status === 'submitting'}
+        className="w-full rounded-md bg-stone-900 py-3 font-semibold text-white transition-colors duration-300 hover:bg-stone-700 disabled:bg-stone-400"
+      >
+        {status === 'submitting' ? (
+          <span {...getVisualEditorAttributes(`${contactFormFieldPath}.sending`)}>
+            {t('contact.form.sending')}
+          </span>
+        ) : (
+          <span {...getVisualEditorAttributes(`${contactFormFieldPath}.submit`)}>
+            {t('contact.form.submit')}
+          </span>
+        )}
+      </button>
+      <div className="text-center" aria-live="polite">
+        {status === 'success' ? (
+          <p className="text-green-600" {...getVisualEditorAttributes(`${contactFormFieldPath}.success`)}>
+            {t('contact.form.success')}
+          </p>
+        ) : null}
+        {status === 'error' ? (
+          <p className="text-red-600" {...getVisualEditorAttributes(`${contactFormFieldPath}.error`)}>
+            {t('contact.form.error')}
+          </p>
+        ) : null}
+      </div>
+    </form>
+  );
 };
 
 const Contact: React.FC = () => {
-    const { t, language } = useLanguage();
-    const { settings } = useSiteSettings();
-    const { contentVersion } = useVisualEditorSync();
-    const contactSettings = settings.contact ?? { email: 'hello@kapunka.com', phone: '+1 (234) 567-890', whatsapp: 'https://wa.me/1234567890' };
-    const emailLink = contactSettings.email ? `mailto:${contactSettings.email}` : '#';
-    const phoneLink = contactSettings.phone ? `tel:${contactSettings.phone.replace(/[^+\d]/g, '')}` : '#';
-    const whatsappLink = contactSettings.whatsapp || '#';
-    const contactFieldPath = `translations.${language}.contact`;
-    const rawSocialImage = settings.home?.heroImage?.trim() ?? '';
-    const socialImage = rawSocialImage ? getCloudinaryUrl(rawSocialImage) ?? rawSocialImage : undefined;
+  const { t, language } = useLanguage();
+  const { settings } = useSiteSettings();
+  const contactSettings = settings.contact ?? {
+    email: 'hello@kapunka.com',
+    phone: '+1 (234) 567-890',
+    whatsapp: 'https://wa.me/1234567890',
+  };
+  const emailLink = contactSettings.email ? `mailto:${contactSettings.email}` : '#';
+  const phoneLink = contactSettings.phone ? `tel:${contactSettings.phone.replace(/[^+\d]/g, '')}` : '#';
+  const whatsappLink = contactSettings.whatsapp || '#';
+  const contactFieldPath = `translations.${language}.contact`;
+  const addressLinesRaw = t<unknown>('contact.addressLines');
+  const addressLines = Array.isArray(addressLinesRaw)
+    ? (addressLinesRaw.filter((line) => typeof line === 'string' && line.trim().length > 0) as string[])
+    : [];
+  const rawSocialImage = settings.home?.heroImage?.trim() ?? '';
+  const socialImage = rawSocialImage ? getCloudinaryUrl(rawSocialImage) ?? rawSocialImage : undefined;
 
-    const pageTitle = `${t('contact.title')} | Kapunka Skincare`;
-    const description = t('contact.metaDescription');
+  const metaTitle = t('contact.metaTitle');
+  const pageTitle = `${metaTitle} | Kapunka Skincare`;
+  const description = t('contact.metaDescription');
 
-    return (
-        <div className="py-16 sm:py-24">
-            <Seo
-                title={pageTitle}
-                description={description}
-                image={socialImage}
-                locale={language}
-            />
-            <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-                <header className="text-center mb-16">
-                <h1
-                    className="text-4xl sm:text-5xl font-semibold tracking-tight"
-                    {...getVisualEditorAttributes(`${contactFieldPath}.headerTitle`)}
-                >
-                    {t('contact.headerTitle')}
-                </h1>
-                <p
-                    className="mt-4 text-lg text-stone-600 max-w-2xl mx-auto"
-                    {...getVisualEditorAttributes(`${contactFieldPath}.headerSubtitle`)}
-                >
-                    {t('contact.headerSubtitle')}
-                </p>
-            </header>
-            
-                <div className="grid md:grid-cols-2 gap-12 max-w-5xl mx-auto">
-                <motion.div 
-                    initial={{ opacity: 0, x: -30 }} 
-                    whileInView={{ opacity: 1, x: 0 }} 
-                    viewport={{ once: true }} 
-                    transition={{ duration: 0.6 }}
-                    className="space-y-8"
-                >
-                    <div>
-                        <h2
-                            className="text-2xl font-semibold mb-4"
-                            {...getVisualEditorAttributes(`${contactFieldPath}.formTitle`)}
-                        >
-                            {t('contact.formTitle')}
-                        </h2>
-                        <ContactForm />
-                    </div>
-                </motion.div>
-                <motion.div 
-                    initial={{ opacity: 0, x: 30 }} 
-                    whileInView={{ opacity: 1, x: 0 }} 
-                    viewport={{ once: true }} 
-                    transition={{ duration: 0.6 }}
-                    className="space-y-8"
-                >
-                    <h2
-                        className="text-2xl font-semibold"
-                        {...getVisualEditorAttributes(`${contactFieldPath}.infoTitle`)}
-                    >
-                        {t('contact.infoTitle')}
-                    </h2>
-                    <div className="space-y-6">
-                        <div className="flex items-start space-x-4">
-                            <Mail className="h-6 w-6 text-stone-600 mt-1" />
-                            <div>
-                                <h3
-                                    className="font-semibold"
-                                    {...getVisualEditorAttributes(`${contactFieldPath}.emailTitle`)}
-                                >
-                                    {t('contact.emailTitle')}
-                                </h3>
-                                <a
-                                    href={emailLink}
-                                    className="text-stone-600 hover:text-stone-900 transition-colors"
-                                    {...getVisualEditorAttributes('site.contact.email')}
-                                >
-                                    {contactSettings.email}
-                                </a>
-                            </div>
-                        </div>
-                        <div className="flex items-start space-x-4">
-                            <Phone className="h-6 w-6 text-stone-600 mt-1" />
-                            <div>
-                                <h3
-                                    className="font-semibold"
-                                    {...getVisualEditorAttributes(`${contactFieldPath}.phoneTitle`)}
-                                >
-                                    {t('contact.phoneTitle')}
-                                </h3>
-                                <a
-                                    href={phoneLink}
-                                    className="text-stone-600 hover:text-stone-900 transition-colors"
-                                    {...getVisualEditorAttributes('site.contact.phone')}
-                                >
-                                    {contactSettings.phone}
-                                </a>
-                            </div>
-                        </div>
-                        <div className="flex items-start space-x-4">
-                            <MessageSquare className="h-6 w-6 text-stone-600 mt-1" />
-                            <div>
-                                <h3
-                                    className="font-semibold"
-                                    {...getVisualEditorAttributes(`${contactFieldPath}.whatsappTitle`)}
-                                >
-                                    {t('contact.whatsappTitle')}
-                                </h3>
-                                <a
-                                    href={whatsappLink}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="text-stone-600 hover:text-stone-900 transition-colors"
-                                    {...getVisualEditorAttributes('site.contact.whatsapp')}
-                                >
-                                    <span {...getVisualEditorAttributes(`${contactFieldPath}.whatsappAction`)}>
-                                        {t('contact.whatsappAction')}
-                                    </span>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                </motion.div>
-                </div>
+  return (
+    <div className="py-16 sm:py-24">
+      <Seo title={pageTitle} description={description} image={socialImage} locale={language} />
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <header className="mb-16 text-center">
+          <h1
+            className="text-4xl font-semibold tracking-tight sm:text-5xl"
+            {...getVisualEditorAttributes(`${contactFieldPath}.headerTitle`)}
+          >
+            {t('contact.headerTitle')}
+          </h1>
+          <p
+            className="mx-auto mt-4 max-w-2xl text-lg text-stone-600"
+            {...getVisualEditorAttributes(`${contactFieldPath}.headerSubtitle`)}
+          >
+            {t('contact.headerSubtitle')}
+          </p>
+        </header>
+
+        <div className="mx-auto grid max-w-5xl gap-12 md:grid-cols-2">
+          <motion.div
+            initial={{ opacity: 0, x: -30 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+            className="space-y-8"
+          >
+            <div>
+              <h2
+                className="mb-4 text-2xl font-semibold"
+                {...getVisualEditorAttributes(`${contactFieldPath}.formTitle`)}
+              >
+                {t('contact.formTitle')}
+              </h2>
+              <ContactForm />
             </div>
+          </motion.div>
+          <motion.div
+            initial={{ opacity: 0, x: 30 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+            className="space-y-8"
+          >
+            <h2
+              className="text-2xl font-semibold"
+              {...getVisualEditorAttributes(`${contactFieldPath}.infoTitle`)}
+            >
+              {t('contact.infoTitle')}
+            </h2>
+            <div className="space-y-6">
+              <div className="flex items-start space-x-4">
+                <Mail className="mt-1 h-6 w-6 text-stone-600" />
+                <div>
+                  <h3
+                    className="font-semibold"
+                    {...getVisualEditorAttributes(`${contactFieldPath}.emailTitle`)}
+                  >
+                    {t('contact.emailTitle')}
+                  </h3>
+                  <a
+                    href={emailLink}
+                    className="text-stone-600 transition-colors hover:text-stone-900"
+                    {...getVisualEditorAttributes('site.contact.email')}
+                  >
+                    {contactSettings.email}
+                  </a>
+                </div>
+              </div>
+              <div className="flex items-start space-x-4">
+                <Phone className="mt-1 h-6 w-6 text-stone-600" />
+                <div>
+                  <h3
+                    className="font-semibold"
+                    {...getVisualEditorAttributes(`${contactFieldPath}.phoneTitle`)}
+                  >
+                    {t('contact.phoneTitle')}
+                  </h3>
+                  <a
+                    href={phoneLink}
+                    className="text-stone-600 transition-colors hover:text-stone-900"
+                    {...getVisualEditorAttributes('site.contact.phone')}
+                  >
+                    {contactSettings.phone}
+                  </a>
+                </div>
+              </div>
+              <div className="flex items-start space-x-4">
+                <MessageSquare className="mt-1 h-6 w-6 text-stone-600" />
+                <div>
+                  <h3
+                    className="font-semibold"
+                    {...getVisualEditorAttributes(`${contactFieldPath}.whatsappTitle`)}
+                  >
+                    {t('contact.whatsappTitle')}
+                  </h3>
+                  <a
+                    href={whatsappLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-stone-600 transition-colors hover:text-stone-900"
+                    {...getVisualEditorAttributes('site.contact.whatsapp')}
+                  >
+                    <span {...getVisualEditorAttributes(`${contactFieldPath}.whatsappAction`)}>
+                      {t('contact.whatsappAction')}
+                    </span>
+                  </a>
+                </div>
+              </div>
+              {addressLines.length > 0 ? (
+                <div className="flex items-start space-x-4">
+                  <MapPin className="mt-1 h-6 w-6 text-stone-600" />
+                  <div>
+                    <h3
+                      className="font-semibold"
+                      {...getVisualEditorAttributes(`${contactFieldPath}.addressTitle`)}
+                    >
+                      {t('contact.addressTitle')}
+                    </h3>
+                    <ul className="mt-2 space-y-1 text-stone-600">
+                      {addressLines.map((line, index) => (
+                        <li
+                          key={`${line}-${index}`}
+                          {...getVisualEditorAttributes(`${contactFieldPath}.addressLines.${index}`)}
+                        >
+                          {line}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </motion.div>
         </div>
-    );
+      </div>
+    </div>
+  );
 };
 
 export default Contact;

--- a/pages/Training.tsx
+++ b/pages/Training.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
 import SectionRenderer from '../components/SectionRenderer';
 import { useLanguage } from '../contexts/LanguageContext';
@@ -8,6 +8,7 @@ import { getVisualEditorAttributes } from '../utils/stackbitBindings';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
 import Seo from '../components/Seo';
+import { fetchTrainingProgramContent, TRAINING_PROGRAM_OBJECT_ID, type TrainingProgramContent } from '../utils/trainingProgramContent';
 
 const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
   'timeline',
@@ -68,6 +69,8 @@ const isPageContent = (value: unknown): value is PageContent => {
 const Training: React.FC = () => {
   const { t, language } = useLanguage();
   const [pageContent, setPageContent] = useState<PageContent | null>(null);
+  const [programContent, setProgramContent] = useState<TrainingProgramContent | null>(null);
+  const [programError, setProgramError] = useState<string | null>(null);
   const { contentVersion } = useVisualEditorSync();
   const { settings: siteSettings } = useSiteSettings();
 
@@ -113,11 +116,73 @@ const Training: React.FC = () => {
     };
   }, [language, contentVersion]);
 
+  useEffect(() => {
+    let isMounted = true;
+    setProgramContent(null);
+    setProgramError(null);
+
+    const loadProgramContent = async () => {
+      try {
+        const content = await fetchTrainingProgramContent();
+        if (!isMounted) {
+          return;
+        }
+
+        if (content) {
+          setProgramContent(content);
+        } else {
+          setProgramError('Unable to load training program details.');
+        }
+      } catch (error) {
+        if (!isMounted) {
+          return;
+        }
+        setProgramError(error instanceof Error ? error.message : 'Unable to load training program details.');
+      }
+    };
+
+    loadProgramContent().catch((error) => {
+      if (!isMounted) {
+        return;
+      }
+      setProgramError(error instanceof Error ? error.message : 'Unable to load training program details.');
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [contentVersion]);
+
   const sections = pageContent?.sections ?? [];
   const sectionsFieldPath = `pages.training_${language}.sections`;
-  const computedTitle = pageContent?.metaTitle ?? `${t('training.metaTitle')} | Kapunka Skincare`;
-  const computedDescription = pageContent?.metaDescription ?? t('training.metaDescription');
+
+  const modules = useMemo(() => (
+    programContent?.modules?.filter((module) => module && (module.title?.trim() || module.description?.trim())) ?? []
+  ), [programContent?.modules]);
+  const objectives = useMemo(() => (
+    programContent?.objectives?.filter((objective) => objective && objective.trim().length > 0) ?? []
+  ), [programContent?.objectives]);
+  const callToActions = useMemo(() => (
+    programContent?.callToActions?.filter((cta) => cta && (cta.label?.trim() || cta.url?.trim())) ?? []
+  ), [programContent?.callToActions]);
+
+  const baseMetaTitle = (programContent?.metaTitle ?? pageContent?.metaTitle ?? t('training.metaTitle'))?.trim();
+  const computedTitle = baseMetaTitle ? `${baseMetaTitle} | Kapunka Skincare` : 'Kapunka Skincare';
+  const computedDescription = (
+    programContent?.metaDescription
+    ?? pageContent?.metaDescription
+    ?? t('training.metaDescription')
+  );
   const socialImage = siteSettings.home?.heroImage;
+
+  const heroTitle = programContent?.headline?.trim() || t('training.title');
+  const heroSubtitle = programContent?.subheadline?.trim() || t('training.subtitle');
+  const heroTitleAnnotations = programContent
+    ? { 'data-sb-field-path': 'headline' }
+    : getVisualEditorAttributes(`translations.${language}.training.title`);
+  const heroSubtitleAnnotations = programContent
+    ? { 'data-sb-field-path': 'subheadline' }
+    : getVisualEditorAttributes(`translations.${language}.training.subtitle`);
 
   return (
     <div>
@@ -128,28 +193,139 @@ const Training: React.FC = () => {
         locale={language}
       />
 
-      <header className="py-20 sm:py-28 bg-stone-100">
+      <header className="bg-stone-100 py-20 sm:py-28" data-sb-object-id={programContent ? TRAINING_PROGRAM_OBJECT_ID : undefined}>
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <motion.h1
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
             className="text-4xl sm:text-5xl font-semibold tracking-tight"
-            {...getVisualEditorAttributes(`translations.${language}.training.title`)}
+            {...heroTitleAnnotations}
           >
-            {t('training.title')}
+            {heroTitle}
           </motion.h1>
           <motion.p
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.1 }}
             className="mt-4 text-lg text-stone-600 max-w-2xl mx-auto"
-            {...getVisualEditorAttributes(`translations.${language}.training.subtitle`)}
+            {...heroSubtitleAnnotations}
           >
-            {t('training.subtitle')}
+            {heroSubtitle}
           </motion.p>
         </div>
       </header>
+
+      {objectives.length > 0 ? (
+        <section className="py-16 sm:py-20" data-sb-object-id={TRAINING_PROGRAM_OBJECT_ID}>
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-3xl rounded-3xl bg-white p-8 shadow-sm shadow-stone-100">
+              <h2
+                className="text-2xl font-semibold text-stone-900"
+                {...getVisualEditorAttributes(`translations.${language}.training.objectivesHeading`)}
+              >
+                {t('training.objectivesHeading')}
+              </h2>
+              <ul className="mt-6 space-y-4 text-base text-stone-600" data-sb-field-path="objectives">
+                {objectives.map((objective, index) => (
+                  <li key={[objective, index].join('|')} className="flex items-start gap-3" data-sb-field-path={`objectives.${index}`}>
+                    <span className="mt-1.5 inline-flex h-2 w-2 flex-none rounded-full bg-stone-900" aria-hidden="true" />
+                    <span>{objective}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {modules.length > 0 ? (
+        <section className="bg-stone-50 py-16 sm:py-24" data-sb-object-id={TRAINING_PROGRAM_OBJECT_ID} data-sb-field-path="modules">
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-2xl text-center">
+              <motion.h2
+                initial={{ opacity: 0, y: 16 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.5 }}
+                className="text-3xl font-semibold text-stone-900"
+                {...getVisualEditorAttributes(`translations.${language}.training.modulesHeading`)}
+              >
+                {t('training.modulesHeading')}
+              </motion.h2>
+            </div>
+            <div className="mt-12 grid gap-8 md:grid-cols-2">
+              {modules.map((module, index) => (
+                <motion.article
+                  key={[module.title, index].join('|')}
+                  initial={{ opacity: 0, y: 24 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.45, delay: index * 0.05 }}
+                  className="flex h-full flex-col justify-between rounded-3xl border border-stone-200 bg-white p-8 shadow-sm shadow-stone-100"
+                  data-sb-field-path={`modules.${index}`}
+                >
+                  <div>
+                    {module.title ? (
+                      <h3 className="text-xl font-semibold text-stone-900">{module.title}</h3>
+                    ) : null}
+                    {module.duration ? (
+                      <p className="mt-2 text-sm font-medium uppercase tracking-wide text-stone-500">{module.duration}</p>
+                    ) : null}
+                    {module.description ? (
+                      <p className="mt-4 text-base text-stone-600">{module.description}</p>
+                    ) : null}
+                  </div>
+                  {module.learningOutcomes && module.learningOutcomes.length > 0 ? (
+                    <ul className="mt-6 list-disc space-y-2 pl-5 text-sm text-stone-500" data-sb-field-path={`modules.${index}.learningOutcomes`}>
+                      {module.learningOutcomes.map((outcome, outcomeIndex) => (
+                        <li key={[outcome, outcomeIndex].join('|')} data-sb-field-path={`modules.${index}.learningOutcomes.${outcomeIndex}`}>
+                          {outcome}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </motion.article>
+              ))}
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {callToActions.length > 0 ? (
+        <section className="bg-stone-900 py-16 sm:py-24" data-sb-object-id={TRAINING_PROGRAM_OBJECT_ID} data-sb-field-path="callToActions">
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center text-stone-100">
+            <motion.h2
+              initial={{ opacity: 0, y: 16 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.45 }}
+              className="text-3xl font-semibold"
+              {...getVisualEditorAttributes(`translations.${language}.training.ctaHeading`)}
+            >
+              {t('training.ctaHeading')}
+            </motion.h2>
+            <div className="mt-8 flex flex-wrap justify-center gap-4">
+              {callToActions.map((cta, index) => (
+                <a
+                  key={[cta.label, cta.url, index].join('|')}
+                  href={cta.url ?? '#'}
+                  className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-stone-900 shadow-sm transition-transform duration-300 hover:scale-[1.02]"
+                  data-sb-field-path={`callToActions.${index}`}
+                  target={cta.url ? '_blank' : undefined}
+                  rel={cta.url ? 'noopener noreferrer' : undefined}
+                >
+                  {cta.label ?? t('training.learnMore')}
+                </a>
+              ))}
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {programError ? (
+        <div className="container mx-auto px-4 py-6 text-center text-sm text-red-600">{programError}</div>
+      ) : null}
 
       {sections.length > 0 ? (
         <SectionRenderer sections={sections} fieldPath={sectionsFieldPath} />

--- a/pages/TrainingProgram.tsx
+++ b/pages/TrainingProgram.tsx
@@ -2,155 +2,13 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
-import { fetchVisualEditorMarkdown } from '../utils/fetchVisualEditorMarkdown';
+import { fetchTrainingProgramContent, TRAINING_PROGRAM_OBJECT_ID, type TrainingProgramContent } from '../utils/trainingProgramContent';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';
 import { getCloudinaryUrl } from '../utils/imageUrl';
 import Seo from '../components/Seo';
 
-interface ModuleContent {
-  title?: string;
-  duration?: string;
-  description?: string;
-  learningOutcomes?: string[];
-}
-
-interface PricingContent {
-  tuition?: string;
-  paymentOptions?: string[];
-}
-
-interface ModalitiesContent {
-  onlineHours?: string;
-  practicalSessions?: string;
-}
-
-interface CallToAction {
-  label?: string;
-  url?: string;
-}
-
-interface TrainingContent {
-  metaTitle?: string;
-  metaDescription?: string;
-  headline?: string;
-  subheadline?: string;
-  objectives?: string[];
-  modules?: ModuleContent[];
-  modalities?: ModalitiesContent;
-  pricing?: PricingContent;
-  callToActions?: CallToAction[];
-  metaTitle?: string;
-  metaDescription?: string;
-}
-
-const TRAINING_FILE_PATH = '/content/pages/training/index.md';
-const TRAINING_OBJECT_ID = 'TrainingProgramPage:content/pages/training/index.md';
-
-const isRecord = (value: unknown): value is Record<string, unknown> => Boolean(value) && typeof value === 'object';
-
-const isStringArray = (value: unknown): value is string[] => Array.isArray(value) && value.every((item) => typeof item === 'string');
-
-const isModuleContent = (value: unknown): value is ModuleContent => {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  const { title, duration, description, learningOutcomes } = value;
-  return (
-    (title === undefined || typeof title === 'string')
-    && (duration === undefined || typeof duration === 'string')
-    && (description === undefined || typeof description === 'string')
-    && (learningOutcomes === undefined || isStringArray(learningOutcomes))
-  );
-};
-
-const isPricingContent = (value: unknown): value is PricingContent => {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  const { tuition, paymentOptions } = value;
-  return (
-    (tuition === undefined || typeof tuition === 'string')
-    && (paymentOptions === undefined || isStringArray(paymentOptions))
-  );
-};
-
-const isModalitiesContent = (value: unknown): value is ModalitiesContent => {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  const { onlineHours, practicalSessions } = value;
-  return (
-    (onlineHours === undefined || typeof onlineHours === 'string')
-    && (practicalSessions === undefined || typeof practicalSessions === 'string')
-  );
-};
-
-const isCallToAction = (value: unknown): value is CallToAction => {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  const { label, url } = value;
-  return (
-    (label === undefined || typeof label === 'string')
-    && (url === undefined || typeof url === 'string')
-  );
-};
-
-const isTrainingContent = (value: unknown): value is TrainingContent => {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  const {
-    objectives,
-    modules,
-    modalities,
-    pricing,
-    callToActions,
-    headline,
-    subheadline,
-    metaTitle,
-    metaDescription,
-  } = value;
-
-  if (objectives !== undefined && !isStringArray(objectives)) {
-    return false;
-  }
-
-  if (modules !== undefined) {
-    if (!Array.isArray(modules) || !modules.every(isModuleContent)) {
-      return false;
-    }
-  }
-
-  if (modalities !== undefined && !isModalitiesContent(modalities)) {
-    return false;
-  }
-
-  if (pricing !== undefined && !isPricingContent(pricing)) {
-    return false;
-  }
-
-  if (callToActions !== undefined) {
-    if (!Array.isArray(callToActions) || !callToActions.every(isCallToAction)) {
-      return false;
-    }
-  }
-
-  return (
-    (headline === undefined || typeof headline === 'string')
-    && (subheadline === undefined || typeof subheadline === 'string')
-    && (metaTitle === undefined || typeof metaTitle === 'string')
-    && (metaDescription === undefined || typeof metaDescription === 'string')
-  );
-};
-
 const TrainingProgram: React.FC = () => {
-  const [content, setContent] = useState<TrainingContent | null>(null);
+  const [content, setContent] = useState<TrainingProgramContent | null>(null);
   const [error, setError] = useState<string | null>(null);
   const { t, language } = useLanguage();
   const { contentVersion } = useVisualEditorSync();
@@ -163,13 +21,13 @@ const TrainingProgram: React.FC = () => {
 
     const loadContent = async () => {
       try {
-        const { data } = await fetchVisualEditorMarkdown<unknown>(TRAINING_FILE_PATH, { cache: 'no-store' });
+        const programContent = await fetchTrainingProgramContent();
         if (!isMounted) {
           return;
         }
 
-        if (isTrainingContent(data)) {
-          setContent(data);
+        if (programContent) {
+          setContent(programContent);
         } else {
           setError('Invalid training page content structure.');
         }
@@ -211,7 +69,7 @@ const TrainingProgram: React.FC = () => {
   const formattedObjectives = useMemo(() => objectives, [objectives]);
 
   return (
-    <div className="bg-stone-50 text-stone-900" data-sb-object-id={TRAINING_OBJECT_ID}>
+    <div className="bg-stone-50 text-stone-900" data-sb-object-id={TRAINING_PROGRAM_OBJECT_ID}>
       <Seo
         title={pageTitle}
         description={metaDescription}

--- a/utils/trainingProgramContent.ts
+++ b/utils/trainingProgramContent.ts
@@ -1,0 +1,155 @@
+import { fetchVisualEditorMarkdown } from './fetchVisualEditorMarkdown';
+
+export interface ModuleContent {
+  title?: string;
+  duration?: string;
+  description?: string;
+  learningOutcomes?: string[];
+}
+
+export interface PricingContent {
+  tuition?: string;
+  paymentOptions?: string[];
+}
+
+export interface ModalitiesContent {
+  onlineHours?: string;
+  practicalSessions?: string;
+}
+
+export interface CallToAction {
+  label?: string;
+  url?: string;
+}
+
+export interface TrainingProgramContent {
+  metaTitle?: string;
+  metaDescription?: string;
+  headline?: string;
+  subheadline?: string;
+  objectives?: string[];
+  modules?: ModuleContent[];
+  modalities?: ModalitiesContent;
+  pricing?: PricingContent;
+  callToActions?: CallToAction[];
+}
+
+export const TRAINING_PROGRAM_FILE_PATH = '/content/pages/training/index.md';
+export const TRAINING_PROGRAM_OBJECT_ID = 'TrainingProgramPage:content/pages/training/index.md';
+
+const isRecord = (value: unknown): value is Record<string, unknown> => Boolean(value) && typeof value === 'object';
+
+const isStringArray = (value: unknown): value is string[] => Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+const isModuleContent = (value: unknown): value is ModuleContent => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { title, duration, description, learningOutcomes } = value;
+
+  return (
+    (title === undefined || typeof title === 'string')
+    && (duration === undefined || typeof duration === 'string')
+    && (description === undefined || typeof description === 'string')
+    && (learningOutcomes === undefined || isStringArray(learningOutcomes))
+  );
+};
+
+const isPricingContent = (value: unknown): value is PricingContent => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { tuition, paymentOptions } = value;
+
+  return (
+    (tuition === undefined || typeof tuition === 'string')
+    && (paymentOptions === undefined || isStringArray(paymentOptions))
+  );
+};
+
+const isModalitiesContent = (value: unknown): value is ModalitiesContent => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { onlineHours, practicalSessions } = value;
+
+  return (
+    (onlineHours === undefined || typeof onlineHours === 'string')
+    && (practicalSessions === undefined || typeof practicalSessions === 'string')
+  );
+};
+
+const isCallToAction = (value: unknown): value is CallToAction => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { label, url } = value;
+
+  return (
+    (label === undefined || typeof label === 'string')
+    && (url === undefined || typeof url === 'string')
+  );
+};
+
+export const isTrainingProgramContent = (value: unknown): value is TrainingProgramContent => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const {
+    objectives,
+    modules,
+    modalities,
+    pricing,
+    callToActions,
+    headline,
+    subheadline,
+    metaTitle,
+    metaDescription,
+  } = value;
+
+  if (objectives !== undefined && !isStringArray(objectives)) {
+    return false;
+  }
+
+  if (modules !== undefined) {
+    if (!Array.isArray(modules) || !modules.every(isModuleContent)) {
+      return false;
+    }
+  }
+
+  if (modalities !== undefined && !isModalitiesContent(modalities)) {
+    return false;
+  }
+
+  if (pricing !== undefined && !isPricingContent(pricing)) {
+    return false;
+  }
+
+  if (callToActions !== undefined) {
+    if (!Array.isArray(callToActions) || !callToActions.every(isCallToAction)) {
+      return false;
+    }
+  }
+
+  return (
+    (headline === undefined || typeof headline === 'string')
+    && (subheadline === undefined || typeof subheadline === 'string')
+    && (metaTitle === undefined || typeof metaTitle === 'string')
+    && (metaDescription === undefined || typeof metaDescription === 'string')
+  );
+};
+
+export const fetchTrainingProgramContent = async (): Promise<TrainingProgramContent | null> => {
+  const { data } = await fetchVisualEditorMarkdown<unknown>(TRAINING_PROGRAM_FILE_PATH, { cache: 'no-store' });
+
+  if (isTrainingProgramContent(data)) {
+    return data;
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Summary
- wire the contact form to Netlify Forms with honeypot handling, expose studio address details, and refresh site contact numbers
- restructure the training hub around the shared training-program content with hero, objectives, module grid, and CTAs backed by a reusable loader
- surface the Founder Story link in the Learn menu and localize new navigation, contact, and training copy while logging the Netlify form update

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2eb8e0fc48320a95cedcb5282614e