### PR TITLE
fix: keep footer sections single column below md

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -121,7 +121,7 @@ const Footer: React.FC = () => {
               )}
             </div>
           </div>
-          <div className="md:col-span-3 grid grid-cols-1 sm:grid-cols-3 gap-8">
+          <div className="md:col-span-3 grid grid-cols-1 md:grid-cols-3 gap-8">
             {FOOTER_SECTIONS.map((section) => (
               <div key={section.key}>
                 <h4


### PR DESCRIPTION
## Summary
- adjust footer link grid to remain single column below the md breakpoint
- retain existing Stackbit bindings while ensuring md and larger viewports keep three columns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e39903f2108320840a40ba4d856711