### PR TITLE
feat: rebuild contact page with cms-driven form

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1669,15 +1669,43 @@ collections:
         preview_path: "/contact"
         fields:
           - { label: "Page Type", name: "type", widget: "hidden", default: "ContactPage" }
-          - label: "Page Metadata"
-            name: "metadata"
+          - label: "SEO"
+            name: "seo"
             widget: "object"
             collapsed: true
-            hint: "SEO title and description for the Contact page."
+            hint: "Meta title and description for the Contact page."
             fields:
               - *meta_title_field
               - *meta_description_field
-          - *sections_field
+          - <<: *localized_string_field
+            label: "Hero Title"
+            name: "heroTitle"
+            hint: "Primary heading that introduces the Contact page (≤60 characters)."
+          - <<: *localized_text_field
+            label: "Hero Subtitle"
+            name: "heroSubtitle"
+            hint: "Supporting copy that appears beneath the hero title (≤200 characters)."
+          - label: "Contact Email"
+            name: "contactEmail"
+            widget: "string"
+            required: true
+            hint: "Email address that receives contact form submissions."
+          - label: "Phone Number"
+            name: "phone"
+            widget: "string"
+            required: false
+            hint: "Optional phone number displayed next to the form. Include country code."
+          - label: "Address"
+            name: "address"
+            widget: "text"
+            required: false
+            hint: "Physical location shown in the contact details. Use line breaks to separate lines."
+          - label: "Map Embed URL"
+            name: "mapEmbedUrl"
+            widget: "string"
+            required: false
+            pattern: ["^https://", "Use a secure (https://) embed URL."]
+            hint: "Paste the full Google Maps iframe URL to render a location map."
       - name: shop
         label: Shop Page
         file: content/shop.json

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+interface ContactFormProps {
+  className?: string;
+}
+
+const combineClassNames = (base: string, extra?: string): string => {
+  if (!extra) {
+    return base;
+  }
+
+  return `${base} ${extra}`.trim();
+};
+
+const ContactForm: React.FC<ContactFormProps> = ({ className }) => (
+  <form
+    name="contact"
+    method="POST"
+    data-netlify="true"
+    netlify-honeypot="bot-field"
+    className={combineClassNames('space-y-6', className)}
+  >
+    <input type="hidden" name="form-name" value="contact" />
+    <div className="hidden" aria-hidden="true">
+      <label htmlFor="contact-bot-field" className="sr-only">
+        Do not fill this field
+      </label>
+      <input
+        id="contact-bot-field"
+        name="bot-field"
+        className="mt-1 w-full rounded-md border border-stone-300 p-2"
+        tabIndex={-1}
+        autoComplete="off"
+      />
+    </div>
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div className="space-y-2">
+        <label htmlFor="contact-name" className="text-sm font-medium text-stone-700">
+          Name
+        </label>
+        <input
+          id="contact-name"
+          type="text"
+          name="name"
+          required
+          autoComplete="name"
+          className="w-full rounded-md border border-stone-300 p-3 focus:border-stone-500 focus:ring-stone-500"
+          placeholder="Your name"
+        />
+      </div>
+      <div className="space-y-2">
+        <label htmlFor="contact-email" className="text-sm font-medium text-stone-700">
+          Email
+        </label>
+        <input
+          id="contact-email"
+          type="email"
+          name="email"
+          required
+          autoComplete="email"
+          className="w-full rounded-md border border-stone-300 p-3 focus:border-stone-500 focus:ring-stone-500"
+          placeholder="you@example.com"
+        />
+      </div>
+    </div>
+    <div className="space-y-2">
+      <label htmlFor="contact-message" className="text-sm font-medium text-stone-700">
+        Message
+      </label>
+      <textarea
+        id="contact-message"
+        name="message"
+        rows={6}
+        required
+        className="w-full rounded-md border border-stone-300 p-3 focus:border-stone-500 focus:ring-stone-500"
+        placeholder="How can we help?"
+      />
+    </div>
+    <div className="flex justify-end">
+      <button
+        type="submit"
+        className="rounded-md bg-stone-900 px-6 py-3 font-semibold text-white transition-colors duration-300 hover:bg-stone-700"
+      >
+        Send message
+      </button>
+    </div>
+  </form>
+);
+
+export default ContactForm;

--- a/content/pages_v2/index.json
+++ b/content/pages_v2/index.json
@@ -806,87 +806,7 @@
       ],
       "fields": [
         {
-          "key": "emailTitle",
-          "value": {
-            "en": "Email",
-            "pt": "E-mail",
-            "es": "Correo electrónico"
-          }
-        },
-        {
-          "key": "form.email",
-          "value": {
-            "en": "Email Address",
-            "pt": "Endereço de E-mail",
-            "es": "Correo Electrónico"
-          }
-        },
-        {
-          "key": "form.error",
-          "value": {
-            "en": "Sorry, something went wrong. Please try again.",
-            "pt": "Desculpe, algo deu errado. Por favor, tente novamente.",
-            "es": "Lo sentimos, algo salió mal. Por favor, inténtalo de nuevo."
-          }
-        },
-        {
-          "key": "form.message",
-          "value": {
-            "en": "Your Message",
-            "pt": "Sua Mensagem",
-            "es": "Tu Mensaje"
-          }
-        },
-        {
-          "key": "form.name",
-          "value": {
-            "en": "Full Name",
-            "pt": "Nome Completo",
-            "es": "Nombre Completo"
-          }
-        },
-        {
-          "key": "form.sending",
-          "value": {
-            "en": "Sending...",
-            "pt": "Enviando...",
-            "es": "Enviando..."
-          }
-        },
-        {
-          "key": "form.submit",
-          "value": {
-            "en": "Send Message",
-            "pt": "Enviar Mensagem",
-            "es": "Enviar Mensaje"
-          }
-        },
-        {
-          "key": "form.success",
-          "value": {
-            "en": "Thank you! Your message has been sent.",
-            "pt": "Obrigado! Sua mensagem foi enviada.",
-            "es": "¡Gracias! Tu mensaje ha sido enviado."
-          }
-        },
-        {
-          "key": "formTitle",
-          "value": {
-            "en": "Send us a message",
-            "pt": "Envie-nos uma mensagem",
-            "es": "Envíanos un mensaje"
-          }
-        },
-        {
-          "key": "headerSubtitle",
-          "value": {
-            "en": "We're here to help. Whether you have a question about our products or want to share your skin journey, we'd love to hear from you.",
-            "pt": "Estamos aqui para ajudar. Se você tem uma pergunta sobre nossos produtos ou quer compartilhar sua jornada com a pele, adoraríamos ouvir de você.",
-            "es": "Estamos aquí para ayudar. Ya sea que tengas una pregunta sobre nuestros productos o quieras compartir tu viaje con la piel, nos encantaría saber de ti."
-          }
-        },
-        {
-          "key": "headerTitle",
+          "key": "heroTitle",
           "value": {
             "en": "Get in Touch",
             "pt": "Entre em Contato",
@@ -894,43 +814,43 @@
           }
         },
         {
-          "key": "infoTitle",
+          "key": "heroSubtitle",
           "value": {
-            "en": "Other ways to connect",
-            "pt": "Outras formas de conectar",
-            "es": "Otras formas de conectar"
+            "en": "We're here to help. Whether you have a question about our products or want to share your skin journey, we'd love to hear from you.",
+            "pt": "Estamos aqui para ajudar. Se você tem uma pergunta sobre nossos produtos ou quer compartilhar sua jornada com a pele, adoraríamos ouvir de você.",
+            "es": "Estamos aquí para ayudar. Ya sea que tengas una pregunta sobre nuestros productos o quieras compartir tu viaje con la piel, nos encantaría saber de ti."
           }
         },
         {
-          "key": "phoneTitle",
+          "key": "contactEmail",
           "value": {
-            "en": "Phone",
-            "pt": "Telefone",
-            "es": "Teléfono"
+            "en": "global@kapunka.com",
+            "pt": "global@kapunka.com",
+            "es": "global@kapunka.com"
           }
         },
         {
-          "key": "title",
+          "key": "phone",
           "value": {
-            "en": "Contact Us",
-            "pt": "Fale Conosco",
-            "es": "Contáctanos"
+            "en": "+34 637 520 704",
+            "pt": "+34 637 520 704",
+            "es": "+34 637 520 704"
           }
         },
         {
-          "key": "whatsappAction",
+          "key": "address",
           "value": {
-            "en": "Chat with us",
-            "pt": "Converse conosco",
-            "es": "Chatea con nosotros"
+            "en": "Els Alamús (25221) Lleida\nCarrer de la Plaça la Placeta, 2, 2º\nSpain",
+            "pt": "Els Alamús (25221) Lleida\nCarrer de la Plaça la Placeta, 2, 2º\nEspanha",
+            "es": "Els Alamús (25221) Lleida\nCarrer de la Plaça la Placeta, 2, 2º\nEspaña"
           }
         },
         {
-          "key": "whatsappTitle",
+          "key": "mapEmbedUrl",
           "value": {
-            "en": "WhatsApp",
-            "pt": "WhatsApp",
-            "es": "WhatsApp"
+            "en": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2995.713025614638!2d0.7958955763531695!3d41.6292109792388!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x12a6f42321753ef3%3A0x3dfcc1a2ddedfb78!2sPla%C3%A7a%20la%20Placeta%2C%202%2C%2025201%20Els%20Alam%C3%BAs%2C%20Lleida%2C%20Spain!5e0!3m2!1sen!2ses!4v1700000000000!5m2!1sen!2ses",
+            "pt": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2995.713025614638!2d0.7958955763531695!3d41.6292109792388!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x12a6f42321753ef3%3A0x3dfcc1a2ddedfb78!2sPla%C3%A7a%20la%20Placeta%2C%202%2C%2025201%20Els%20Alam%C3%BAs%2C%20Lleida%2C%20Spain!5e0!3m2!1sen!2ses!4v1700000000000!5m2!1sen!2ses",
+            "es": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2995.713025614638!2d0.7958955763531695!3d41.6292109792388!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x12a6f42321753ef3%3A0x3dfcc1a2ddedfb78!2sPla%C3%A7a%20la%20Placeta%2C%202%2C%2025201%20Els%20Alam%C3%BAs%2C%20Lleida%2C%20Spain!5e0!3m2!1sen!2ses!4v1700000000000!5m2!1sen!2ses"
           }
         }
       ]

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-18 — Refreshed Contact page schema & Netlify form
+- **What changed**: Rebuilt the `/contact` page to load unified page data, added a reusable Netlify-enabled `ContactForm` component, and updated the CMS schema so editors manage hero copy, email, phone, address, and map embeds in one place.
+- **Impact & follow-up**: Editors now have dedicated fields for contact details and the rendered page mirrors those updates while keeping a Netlify form fallback. Confirm the Google Maps embed renders correctly across locales and monitor Netlify form submissions after deployment.
+- **References**: Pending PR
+
 ## 2025-10-17 — Enforced training catalog validation
 - **What changed**: Marked the training catalog list in `admin/config.yml` with a minimum entry count and required course title/summaries so editors cannot save empty modules. Updated the TrainingList React component to ignore entries without titles and hide empty summaries/CTAs on the `/training` page.
 - **Impact & follow-up**: Prevents blank "Learn more" cards from rendering when placeholder rows exist in Decap. Monitor future catalog imports to ensure they provide both title and summary content.

--- a/utils/loadContactPageContent.ts
+++ b/utils/loadContactPageContent.ts
@@ -1,0 +1,52 @@
+import type { Language } from '../types';
+import { fetchVisualEditorMarkdown, type VisualEditorContentSource } from './fetchVisualEditorMarkdown';
+import { loadUnifiedPage } from './unifiedPageLoader';
+import { loadPage } from '../src/lib/content';
+
+export interface ContactPageData {
+  metaTitle?: string;
+  metaDescription?: string;
+  heroTitle?: string;
+  heroSubtitle?: string;
+  contactEmail?: string;
+  phone?: string;
+  address?: string;
+  mapEmbedUrl?: string;
+  sections?: unknown[];
+}
+
+export interface ContactPageContentResult {
+  data: ContactPageData;
+  locale: Language;
+  source: VisualEditorContentSource;
+}
+
+export const loadContactPageContent = async (
+  language: Language,
+): Promise<ContactPageContentResult | null> => {
+  const unified = await loadUnifiedPage<ContactPageData>('contact', language);
+  if (unified) {
+    return unified;
+  }
+
+  try {
+    const result = await loadPage({
+      slug: 'contact',
+      locale: language,
+      loader: async ({ locale: currentLocale }) => fetchVisualEditorMarkdown<ContactPageData>(
+        `/content/pages/${currentLocale}/contact.md`,
+        { cache: 'no-store' },
+      ),
+    });
+
+    return {
+      data: result.data,
+      locale: result.localeUsed,
+      source: result.source,
+    };
+  } catch (error) {
+    console.warn('Contact page content fetch failed', error);
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Summary
- add a reusable Netlify-enabled contact form component
- load /contact hero, details, and map from unified CMS data with fallbacks
- expose localized contact fields in Decap and seed the unified page entry

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e379c646088320bc2c02dfc1881ae8