### PR TITLE
feat: enable tabbed multilingual editing for pages

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1045,7 +1045,7 @@ collections:
         media_folder: "content/uploads/home"
         public_folder: "/content/uploads/home"
         i18n: true
-        editor: { preview: true }
+        editor: { preview: true, type: tabs }
         description: "Hero and storytelling blocks presented in live page order."
         preview_path: "/"
         fields:
@@ -1193,7 +1193,7 @@ collections:
         media_folder: "content/uploads/learn"
         public_folder: "/content/uploads/learn"
         i18n: true
-        editor: { preview: true }
+        editor: { preview: true, type: tabs }
         description: "Optional storytelling sections surrounding the Learn hub."
         preview_path: "/learn"
         fields:
@@ -1248,7 +1248,7 @@ collections:
         media_folder: "content/uploads/method"
         public_folder: "/content/uploads/method"
         i18n: true
-        editor: { preview: true }
+        editor: { preview: true, type: tabs }
         description: "Clinical method overview plus supporting content blocks."
         preview_path: "/method"
         fields:
@@ -1313,7 +1313,7 @@ collections:
         media_folder: "content/uploads/clinics"
         public_folder: "/content/uploads/clinics"
         i18n: true
-        editor: { preview: true }
+        editor: { preview: true, type: tabs }
         description: "Clinic partnership story arranged top-to-bottom."
         preview_path: "/for-clinics"
         fields:
@@ -1549,7 +1549,7 @@ collections:
         media_folder: "content/uploads/about"
         public_folder: "/content/uploads/about"
         i18n: true
-        editor: { preview: true }
+        editor: { preview: true, type: tabs }
         description: "Brand story sections in live page sequence."
         preview_path: "/about"
         fields:
@@ -1570,7 +1570,7 @@ collections:
         media_folder: "content/uploads/story"
         public_folder: "/content/uploads/story"
         i18n: true
-        editor: { preview: true }
+        editor: { preview: true, type: tabs }
         description: "Brand manifesto narrative, value pillars, and optional supporting sections."
         preview_path: "/story"
         fields:
@@ -1664,7 +1664,7 @@ collections:
         media_folder: "content/uploads/contact"
         public_folder: "/content/uploads/contact"
         i18n: true
-        editor: { preview: true }
+        editor: { preview: true, type: tabs }
         description: "Contact introductions and optional follow-up sections."
         preview_path: "/contact"
         fields:

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-05 — Added Decap tabs to page locale editors
+- **What changed**: Enabled the tabbed editor layout for every file in the `pages` collection so translators can switch between English, Portuguese, and Spanish views without scrolling through sequential field groups.
+- **Impact & follow-up**: Simplifies copy editing by aligning all page-level forms with the localized section widgets. Verify Decap renders the tabs correctly once deployed and extend the pattern to any new page entries.
+- **References**: Pending PR
+
 ## 2025-10-05 — Enabled tabbed multilingual editing for pages
 - **What changed**: Updated `admin/config.yml` so every page-level field that editors translate now uses locale objects rendered as language tabs. Collapsed the reusable section widgets and rewired section summaries so the English copy previews instead of showing `[object Object]`.
 - **Impact & follow-up**: Editors can toggle English, Portuguese, and Spanish copy side-by-side without scrolling, reducing translation errors. Confirm the updated Decap widgets render correctly in staging and adjust any additional collection summaries if future locales are added.


### PR DESCRIPTION
## Summary
- set each page builder entry to use Decap's tabbed editor layout for locale switching
- record the CMS editor tweak in the Decap/Netlify rolling log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2fdacbe248320833d3002e0a4233c