### PR TITLE
Add motion-aware hero and section building blocks

### DIFF
--- a/components/sections/ImageTextHalf.tsx
+++ b/components/sections/ImageTextHalf.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import ReactMarkdown from 'react-markdown';
 import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
 import { getCloudinaryUrl } from '../../utils/imageUrl';
-import { usePrefersReducedMotion } from '../../src/hooks/useReducedMotion';
+import { usePrefersReducedMotion } from '../../src/hooks/usePrefersReducedMotion';
 
 interface ImageTextHalfProps {
   image?: string;

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -10,7 +10,7 @@ import ImageTextHalf from '../components/sections/ImageTextHalf';
 import ImageGrid from '../components/sections/ImageGrid';
 import CommunityCarousel from '../components/sections/CommunityCarousel';
 import MediaShowcase from '../components/sections/MediaShowcase';
-import { usePrefersReducedMotion } from '../src/hooks/useReducedMotion';
+import { usePrefersReducedMotion } from '../src/hooks/usePrefersReducedMotion';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useSiteSettings } from '../contexts/SiteSettingsContext';
 import { useVisualEditorSync } from '../contexts/VisualEditorSyncContext';

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
+
+const EASING: [number, number, number, number] = [0.21, 0.75, 0.31, 0.96];
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 24 },
+  visible: { opacity: 1, y: 0 },
+} as const;
+
+type HeroImage = {
+  id?: string;
+  src: string;
+  alt: string;
+  className?: string;
+};
+
+interface HeroProps extends React.HTMLAttributes<HTMLElement> {
+  eyebrow?: React.ReactNode;
+  heading: React.ReactNode;
+  subheading?: React.ReactNode;
+  images?: HeroImage[];
+  actions?: React.ReactNode;
+  align?: 'left' | 'center';
+}
+
+const buildContainerClassName = (align: HeroProps['align']): string => {
+  switch (align) {
+    case 'center':
+      return 'text-center md:items-center md:text-center';
+    case 'left':
+    default:
+      return 'text-left md:text-left md:items-start';
+  }
+};
+
+const Hero: React.FC<HeroProps> = ({
+  eyebrow,
+  heading,
+  subheading,
+  images = [],
+  actions,
+  align = 'left',
+  className,
+  ...rest
+}) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const containerAlignment = buildContainerClassName(align);
+
+  const actionsAlignment = align === 'center' ? 'sm:justify-center' : 'sm:justify-start';
+
+  const headingContent = (
+    <>
+      {eyebrow ? (
+        <p className="text-xs font-medium uppercase tracking-[0.3em] text-stone-500">
+          {eyebrow}
+        </p>
+      ) : null}
+      <h1 className="text-4xl sm:text-5xl md:text-6xl font-semibold tracking-tight text-stone-900">
+        {heading}
+      </h1>
+      {subheading ? (
+        <p className="text-lg text-stone-600 leading-relaxed md:max-w-2xl md:mx-0">
+          {subheading}
+        </p>
+      ) : null}
+      {actions ? (
+        <div className={`mt-8 flex flex-col items-stretch gap-4 sm:flex-row ${actionsAlignment}`}>
+          {actions}
+        </div>
+      ) : null}
+    </>
+  );
+
+  const headingNode = prefersReducedMotion ? (
+    <div className={`space-y-6 ${containerAlignment}`}>
+      {headingContent}
+    </div>
+  ) : (
+    <motion.div
+      className={`space-y-6 ${containerAlignment}`}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, amount: 0.6 }}
+      variants={fadeUp}
+      transition={{ duration: 0.7, ease: EASING }}
+    >
+      {headingContent}
+    </motion.div>
+  );
+
+  const renderedImages = images.map((image, index) => {
+    const key = image.id ?? `${image.src}-${index}`;
+    const imageNode = (
+      <img
+        src={image.src}
+        alt={image.alt}
+        className={`h-full w-full rounded-3xl object-cover shadow-lg ${image.className ?? ''}`}
+        loading="lazy"
+      />
+    );
+
+    if (prefersReducedMotion) {
+      return (
+        <div key={key} className="relative overflow-hidden rounded-3xl shadow-lg">
+          {imageNode}
+        </div>
+      );
+    }
+
+    return (
+      <motion.div
+        key={key}
+        className="relative overflow-hidden rounded-3xl shadow-lg"
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, amount: 0.5 }}
+        variants={fadeUp}
+        transition={{ duration: 0.6, ease: EASING, delay: index * 0.1 }}
+        whileHover={{ y: -6 }}
+      >
+        {imageNode}
+      </motion.div>
+    );
+  });
+
+  const imageGridColumns = images.length > 1 ? 'md:grid-cols-2' : 'md:grid-cols-1';
+
+  return (
+    <section
+      className={`relative overflow-hidden py-20 sm:py-24 ${className ?? ''}`.trim()}
+      {...rest}
+    >
+      <div className="container mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 md:grid-cols-2 lg:px-8">
+        {headingNode}
+        {renderedImages.length > 0 ? (
+          <div className={`grid gap-6 ${imageGridColumns}`}>
+            {renderedImages}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+};
+
+export type { HeroProps, HeroImage };
+export default Hero;

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
+
+const EASING: [number, number, number, number] = [0.21, 0.75, 0.31, 0.96];
+
+const containerVariants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: { opacity: 1, y: 0 },
+} as const;
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: { opacity: 1, y: 0 },
+} as const;
+
+type ElementTag = keyof JSX.IntrinsicElements;
+
+interface SectionContextValue {
+  prefersReducedMotion: boolean;
+}
+
+const SectionContext = React.createContext<SectionContextValue>({ prefersReducedMotion: false });
+
+interface SectionProps extends React.HTMLAttributes<HTMLElement> {
+  as?: ElementTag;
+  staggerChildren?: number;
+  delayChildren?: number;
+  viewportAmount?: number;
+}
+
+interface SectionItemProps extends React.HTMLAttributes<HTMLElement> {
+  as?: ElementTag;
+  delay?: number;
+}
+
+type SectionItemComponent = React.ForwardRefExoticComponent<SectionItemProps & React.RefAttributes<HTMLElement>> & {
+  __sectionItem: true;
+};
+
+const SectionItem = React.forwardRef<HTMLElement, SectionItemProps>(({
+  as: Component = 'div',
+  className,
+  children,
+  delay,
+  ...rest
+}, ref) => {
+  const { prefersReducedMotion } = React.useContext(SectionContext);
+  const Element = Component as React.ElementType;
+
+  if (prefersReducedMotion) {
+    return (
+      <Element ref={ref as React.Ref<any>} className={className} {...rest}>
+        {children}
+      </Element>
+    );
+  }
+
+  const MotionElement = motion(Element);
+
+  return (
+    <MotionElement
+      ref={ref as React.Ref<any>}
+      className={className}
+      variants={itemVariants}
+      transition={{
+        duration: 0.55,
+        ease: EASING,
+        delay,
+      }}
+      {...rest}
+    >
+      {children}
+    </MotionElement>
+  );
+}) as SectionItemComponent;
+
+SectionItem.__sectionItem = true;
+
+const SectionRoot = React.forwardRef<HTMLElement, SectionProps>(({
+  as: Component = 'section',
+  className,
+  children,
+  staggerChildren = 0.14,
+  delayChildren = 0.08,
+  viewportAmount = 0.2,
+  ...rest
+}, ref) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const Element = Component as React.ElementType;
+  const childCount = React.Children.count(children);
+
+  const animatedChildren = prefersReducedMotion
+    ? React.Children.toArray(children)
+    : React.Children.map(children, (child, index) => {
+        if (!React.isValidElement(child)) {
+          return (
+            <SectionItem key={`section-item-${index}`}>
+              {child}
+            </SectionItem>
+          );
+        }
+
+        const isSectionItem = (child.type as SectionItemComponent | undefined)?.__sectionItem === true;
+        if (isSectionItem) {
+          return child;
+        }
+
+        const key = child.key ?? `section-item-${index}`;
+
+        return (
+          <SectionItem key={key}>
+            {child}
+          </SectionItem>
+        );
+      });
+
+  if (prefersReducedMotion) {
+    return (
+      <SectionContext.Provider value={{ prefersReducedMotion }}>
+        <Element ref={ref as React.Ref<any>} className={className} {...rest}>
+          {animatedChildren}
+        </Element>
+      </SectionContext.Provider>
+    );
+  }
+
+  const MotionComponent = motion(Element);
+
+  return (
+    <SectionContext.Provider value={{ prefersReducedMotion }}>
+      <MotionComponent
+        ref={ref as React.Ref<any>}
+        className={className}
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, amount: viewportAmount }}
+        variants={containerVariants}
+        transition={{
+          duration: 0.6,
+          ease: EASING,
+          staggerChildren: childCount > 1 ? staggerChildren : undefined,
+          delayChildren: childCount > 1 ? delayChildren : undefined,
+        }}
+        {...rest}
+      >
+        {animatedChildren}
+      </MotionComponent>
+    </SectionContext.Provider>
+  );
+});
+
+SectionRoot.displayName = 'Section';
+
+const Section = Object.assign(SectionRoot, { Item: SectionItem });
+
+export type { SectionProps, SectionItemProps };
+export { SectionItem };
+export default Section;

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+const MEDIA_QUERY = '(prefers-reduced-motion: reduce)';
+
+const getInitialPreference = (): boolean => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+
+  return window.matchMedia(MEDIA_QUERY).matches;
+};
+
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(getInitialPreference);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+
+    const mediaQueryList = window.matchMedia(MEDIA_QUERY);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    setPrefersReducedMotion(mediaQueryList.matches);
+
+    if (typeof mediaQueryList.addEventListener === 'function') {
+      mediaQueryList.addEventListener('change', handleChange);
+
+      return () => {
+        mediaQueryList.removeEventListener('change', handleChange);
+      };
+    }
+
+    mediaQueryList.addListener(handleChange);
+
+    return () => {
+      mediaQueryList.removeListener(handleChange);
+    };
+  }, []);
+
+  return prefersReducedMotion;
+}

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,7 +1,0 @@
-export function usePrefersReducedMotion(): boolean {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-}


### PR DESCRIPTION
## Summary
- add a `usePrefersReducedMotion` hook that reacts to media query changes
- create animated Hero and Section components that fade upward on scroll and respect reduced-motion users
- point existing sections to the new hook implementation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68e2f15e6084832089633bb8667560a6