### PR TITLE
feat(cms): enable tabbed multilingual editing

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -8,6 +8,8 @@ localized_string_field: &localized_string_field
   widget: object
   i18n: true
   required: false
+  editor:
+    type: tabs
   fields:
     - { label: English, name: en, widget: string }
     - { label: Portuguese, name: pt, widget: string }
@@ -17,6 +19,8 @@ localized_text_field: &localized_text_field
   widget: object
   i18n: true
   required: false
+  editor:
+    type: tabs
   fields:
     - { label: English, name: en, widget: text }
     - { label: Portuguese, name: pt, widget: text }
@@ -26,6 +30,8 @@ localized_markdown_field: &localized_markdown_field
   widget: object
   i18n: true
   required: false
+  editor:
+    type: tabs
   fields:
     - { label: English, name: en, widget: markdown }
     - { label: Portuguese, name: pt, widget: markdown }
@@ -158,14 +164,14 @@ hero_object: &hero_object
   label: "Hero Content"
   name: "content"
   widget: "object"
-  summary: "{{fields.headline}}"
+  summary: "{{fields.headline.en}}"
   fields: *hero_content_fields
 
 media_copy_object: &media_copy_object
   label: "Media & Copy"
   name: "content"
   widget: "object"
-  summary: "{{fields.heading}}"
+  summary: "{{fields.heading.en}}"
   fields: *media_copy_fields
 
 shared_sections: &shared_sections
@@ -173,7 +179,8 @@ shared_sections: &shared_sections
     label: "Hero Section"
     name: "hero"
     widget: "object"
-    summary: "Hero · {{fields.content.headline}}"
+    collapsed: true
+    summary: "Hero · {{fields.content.headline.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "hero" }
       - *hero_object
@@ -181,7 +188,8 @@ shared_sections: &shared_sections
     label: "Media + Copy"
     name: "mediaCopy"
     widget: "object"
-    summary: "Media + Copy · {{fields.content.heading}}"
+    collapsed: true
+    summary: "Media + Copy · {{fields.content.heading.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "mediaCopy" }
       - *media_copy_object
@@ -251,49 +259,96 @@ shared_sections: &shared_sections
     label: "Media Showcase"
     name: "mediaShowcase"
     widget: "object"
-    summary: "Media Showcase · {{fields.title}}"
+    collapsed: true
+    summary: "Media Showcase · {{fields.title.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "mediaShowcase" }
-      - { label: "Title", name: "title", widget: "string", i18n: true, required: false, hint: "Optional section heading (≤60 characters)." }
+      - <<: *localized_string_field
+        label: "Title"
+        name: "title"
+        required: false
+        hint: "Optional section heading (≤60 characters)."
       - label: "Items"
         name: "items"
         widget: "list"
         collapsed: false
         hint: "Add up to four feature cards with imagery and copy."
         fields:
-          - { label: "Eyebrow", name: "eyebrow", widget: "string", i18n: true, required: false, hint: "Optional category label above the card title (≤40 characters)." }
-          - { label: "Title", name: "title", widget: "string", i18n: true, required: false, hint: "Card headline (≤60 characters)." }
-          - { label: "Body", name: "body", widget: "text", i18n: true, required: false, hint: "Supporting description for the card (≤240 characters)." }
+          - <<: *localized_string_field
+            label: "Eyebrow"
+            name: "eyebrow"
+            required: false
+            hint: "Optional category label above the card title (≤40 characters)."
+          - <<: *localized_string_field
+            label: "Title"
+            name: "title"
+            required: false
+            hint: "Card headline (≤60 characters)."
+          - <<: *localized_text_field
+            label: "Body"
+            name: "body"
+            required: false
+            hint: "Supporting description for the card (≤240 characters)."
           - { label: "Image Upload", name: "image", widget: "image", choose_url: true, i18n: true, required: false, hint: "Upload or choose from existing assets." }
-          - { label: "Image Alt Text", name: "imageAlt", widget: "string", i18n: true, required: false, hint: "Describe the image for accessibility (≤120 characters)." }
-          - { label: "CTA Label", name: "ctaLabel", widget: "string", i18n: true, required: false, hint: "Button label for the card (≤24 characters)." }
-          - { label: "CTA Href", name: "ctaHref", widget: "string", i18n: true, required: false, hint: "Supports internal (#/ or /path) and external URLs." }
+          - <<: *localized_string_field
+            label: "Image Alt Text"
+            name: "imageAlt"
+            required: false
+            hint: "Describe the image for accessibility (≤120 characters)."
+          - <<: *localized_string_field
+            label: "CTA Label"
+            name: "ctaLabel"
+            required: false
+            hint: "Button label for the card (≤24 characters)."
+          - <<: *localized_string_field
+            label: "CTA Href"
+            name: "ctaHref"
+            required: false
+            hint: "Supports internal (#/ or /path) and external URLs."
   - &section_featureGrid
     label: "Feature Grid"
     name: "featureGrid"
     widget: "object"
-    summary: "Feature Grid · {{fields.title}}"
+    collapsed: true
+    summary: "Feature Grid · {{fields.title.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "featureGrid" }
-      - { label: "Title", name: "title", widget: "string", i18n: true, required: false, hint: "Optional heading displayed above the features (≤60 characters)." }
+      - <<: *localized_string_field
+        label: "Title"
+        name: "title"
+        required: false
+        hint: "Optional heading displayed above the features (≤60 characters)."
       - { label: "Columns", name: "columns", widget: "number", value_type: "int", min: 1, max: 4, required: false, hint: "Override the number of columns shown (1–4)." }
       - label: "Items"
         name: "items"
         widget: "list"
         collapsed: true
-        summary: "{{fields.label}}"
+        summary: "{{fields.label.en}}"
         hint: "Add the individual product or service features to highlight."
         fields:
-          - { label: "Label", name: "label", widget: "string", i18n: true, required: false, hint: "Feature title (≤60 characters)." }
-          - { label: "Description", name: "description", widget: "markdown", i18n: true, required: false, hint: "Use Markdown for supporting detail (≤300 characters)." }
+          - <<: *localized_string_field
+            label: "Label"
+            name: "label"
+            required: false
+            hint: "Feature title (≤60 characters)."
+          - <<: *localized_markdown_field
+            label: "Description"
+            name: "description"
+            required: false
+            hint: "Use Markdown for supporting detail (≤300 characters)."
   - &section_productGrid
     label: "Product Grid"
     name: "productGrid"
     widget: "object"
-    summary: "Product Grid · {{fields.title}}"
+    collapsed: true
+    summary: "Product Grid · {{fields.title.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "productGrid" }
-      - { label: "Title", name: "title", widget: "string", i18n: true, required: false, hint: "Heading for the product grid (≤60 characters)." }
+      - <<: *localized_string_field
+        label: "Title"
+        name: "title"
+        required: false
+        hint: "Heading for the product grid (≤60 characters)."
       - { label: "Columns", name: "columns", widget: "number", value_type: "int", min: 1, max: 4, required: false, hint: "Override how many products show per row (1–4)." }
       - label: "Products"
         name: "products"
@@ -319,36 +374,41 @@ shared_sections: &shared_sections
     label: "Testimonials"
     name: "testimonials"
     widget: "object"
-    summary: "Testimonials · {{fields.testimonials.0.author | default(fields.title)}}"
+    collapsed: true
+    summary: "Testimonials · {{fields.testimonials.0.author.en | default(fields.title.en)}}"
     fields:
       - { name: "type", widget: "hidden", default: "testimonials" }
-      - { label: "Section Title", name: "title", widget: "string", i18n: true, required: false, hint: "Optional heading displayed above the testimonial list." }
+      - <<: *localized_string_field
+        label: "Section Title"
+        name: "title"
+        required: false
+        hint: "Optional heading displayed above the testimonial list."
       - label: "Testimonials"
         name: "testimonials"
         widget: "list"
         collapsed: true
-        summary: "{{fields.author}}"
+        summary: "{{fields.author.en}}"
         fields: *testimonial_fields
   - &section_communityCarousel
     label: "Community Carousel"
     name: "communityCarousel"
     widget: "object"
-    summary: "Community Carousel · {{fields.title}}"
+    collapsed: true
+    summary: "Community Carousel · {{fields.title.en}}"
     fields:
       - name: "type"
         widget: "hidden"
         default: "communityCarousel"
-      - label: "Title"
+      - <<: *localized_string_field
+        label: "Title"
         name: "title"
-        widget: "string"
-        i18n: true
         required: false
         hint: "Headline shown above the carousel (≤60 characters)."
       - label: "Slides"
         name: "slides"
         widget: "list"
         collapsed: true
-        summary: "{{fields.name}}"
+        summary: "{{fields.name.en}}"
         hint: "Add community stories or testimonials to rotate."
         fields:
           - label: "Image Upload"
@@ -358,28 +418,24 @@ shared_sections: &shared_sections
             i18n: true
             required: false
             hint: "Upload or choose from existing assets."
-          - label: "Alt Text"
+          - <<: *localized_string_field
+            label: "Alt Text"
             name: "alt"
-            widget: "string"
-            i18n: true
             required: false
             hint: "Describe the slide imagery (≤120 characters)."
-          - label: "Quote"
+          - <<: *localized_markdown_field
+            label: "Quote"
             name: "quote"
-            widget: "markdown"
-            i18n: true
             required: false
             hint: "Optional quote or caption for the slide (≤320 characters)."
-          - label: "Name"
+          - <<: *localized_string_field
+            label: "Name"
             name: "name"
-            widget: "string"
-            i18n: true
             required: false
             hint: "Name of the person or partner featured (≤60 characters)."
-          - label: "Role or Context"
+          - <<: *localized_string_field
+            label: "Role or Context"
             name: "role"
-            widget: "string"
-            i18n: true
             required: false
             hint: "Role, clinic, or location shown under the name (≤60 characters)."
           - label: "Slide Duration (ms)"
@@ -398,42 +454,89 @@ shared_sections: &shared_sections
     label: "FAQ"
     name: "faq"
     widget: "object"
-    summary: "FAQ · {{fields.title}}"
+    collapsed: true
+    summary: "FAQ · {{fields.title.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "faq" }
-      - { label: "Title", name: "title", widget: "string", i18n: true, required: false, hint: "Heading displayed above the FAQ (≤60 characters)." }
+      - <<: *localized_string_field
+        label: "Title"
+        name: "title"
+        required: false
+        hint: "Heading displayed above the FAQ (≤60 characters)."
       - label: "Items"
         name: "items"
         widget: "list"
         collapsed: true
-        summary: "{{fields.q}}"
+        summary: "{{fields.q.en}}"
         hint: "Add visitor questions and helpful answers."
         fields:
-          - { label: "Question", name: "q", widget: "string", i18n: true, hint: "FAQ question phrased clearly (≤100 characters)." }
-          - { label: "Answer", name: "a", widget: "markdown", i18n: true, hint: "Use Markdown for concise answers (≤400 characters)." }
+          - <<: *localized_string_field
+            label: "Question"
+            name: "q"
+            required: true
+            hint: "FAQ question phrased clearly (≤100 characters)."
+          - <<: *localized_markdown_field
+            label: "Answer"
+            name: "a"
+            required: true
+            hint: "Use Markdown for concise answers (≤400 characters)."
   - &section_banner
     label: "Banner"
     name: "banner"
     widget: "object"
-    summary: "Banner · {{fields.text}}"
+    collapsed: true
+    summary: "Banner · {{fields.text.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "banner" }
-      - { label: "Text", name: "text", widget: "string", i18n: true, required: false, hint: "Banner announcement copy (≤140 characters)." }
-      - { label: "CTA Label", name: "cta", widget: "string", i18n: true, required: false, hint: "Optional button label (≤24 characters)." }
-      - { label: "CTA URL", name: "url", widget: "string", i18n: true, required: false, hint: "Destination for the banner CTA (https:// or /path)." }
+      - <<: *localized_string_field
+        label: "Text"
+        name: "text"
+        required: false
+        hint: "Banner announcement copy (≤140 characters)."
+      - <<: *localized_string_field
+        label: "CTA Label"
+        name: "cta"
+        required: false
+        hint: "Optional button label (≤24 characters)."
+      - <<: *localized_string_field
+        label: "CTA URL"
+        name: "url"
+        required: false
+        hint: "Destination for the banner CTA (https:// or /path)."
       - { label: "Style", name: "style", widget: "select", options: ["muted", "inset"], required: false, hint: "Choose between muted or inset banner styling." }
   - &section_newsletterSignup
     label: "Newsletter Signup"
     name: "newsletterSignup"
     widget: "object"
-    summary: "Newsletter · {{fields.title}}"
+    collapsed: true
+    summary: "Newsletter · {{fields.title.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "newsletterSignup" }
-      - { label: "Title", name: "title", widget: "string", i18n: true, required: false, hint: "Headline encouraging newsletter signups (≤60 characters)." }
-      - { label: "Subtitle", name: "subtitle", widget: "text", i18n: true, required: false, hint: "Supportive message explaining the value (≤200 characters)." }
-      - { label: "Email Placeholder", name: "placeholder", widget: "string", i18n: true, required: false, hint: "Input placeholder text for the email field (≤40 characters)." }
-      - { label: "CTA Label", name: "ctaLabel", widget: "string", i18n: true, required: false, hint: "Submit button label (≤20 characters)." }
-      - { label: "Confirmation Message", name: "confirmation", widget: "text", i18n: true, required: false, hint: "Success message after form submission (≤200 characters)." }
+      - <<: *localized_string_field
+        label: "Title"
+        name: "title"
+        required: false
+        hint: "Headline encouraging newsletter signups (≤60 characters)."
+      - <<: *localized_text_field
+        label: "Subtitle"
+        name: "subtitle"
+        required: false
+        hint: "Supportive message explaining the value (≤200 characters)."
+      - <<: *localized_string_field
+        label: "Email Placeholder"
+        name: "placeholder"
+        required: false
+        hint: "Input placeholder text for the email field (≤40 characters)."
+      - <<: *localized_string_field
+        label: "CTA Label"
+        name: "ctaLabel"
+        required: false
+        hint: "Submit button label (≤20 characters)."
+      - <<: *localized_text_field
+        label: "Confirmation Message"
+        name: "confirmation"
+        required: false
+        hint: "Success message after form submission (≤200 characters)."
       - label: "Background"
         name: "background"
         widget: "select"
@@ -457,104 +560,192 @@ shared_sections: &shared_sections
     label: "Video Gallery"
     name: "videoGallery"
     widget: "object"
-    summary: "Video Gallery · {{fields.title}}"
+    collapsed: true
+    summary: "Video Gallery · {{fields.title.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "videoGallery" }
-      - { label: "Title", name: "title", widget: "string", i18n: true, required: false, hint: "Section heading for the video gallery (≤60 characters)." }
-      - { label: "Description", name: "description", widget: "text", i18n: true, required: false, hint: "Introductory copy describing the gallery (≤200 characters)." }
+      - <<: *localized_string_field
+        label: "Title"
+        name: "title"
+        required: false
+        hint: "Section heading for the video gallery (≤60 characters)."
+      - <<: *localized_text_field
+        label: "Description"
+        name: "description"
+        required: false
+        hint: "Introductory copy describing the gallery (≤200 characters)."
       - label: "Entries"
         name: "entries"
         widget: "list"
         collapsed: true
-        summary: "{{fields.title}}"
+        summary: "{{fields.title.en}}"
         hint: "Add each video with a title, description, and URL."
         fields:
-          - { label: "Title", name: "title", widget: "string", i18n: true, required: false, hint: "Video title (≤80 characters)." }
-          - { label: "Description", name: "description", widget: "text", i18n: true, required: false, hint: "Brief description of the video content (≤240 characters)." }
+          - <<: *localized_string_field
+            label: "Title"
+            name: "title"
+            required: false
+            hint: "Video title (≤80 characters)."
+          - <<: *localized_text_field
+            label: "Description"
+            name: "description"
+            required: false
+            hint: "Brief description of the video content (≤240 characters)."
           - { label: "Video URL", name: "videoUrl", widget: "string", required: false, hint: "Link to the hosted video (YouTube, Vimeo, etc.)." }
           - { label: "Thumbnail", name: "thumbnail", widget: "image", choose_url: true, required: false, hint: "Upload a preview image for the video." }
   - &section_trainingList
     label: "Training List"
     name: "trainingList"
     widget: "object"
-    summary: "Training List · {{fields.title}}"
+    collapsed: true
+    summary: "Training List · {{fields.title.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "trainingList" }
-      - { label: "Title", name: "title", widget: "string", i18n: true, required: false, hint: "Headline for the training opportunities (≤60 characters)." }
-      - { label: "Description", name: "description", widget: "text", i18n: true, required: false, hint: "Overview of the training offerings (≤200 characters)." }
+      - <<: *localized_string_field
+        label: "Title"
+        name: "title"
+        required: false
+        hint: "Headline for the training opportunities (≤60 characters)."
+      - <<: *localized_text_field
+        label: "Description"
+        name: "description"
+        required: false
+        hint: "Overview of the training offerings (≤200 characters)."
       - label: "Entries"
         name: "entries"
         widget: "list"
         collapsed: true
-        summary: "{{fields.courseTitle}}"
+        summary: "{{fields.courseTitle.en}}"
         hint: "List each training course that is available."
         fields:
-          - { label: "Course Title", name: "courseTitle", widget: "string", i18n: true, required: false, hint: "Name of the course (≤80 characters)." }
-          - { label: "Summary", name: "courseSummary", widget: "text", i18n: true, required: false, hint: "Brief description of what the course covers (≤240 characters)." }
-          - { label: "Link URL", name: "linkUrl", widget: "string", i18n: true, required: false, hint: "URL to learn more or register for the course." }
+          - <<: *localized_string_field
+            label: "Course Title"
+            name: "courseTitle"
+            required: false
+            hint: "Name of the course (≤80 characters)."
+          - <<: *localized_text_field
+            label: "Summary"
+            name: "courseSummary"
+            required: false
+            hint: "Brief description of what the course covers (≤240 characters)."
+          - <<: *localized_string_field
+            label: "Link URL"
+            name: "linkUrl"
+            required: false
+            hint: "URL to learn more or register for the course."
   - &section_timeline
     label: "Timeline"
     name: "timeline"
     widget: "object"
-    summary: "Timeline · {{fields.title}}"
+    collapsed: true
+    summary: "Timeline · {{fields.title.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "timeline" }
-      - { label: "Title", name: "title", widget: "string", i18n: true, required: false, hint: "Timeline section heading (≤60 characters)." }
+      - <<: *localized_string_field
+        label: "Title"
+        name: "title"
+        required: false
+        hint: "Timeline section heading (≤60 characters)."
       - label: "Entries"
         name: "entries"
         widget: "list"
         collapsed: true
-        summary: "{{fields.year}}"
+        summary: "{{fields.year.en}}"
         hint: "Add chronological milestones to tell the story."
         fields:
-          - { label: "Year", name: "year", widget: "string", i18n: true, hint: "Year or short date marker (≤12 characters)." }
-          - { label: "Title", name: "title", widget: "string", i18n: true, hint: "Headline for the milestone (≤80 characters)." }
-          - { label: "Description", name: "description", widget: "markdown", i18n: true, hint: "Expanded detail about the milestone (≤400 characters)." }
+          - <<: *localized_string_field
+            label: "Year"
+            name: "year"
+            required: true
+            hint: "Year or short date marker (≤12 characters)."
+          - <<: *localized_string_field
+            label: "Title"
+            name: "title"
+            required: true
+            hint: "Headline for the milestone (≤80 characters)."
+          - <<: *localized_markdown_field
+            label: "Description"
+            name: "description"
+            required: true
+            hint: "Expanded detail about the milestone (≤400 characters)."
           - { label: "Image", name: "image", widget: "image", choose_url: true, required: false, hint: "Optional supporting image for the milestone." }
   - &section_facts
     label: "Facts"
     name: "facts"
     widget: "object"
-    summary: "Facts · {{fields.title}}"
+    collapsed: true
+    summary: "Facts · {{fields.title.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "facts" }
-      - { label: "Title", name: "title", widget: "string", i18n: true, hint: "Short headline introducing the fact (≤60 characters)." }
-      - { label: "Body", name: "text", widget: "text", i18n: true, hint: "Supporting statement or statistic (≤240 characters)." }
+      - <<: *localized_string_field
+        label: "Title"
+        name: "title"
+        required: true
+        hint: "Short headline introducing the fact (≤60 characters)."
+      - <<: *localized_text_field
+        label: "Body"
+        name: "text"
+        required: true
+        hint: "Supporting statement or statistic (≤240 characters)."
   - &section_bullets
     label: "Bulleted List"
     name: "bullets"
     widget: "object"
-    summary: "Bullets · {{fields.title}}"
+    collapsed: true
+    summary: "Bullets · {{fields.title.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "bullets" }
-      - { label: "Title", name: "title", widget: "string", i18n: true, hint: "Bulleted section heading (≤60 characters)." }
+      - <<: *localized_string_field
+        label: "Title"
+        name: "title"
+        required: true
+        hint: "Bulleted section heading (≤60 characters)."
       - label: "Items"
         name: "items"
         widget: "list"
         collapsed: true
         hint: "Add each bullet point to share quick highlights."
-        field: { label: "Item", name: "item", widget: "string", i18n: true, hint: "Single bullet point (≤120 characters)." }
+        field:
+          <<: *localized_string_field
+          label: "Item"
+          name: "item"
+          required: true
+          hint: "Single bullet point (≤120 characters)."
   - &section_specialties
     label: "Specialties"
     name: "specialties"
     widget: "object"
-    summary: "Specialties · {{fields.title}}"
+    collapsed: true
+    summary: "Specialties · {{fields.title.en}}"
     fields:
       - { name: "type", widget: "hidden", default: "specialties" }
-      - { label: "Title", name: "title", widget: "string", i18n: true, required: false, hint: "Overall heading for the specialties section (≤60 characters)." }
+      - <<: *localized_string_field
+        label: "Title"
+        name: "title"
+        required: false
+        hint: "Overall heading for the specialties section (≤60 characters)."
       - label: "Specialties"
         name: "items"
         widget: "list"
         collapsed: true
-        summary: "{{fields.title}}"
+        summary: "{{fields.title.en}}"
         hint: "Add each specialty block with bullets."
         fields:
-          - { label: "Specialty Title", name: "title", widget: "string", i18n: true, hint: "Name of the specialty focus (≤60 characters)." }
+          - <<: *localized_string_field
+            label: "Specialty Title"
+            name: "title"
+            required: true
+            hint: "Name of the specialty focus (≤60 characters)."
           - label: "Bullets"
             name: "bullets"
             widget: "list"
             hint: "List supporting points for the specialty."
-            field: { label: "Bullet", name: "bullet", widget: "string", i18n: true, hint: "Individual specialty detail (≤120 characters)." }
+            field:
+              <<: *localized_string_field
+              label: "Bullet"
+              name: "bullet"
+              required: true
+              hint: "Individual specialty detail (≤120 characters)."
 meta_title_field: &meta_title_field
   <<: *localized_string_field
   label: "Meta Title"
@@ -598,7 +789,7 @@ sections_field: &sections_field
   widget: "list"
   i18n: true
   collapsed: true
-  summary: "{{fields.type}} · {{fields.title}}"
+  summary: "{{fields.type}} · {{fields.title.en | default(fields.content.headline.en) | default(fields.content.heading.en)}}"
   hint: "Reorder or edit the content sections that compose this page."
   types: *section_library
 
@@ -992,7 +1183,7 @@ collections:
             name: "sections"
             widget: "list"
             collapsed: true
-            summary: "{{fields.type}} · {{fields.title}}"
+            summary: "{{fields.type}} · {{fields.title.en | default(fields.content.headline.en) | default(fields.content.heading.en)}}"
             hint: "Scroll, reorder, duplicate, or add sections in page order."
             types: *section_library
       - name: learn
@@ -1110,7 +1301,7 @@ collections:
             name: "sections"
             widget: "list"
             collapsed: true
-            summary: "{{fields.title}} · {{fields.type}}"
+            summary: "{{fields.title.en | default(fields.type)}} · {{fields.type}}"
             types:
               - *section_facts
               - *section_bullets

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-05 — Enabled tabbed multilingual editing for pages
+- **What changed**: Updated `admin/config.yml` so every page-level field that editors translate now uses locale objects rendered as language tabs. Collapsed the reusable section widgets and rewired section summaries so the English copy previews instead of showing `[object Object]`.
+- **Impact & follow-up**: Editors can toggle English, Portuguese, and Spanish copy side-by-side without scrolling, reducing translation errors. Confirm the updated Decap widgets render correctly in staging and adjust any additional collection summaries if future locales are added.
+- **References**: Pending PR
+
 ## 2025-10-16 — Enabled Netlify contact form submissions
 - **What changed**: Wired the `/contact` form to Netlify Forms with the required hidden inputs, honeypot, and encoded POST handler. Updated contact translations to include the studio address and refreshed the site config phone/WhatsApp numbers.
 - **Impact & follow-up**: Messages now deliver to Netlify instead of the previous in-memory mock. Confirm the Netlify dashboard lists the new "kapunka-contact" form after deployment and set up notifications if needed.


### PR DESCRIPTION
## Summary
- present locale-specific strings in tabbed editors and reuse the localized anchors across page sections
- collapse reusable section widgets and update section summaries so lists display English copy instead of objects
- document the CMS configuration update in the Decap rolling log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2f893b3e88320ac1c3e54a5f2405c