### PR TITLE
feat: enrich contact/training CMS previews

### DIFF
--- a/admin/cms.js
+++ b/admin/cms.js
@@ -444,6 +444,177 @@
       );
     }
 
+    function ContactPreview(props) {
+      const { entry } = props;
+      noteEntryLocale(entry);
+      scheduleLocaleRender();
+
+      const heroTitle = getEntryValue(entry, ['data', 'heroTitle'], 'Invite visitors to reach out');
+      const heroSubtitle = getEntryValue(entry, ['data', 'heroSubtitle'], 'Share how Kapunka can support enquiries.');
+      const contactEmail = getEntryValue(entry, ['data', 'contactEmail'], '');
+      const phone = getEntryValue(entry, ['data', 'phone'], '');
+      const address = getEntryValue(entry, ['data', 'address'], '');
+      const mapEmbedUrl = getEntryValue(entry, ['data', 'mapEmbedUrl'], '');
+      const sections = asArray(getEntryValue(entry, ['data', 'sections'], []));
+
+      const details = [];
+
+      if (typeof contactEmail === 'string' && contactEmail.trim().length > 0) {
+        details.push({ label: 'Email', value: contactEmail.trim(), type: 'text' });
+      }
+
+      if (typeof phone === 'string' && phone.trim().length > 0) {
+        details.push({ label: 'Phone', value: phone.trim(), type: 'text' });
+      }
+
+      if (typeof address === 'string' && address.trim().length > 0) {
+        details.push({ label: 'Address', value: address.trim(), type: 'address' });
+      }
+
+      if (typeof mapEmbedUrl === 'string' && mapEmbedUrl.trim().length > 0) {
+        details.push({ label: 'Map embed URL', value: mapEmbedUrl.trim(), type: 'map' });
+      }
+
+      const renderedSections = sections.map((section, index) => renderHomeSection(section || {}, index));
+
+      return createElement(
+        PreviewLayout,
+        null,
+        createElement(Hero, {
+          badge: 'Contact hero',
+          headline: heroTitle,
+          subheadline: heroSubtitle,
+        }),
+        createElement('section', { className: 'cms-preview-card border border-stone-200 bg-white p-8 space-y-6' },
+          createElement('div', { className: 'flex flex-wrap items-center justify-between gap-3' },
+            createElement('h2', { className: 'text-2xl font-semibold text-stone-900' }, 'Contact details'),
+            createElement('span', { className: 'cms-preview-pill' }, `${details.length} item${details.length === 1 ? '' : 's'}`),
+          ),
+          details.length > 0
+            ? createElement('dl', { className: 'cms-preview-contact-details sm:grid-cols-2' },
+                details.map((item, idx) => createElement('div', { key: `detail-${idx}`, className: 'space-y-1' },
+                  createElement('dt', { className: 'text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-400' }, item.label),
+                  createElement('dd', {
+                    className: item.type === 'map'
+                      ? 'cms-preview-monospace text-xs text-stone-500 break-all rounded-lg bg-stone-900/5 px-3 py-2'
+                      : item.type === 'address'
+                        ? 'text-sm text-stone-600 leading-relaxed whitespace-pre-line'
+                        : 'text-sm text-stone-600 leading-relaxed',
+                  }, item.value),
+                )),
+              )
+            : createElement('p', { className: 'cms-preview-muted text-sm' }, 'Add an email, phone number, address, or map embed URL for the contact page.'),
+        ),
+        renderedSections.length > 0
+          ? createElement('section', { className: 'space-y-6' },
+              createElement('h2', { className: 'text-2xl font-semibold text-stone-900' }, 'Supporting sections'),
+              createElement('div', { className: 'cms-preview-grid md:grid-cols-2' }, renderedSections),
+            )
+          : createElement('section', { className: 'cms-preview-card p-12 text-center text-stone-500 border border-dashed border-stone-300' }, 'Add optional sections such as FAQs or media blocks to round out the Contact page.'),
+      );
+    }
+
+    function renderTrainingSection(section, index) {
+      const type = typeof section.type === 'string' ? section.type : 'section';
+      const title = section.title || section.heading || `Section ${index + 1}`;
+
+      if (type === 'trainingList') {
+        const entries = asArray(section.entries);
+        const entryNodes = entries.length > 0
+          ? entries.map((entry, idx) => createElement('div', { key: `training-entry-${idx}`, className: 'rounded-2xl border border-stone-200 bg-white/60 p-5 space-y-2' },
+              createElement('h4', { className: 'text-sm font-semibold text-stone-900' }, entry.courseTitle || `Course ${idx + 1}`),
+              entry.courseSummary
+                ? createElement('p', { className: 'text-sm text-stone-600 leading-relaxed' }, entry.courseSummary)
+                : null,
+              entry.linkUrl
+                ? createElement('span', { className: 'cms-preview-pill w-fit' }, entry.linkUrl)
+                : null,
+            ))
+          : createElement('p', { className: 'cms-preview-muted text-sm' }, 'Add training entries with course titles, summaries, and optional links.');
+
+        return createElement(SectionCard, {
+          key: `training-section-${index}`,
+          badge: type,
+          title,
+          meta: entries.length > 0 ? `${entries.length} course${entries.length === 1 ? '' : 's'}` : null,
+        }, entryNodes);
+      }
+
+      if (type === 'timeline') {
+        const milestones = asArray(section.entries);
+        const milestoneNodes = milestones.length > 0
+          ? milestones.map((milestone, idx) => createElement('div', { key: `timeline-entry-${idx}`, className: 'relative border-l-2 border-stone-200 pl-5 space-y-1' },
+              createElement('span', { className: 'absolute -left-[9px] top-1.5 h-3 w-3 rounded-full bg-stone-400' }),
+              createElement('h4', { className: 'text-sm font-semibold text-stone-900' }, milestone.title || `Milestone ${idx + 1}`),
+              milestone.description
+                ? createElement('p', { className: 'text-sm text-stone-600 leading-relaxed' }, milestone.description)
+                : null,
+            ))
+          : createElement('p', { className: 'cms-preview-muted text-sm' }, 'Add timeline entries to outline the training journey.');
+
+        return createElement(SectionCard, {
+          key: `training-section-${index}`,
+          badge: type,
+          title,
+          meta: milestones.length > 0 ? `${milestones.length} step${milestones.length === 1 ? '' : 's'}` : null,
+        }, milestoneNodes);
+      }
+
+      if (type === 'videoGallery') {
+        const videos = asArray(section.entries);
+        const videoNodes = videos.length > 0
+          ? createElement('div', { className: 'grid gap-3 sm:grid-cols-2' },
+              videos.map((video, idx) => createElement('div', { key: `video-${idx}`, className: 'space-y-2 rounded-2xl border border-stone-200 bg-white p-4' },
+                createElement('h4', { className: 'text-sm font-semibold text-stone-900' }, video.title || `Video ${idx + 1}`),
+                video.description
+                  ? createElement('p', { className: 'text-sm text-stone-600 leading-relaxed' }, video.description)
+                  : null,
+                video.videoUrl
+                  ? createElement('div', { className: 'cms-preview-monospace text-xs text-stone-500 break-all rounded-lg bg-stone-900/5 px-3 py-2' }, video.videoUrl)
+                  : null,
+              )))
+          : createElement('p', { className: 'cms-preview-muted text-sm' }, 'Add videos with titles, descriptions, and URLs to enrich the gallery.');
+
+        return createElement(SectionCard, {
+          key: `training-section-${index}`,
+          badge: type,
+          title,
+          meta: videos.length > 0 ? `${videos.length} video${videos.length === 1 ? '' : 's'}` : null,
+        }, videoNodes);
+      }
+
+      return renderHomeSection(section, index);
+    }
+
+    function TrainingPreview(props) {
+      const { entry } = props;
+      noteEntryLocale(entry);
+      scheduleLocaleRender();
+
+      const metaTitle = getEntryValue(entry, ['data', 'metaTitle'], 'Introduce the Kapunka training program');
+      const metaDescription = getEntryValue(entry, ['data', 'metaDescription'], 'Summarise who the training supports and what participants will learn.');
+      const sections = asArray(getEntryValue(entry, ['data', 'sections'], []));
+      const renderedSections = sections.map((section, index) => renderTrainingSection(section || {}, index));
+
+      return createElement(
+        PreviewLayout,
+        null,
+        createElement('section', { className: 'cms-preview-card bg-white p-10 space-y-6 border border-stone-200' },
+          createElement('div', { className: 'cms-preview-badge text-stone-700 bg-stone-100' }, 'Training overview'),
+          createElement('h1', { className: 'text-4xl font-semibold text-stone-900 tracking-tight' }, metaTitle || 'Training page'),
+          metaDescription
+            ? createElement('p', { className: 'text-base text-stone-600 leading-relaxed max-w-3xl whitespace-pre-line' }, metaDescription)
+            : createElement('p', { className: 'cms-preview-muted text-sm' }, 'Add meta description copy to introduce the training journey.'),
+        ),
+        renderedSections.length > 0
+          ? createElement('section', { className: 'space-y-6' },
+              createElement('h2', { className: 'text-2xl font-semibold text-stone-900' }, 'Training sections'),
+              createElement('div', { className: 'cms-preview-grid md:grid-cols-2' }, renderedSections),
+            )
+          : createElement('section', { className: 'cms-preview-card p-12 text-center text-stone-500 border border-dashed border-stone-300' }, 'Add modules, timelines, or video galleries to preview the training experience.'),
+      );
+    }
+
     function MethodPreview(props) {
       const { entry } = props;
       noteEntryLocale(entry);
@@ -525,6 +696,10 @@
           return createElement(LearnPreview, props);
         case 'method':
           return createElement(MethodPreview, props);
+        case 'contact':
+          return createElement(ContactPreview, props);
+        case 'training':
+          return createElement(TrainingPreview, props);
         default:
           return createElement(GenericPagePreview, props);
       }
@@ -641,6 +816,21 @@
     });
 
     CMS.registerWidget('dashboard', DashboardWidget);
+
+    let registerPagePreviews;
+    try {
+      ({ registerPagePreviews } = await import('./preview-templates.js'));
+    } catch (error) {
+      console.warn('Failed to load targeted preview templates', error);
+    }
+
+    if (typeof registerPagePreviews === 'function') {
+      try {
+        registerPagePreviews(CMS, { ContactPreview, TrainingPreview });
+      } catch (error) {
+        console.warn('Failed to register targeted previews', error);
+      }
+    }
 
     CMS.registerPreviewTemplate('pages', PagePreview);
   }

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -9,7 +9,7 @@ localized_string_field: &localized_string_field
   i18n: true
   required: false
   editor:
-    type: tabs
+    display: 'tabs'
   fields:
     - { label: English, name: en, widget: string }
     - { label: Portuguese, name: pt, widget: string }
@@ -20,7 +20,7 @@ localized_text_field: &localized_text_field
   i18n: true
   required: false
   editor:
-    type: tabs
+    display: 'tabs'
   fields:
     - { label: English, name: en, widget: text }
     - { label: Portuguese, name: pt, widget: text }
@@ -31,7 +31,7 @@ localized_markdown_field: &localized_markdown_field
   i18n: true
   required: false
   editor:
-    type: tabs
+    display: 'tabs'
   fields:
     - { label: English, name: en, widget: markdown }
     - { label: Portuguese, name: pt, widget: markdown }
@@ -1045,7 +1045,7 @@ collections:
         media_folder: "content/uploads/home"
         public_folder: "/content/uploads/home"
         i18n: true
-        editor: { preview: true, type: tabs }
+        editor: { preview: true, display: 'tabs' }
         description: "Hero and storytelling blocks presented in live page order."
         preview_path: "/"
         fields:
@@ -1193,7 +1193,7 @@ collections:
         media_folder: "content/uploads/learn"
         public_folder: "/content/uploads/learn"
         i18n: true
-        editor: { preview: true, type: tabs }
+        editor: { preview: true, display: 'tabs' }
         description: "Optional storytelling sections surrounding the Learn hub."
         preview_path: "/learn"
         fields:
@@ -1248,7 +1248,7 @@ collections:
         media_folder: "content/uploads/method"
         public_folder: "/content/uploads/method"
         i18n: true
-        editor: { preview: true, type: tabs }
+        editor: { preview: true, display: 'tabs' }
         description: "Clinical method overview plus supporting content blocks."
         preview_path: "/method"
         fields:
@@ -1313,7 +1313,7 @@ collections:
         media_folder: "content/uploads/clinics"
         public_folder: "/content/uploads/clinics"
         i18n: true
-        editor: { preview: true, type: tabs }
+        editor: { preview: true, display: 'tabs' }
         description: "Clinic partnership story arranged top-to-bottom."
         preview_path: "/for-clinics"
         fields:
@@ -1549,7 +1549,7 @@ collections:
         media_folder: "content/uploads/about"
         public_folder: "/content/uploads/about"
         i18n: true
-        editor: { preview: true, type: tabs }
+        editor: { preview: true, display: 'tabs' }
         description: "Brand story sections in live page sequence."
         preview_path: "/about"
         fields:
@@ -1570,7 +1570,7 @@ collections:
         media_folder: "content/uploads/story"
         public_folder: "/content/uploads/story"
         i18n: true
-        editor: { preview: true, type: tabs }
+        editor: { preview: true, display: 'tabs' }
         description: "Brand manifesto narrative, value pillars, and optional supporting sections."
         preview_path: "/story"
         fields:
@@ -1664,7 +1664,7 @@ collections:
         media_folder: "content/uploads/contact"
         public_folder: "/content/uploads/contact"
         i18n: true
-        editor: { preview: true, type: tabs }
+        editor: { preview: true, display: 'tabs' }
         description: "Contact introductions and optional follow-up sections."
         preview_path: "/contact"
         fields:

--- a/admin/preview-styles.css
+++ b/admin/preview-styles.css
@@ -1,0 +1,24 @@
+@import './preview.css';
+
+.cms-preview-contact-details {
+  display: grid;
+  gap: 1rem;
+}
+
+.cms-preview-contact-details dt {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(120, 113, 108, 0.65);
+}
+
+.cms-preview-contact-details dd {
+  font-size: 0.875rem;
+  color: #57534e;
+  line-height: 1.6;
+}
+
+.cms-preview-monospace {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}

--- a/admin/preview-templates.js
+++ b/admin/preview-templates.js
@@ -1,0 +1,43 @@
+const ensurePreviewStyles = () => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  if (document.querySelector('link[data-preview-styles="contact-training"]')) {
+    return;
+  }
+
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = new URL('./preview-styles.css', import.meta.url).toString();
+  link.dataset.previewStyles = 'contact-training';
+  document.head.appendChild(link);
+};
+
+export function registerPagePreviews(CMS, templates) {
+  if (!CMS || !templates) {
+    return;
+  }
+
+  ensurePreviewStyles();
+
+  if (typeof CMS.registerPreviewStyle === 'function') {
+    CMS.registerPreviewStyle('/styles/globals.css');
+  }
+
+  if (typeof CMS.registerPreviewTemplate !== 'function') {
+    return;
+  }
+
+  const { ContactPreview, TrainingPreview } = templates;
+
+  if (typeof ContactPreview === 'function') {
+    CMS.registerPreviewTemplate('contact', ContactPreview);
+    CMS.registerPreviewTemplate('pages/contact', ContactPreview);
+  }
+
+  if (typeof TrainingPreview === 'function') {
+    CMS.registerPreviewTemplate('training', TrainingPreview);
+    CMS.registerPreviewTemplate('pages/training', TrainingPreview);
+  }
+}

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -11,6 +11,11 @@ This log records day-to-day investigations, fixes, and decisions that affect the
 
 ---
 
+## 2025-10-21 — Streamlined contact & training editing previews
+- **What changed**: Updated `admin/config.yml` so every page builder form renders locale tabs via the new `display: 'tabs'` editor setting and added targeted contact/training preview components plus a shared template loader to reuse site styles.
+- **Impact & follow-up**: Editors get consistent language tabs across key pages and live previews for contact/training entries that surface hero copy, contact details, and module sections. Monitor Decap for any console warnings about the targeted templates on load.
+- **References**: Pending PR
+
 ## 2025-10-18 — Refreshed Contact page schema & Netlify form
 - **What changed**: Rebuilt the `/contact` page to load unified page data, added a reusable Netlify-enabled `ContactForm` component, and updated the CMS schema so editors manage hero copy, email, phone, address, and map embeds in one place.
 - **Impact & follow-up**: Editors now have dedicated fields for contact details and the rendered page mirrors those updates while keeping a Netlify form fallback. Confirm the Google Maps embed renders correctly across locales and monitor Netlify form submissions after deployment.


### PR DESCRIPTION
## Summary
- switch localized field anchors and page builders to use the `display: 'tabs'` editor configuration so locales render in tabbed panels
- add dedicated contact and training preview components plus a lightweight template loader to register them with shared styles
- extend preview styling with reusable classes for contact detail grids and monospace embeds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e383b2877c83209652b1c691e63ad3