### PR TITLE
feat: support new visual editor sections

### DIFF
--- a/components/SectionRenderer.tsx
+++ b/components/SectionRenderer.tsx
@@ -2,6 +2,16 @@ import React, { useCallback, useMemo, useState } from 'react';
 import TimelineSection from './TimelineSection';
 import ImageTextHalf from './sections/ImageTextHalf';
 import ImageGrid from './sections/ImageGrid';
+import MediaCopy from './sections/MediaCopy';
+import MediaShowcase from './sections/MediaShowcase';
+import FeatureGrid from './sections/FeatureGrid';
+import ProductGrid from './sections/ProductGrid';
+import Banner from './sections/Banner';
+import NewsletterSignupSection from './sections/NewsletterSignup';
+import Testimonials from './sections/Testimonials';
+import Facts from './sections/Facts';
+import Bullets from './sections/Bullets';
+import Specialties from './sections/Specialties';
 import VideoGallery from './VideoGallery';
 import TrainingList from './TrainingList';
 import CommunityCarousel from './sections/CommunityCarousel';
@@ -134,6 +144,14 @@ const SectionRenderer: React.FC<SectionRendererProps> = ({ sections, fieldPath }
                 fieldPath={sectionFieldPath}
               />
             );
+          case 'mediaCopy':
+            return (
+              <MediaCopy
+                key={buildSectionKey('media-copy', section)}
+                section={section}
+                fieldPath={sectionFieldPath}
+              />
+            );
           case 'imageTextHalf':
             return (
               <ImageTextHalf
@@ -150,6 +168,30 @@ const SectionRenderer: React.FC<SectionRendererProps> = ({ sections, fieldPath }
               <ImageGrid
                 key={buildSectionKey('image-grid', section)}
                 items={section.items}
+                fieldPath={sectionFieldPath}
+              />
+            );
+          case 'mediaShowcase':
+            return (
+              <MediaShowcase
+                key={buildSectionKey('media-showcase', section)}
+                section={section}
+                fieldPath={sectionFieldPath}
+              />
+            );
+          case 'featureGrid':
+            return (
+              <FeatureGrid
+                key={buildSectionKey('feature-grid', section)}
+                section={section}
+                fieldPath={sectionFieldPath}
+              />
+            );
+          case 'productGrid':
+            return (
+              <ProductGrid
+                key={buildSectionKey('product-grid', section)}
+                section={section}
                 fieldPath={sectionFieldPath}
               />
             );
@@ -178,6 +220,54 @@ const SectionRenderer: React.FC<SectionRendererProps> = ({ sections, fieldPath }
               <ProductTabsSection
                 key={buildSectionKey('product-tabs', section)}
                 section={section}
+              />
+            );
+          case 'banner':
+            return (
+              <Banner
+                key={buildSectionKey('banner', section)}
+                section={section}
+                fieldPath={sectionFieldPath}
+              />
+            );
+          case 'newsletterSignup':
+            return (
+              <NewsletterSignupSection
+                key={buildSectionKey('newsletter-signup', section)}
+                section={section}
+                fieldPath={sectionFieldPath}
+              />
+            );
+          case 'testimonials':
+            return (
+              <Testimonials
+                key={buildSectionKey('testimonials', section)}
+                section={section}
+                fieldPath={sectionFieldPath}
+              />
+            );
+          case 'facts':
+            return (
+              <Facts
+                key={buildSectionKey('facts', section)}
+                section={section}
+                fieldPath={sectionFieldPath}
+              />
+            );
+          case 'bullets':
+            return (
+              <Bullets
+                key={buildSectionKey('bullets', section)}
+                section={section}
+                fieldPath={sectionFieldPath}
+              />
+            );
+          case 'specialties':
+            return (
+              <Specialties
+                key={buildSectionKey('specialties', section)}
+                section={section}
+                fieldPath={sectionFieldPath}
               />
             );
           case 'communityCarousel': {

--- a/components/sections/Banner.tsx
+++ b/components/sections/Banner.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { buildLocalizedPath } from '../../utils/localePaths';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import type { BannerSectionContent } from '../../types';
+
+interface BannerProps {
+  section: BannerSectionContent;
+  fieldPath?: string;
+}
+
+const resolveVariant = (variant: string | undefined) => {
+  const normalized = variant?.toLowerCase().trim();
+  switch (normalized) {
+    case 'light':
+      return 'bg-stone-100 text-stone-900';
+    case 'outline':
+      return 'border border-stone-900 text-stone-900 bg-transparent';
+    case 'accent':
+      return 'bg-amber-500 text-stone-900';
+    default:
+      return 'bg-stone-900 text-white';
+  }
+};
+
+const isInternalUrl = (url: string) => url.startsWith('/') || url.startsWith('#/');
+
+const normalizeInternalUrl = (url: string) => {
+  if (url.startsWith('#/')) {
+    const normalized = url.slice(1);
+    return normalized.startsWith('/') ? normalized : `/${normalized}`;
+  }
+  return url.startsWith('/') ? url : `/${url}`;
+};
+
+const Banner: React.FC<BannerProps> = ({ section, fieldPath }) => {
+  const { translate, language } = useLanguage();
+
+  const text = section.text ? translate(section.text) : '';
+  const cta = section.cta ? translate(section.cta) : '';
+  const url = section.url ? translate(section.url) : '';
+  const styleVariant = section.style ? translate(section.style) : undefined;
+
+  if (!text?.trim() && !cta?.trim()) {
+    return null;
+  }
+
+  const variantClasses = resolveVariant(styleVariant);
+  const linkContent = cta?.trim() ? (
+    <span {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.cta` : undefined)}>{cta}</span>
+  ) : null;
+
+  const urlFieldPath = fieldPath ? `${fieldPath}.url` : undefined;
+
+  const renderCta = () => {
+    if (!cta?.trim() || !url?.trim()) {
+      return null;
+    }
+
+    if (isInternalUrl(url)) {
+      return (
+        <Link
+          to={buildLocalizedPath(normalizeInternalUrl(url), language)}
+          className="inline-flex items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-stone-900 transition hover:bg-white"
+          {...getVisualEditorAttributes(urlFieldPath)}
+        >
+          {linkContent}
+        </Link>
+      );
+    }
+
+    return (
+      <a
+        href={url}
+        className="inline-flex items-center rounded-full bg-white/20 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/30"
+        target="_blank"
+        rel="noreferrer"
+        {...getVisualEditorAttributes(urlFieldPath)}
+      >
+        {linkContent}
+      </a>
+    );
+  };
+
+  return (
+    <section className="py-8" {...getVisualEditorAttributes(fieldPath)} data-sb-field-path={fieldPath}>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <div className={`flex flex-col gap-3 rounded-3xl px-6 py-5 sm:flex-row sm:items-center sm:justify-between ${variantClasses}`}>
+          <span
+            className="text-sm font-semibold uppercase tracking-[0.18em]"
+            {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.text` : undefined)}
+          >
+            {text}
+          </span>
+          {renderCta()}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Banner;

--- a/components/sections/Bullets.tsx
+++ b/components/sections/Bullets.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import type { BulletsSectionContent } from '../../types';
+
+interface BulletsProps {
+  section: BulletsSectionContent;
+  fieldPath?: string;
+}
+
+const Bullets: React.FC<BulletsProps> = ({ section, fieldPath }) => {
+  const { translate } = useLanguage();
+
+  const title = section.title ? translate(section.title) : '';
+  const items = (section.items ?? []).map((item, index) => {
+    const text = item ? translate(item) : '';
+    const itemFieldPath = fieldPath ? `${fieldPath}.items.${index}` : undefined;
+    return {
+      text,
+      fieldPath: itemFieldPath,
+      hasContent: Boolean(text?.trim()),
+    };
+  }).filter((item) => item.hasContent);
+
+  if (!title?.trim() && items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="py-16 sm:py-24 bg-white" {...getVisualEditorAttributes(fieldPath)} data-sb-field-path={fieldPath}>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl">
+          {title?.trim() ? (
+            <h2
+              className="text-3xl sm:text-4xl font-semibold text-stone-900"
+              {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.title` : undefined)}
+            >
+              {title}
+            </h2>
+          ) : null}
+          {items.length > 0 ? (
+            <ul className="mt-6 space-y-3 text-lg text-stone-700">
+              {items.map((item, index) => (
+                <li
+                  key={item.fieldPath ?? index}
+                  className="flex items-start gap-3"
+                  {...getVisualEditorAttributes(item.fieldPath)}
+                  data-sb-field-path={item.fieldPath}
+                >
+                  <span className="mt-1 inline-block h-2 w-2 rounded-full bg-stone-900" aria-hidden />
+                  <span {...getVisualEditorAttributes(item.fieldPath)}>{item.text}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Bullets;

--- a/components/sections/Facts.tsx
+++ b/components/sections/Facts.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import type { FactsSectionContent } from '../../types';
+
+interface FactsProps {
+  section: FactsSectionContent;
+  fieldPath?: string;
+}
+
+const Facts: React.FC<FactsProps> = ({ section, fieldPath }) => {
+  const { translate } = useLanguage();
+
+  const title = section.title ? translate(section.title) : '';
+  const text = section.text ? translate(section.text) : '';
+
+  if (!title?.trim() && !text?.trim()) {
+    return null;
+  }
+
+  return (
+    <section className="py-16 sm:py-24 bg-white" {...getVisualEditorAttributes(fieldPath)} data-sb-field-path={fieldPath}>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          {title?.trim() ? (
+            <h2
+              className="text-3xl sm:text-4xl font-semibold text-stone-900"
+              {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.title` : undefined)}
+            >
+              {title}
+            </h2>
+          ) : null}
+          {text?.trim() ? (
+            <div
+              className="mt-6 text-lg leading-relaxed text-stone-600"
+              {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.text` : undefined)}
+            >
+              <ReactMarkdown>{text}</ReactMarkdown>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Facts;

--- a/components/sections/FeatureGrid.tsx
+++ b/components/sections/FeatureGrid.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import { getCloudinaryUrl } from '../../utils/imageUrl';
+import type { FeatureGridSectionContent, LocalizedNumber } from '../../types';
+
+interface FeatureGridProps {
+  section: FeatureGridSectionContent;
+  fieldPath?: string;
+}
+
+const coerceNumber = (
+  translate: ReturnType<typeof useLanguage>['translate'],
+  value: LocalizedNumber | undefined,
+): number | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+
+  const translated = translate<number | string>(value);
+  if (typeof translated === 'number') {
+    return translated;
+  }
+
+  const parsed = Number(translated);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const FeatureGrid: React.FC<FeatureGridProps> = ({ section, fieldPath }) => {
+  const { translate } = useLanguage();
+
+  const resolvedTitle = section.title ? translate(section.title) : '';
+  const resolvedColumns = coerceNumber(translate, section.columns);
+
+  const items = (section.items ?? []).map((item, index) => {
+    const label = item?.label ? translate(item.label) : '';
+    const description = item?.description ? translate(item.description) : '';
+    const iconSrc = item?.icon?.trim();
+    const imageUrl = iconSrc ? getCloudinaryUrl(iconSrc) ?? iconSrc : undefined;
+    const itemFieldPath = fieldPath ? `${fieldPath}.items.${index}` : undefined;
+
+    return {
+      label,
+      description,
+      imageUrl,
+      hasContent: Boolean(label?.trim() || description?.trim() || imageUrl),
+      fieldPath: itemFieldPath,
+      labelFieldPath: itemFieldPath ? `${itemFieldPath}.label` : undefined,
+      descriptionFieldPath: itemFieldPath ? `${itemFieldPath}.description` : undefined,
+      iconFieldPath: itemFieldPath ? `${itemFieldPath}.icon` : undefined,
+    };
+  });
+
+  const visibleItems = items.filter((item) => item.hasContent);
+
+  if (!resolvedTitle?.trim() && visibleItems.length === 0) {
+    return null;
+  }
+
+  const columnsClass = (() => {
+    const columns = resolvedColumns && resolvedColumns >= 1 ? Math.min(Math.round(resolvedColumns), 4) : undefined;
+    switch (columns) {
+      case 4:
+        return 'grid-cols-1 md:grid-cols-2 xl:grid-cols-4';
+      case 3:
+        return 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3';
+      case 2:
+        return 'grid-cols-1 md:grid-cols-2';
+      default:
+        return 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3';
+    }
+  })();
+
+  return (
+    <section className="py-16 sm:py-24 bg-white" {...getVisualEditorAttributes(fieldPath)} data-sb-field-path={fieldPath}>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        {resolvedTitle?.trim() ? (
+          <div className="mb-10 max-w-3xl">
+            <h2
+              className="text-3xl sm:text-4xl font-semibold text-stone-900"
+              {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.title` : undefined)}
+            >
+              {resolvedTitle}
+            </h2>
+          </div>
+        ) : null}
+
+        <div className={`grid gap-6 ${columnsClass}`}>
+          {visibleItems.map((item, index) => (
+            <article
+              key={`${item.fieldPath ?? index}`}
+              className="rounded-2xl border border-stone-200 bg-stone-50 p-6 shadow-sm"
+              {...getVisualEditorAttributes(item.fieldPath)}
+              data-sb-field-path={item.fieldPath}
+            >
+              {item.imageUrl ? (
+                <img
+                  src={item.imageUrl}
+                  alt={item.label || 'Feature icon'}
+                  className="mb-4 h-12 w-12 object-contain"
+                  {...getVisualEditorAttributes(item.iconFieldPath)}
+                />
+              ) : null}
+              {item.label?.trim() ? (
+                <h3
+                  className="text-xl font-semibold text-stone-900"
+                  {...getVisualEditorAttributes(item.labelFieldPath)}
+                >
+                  {item.label}
+                </h3>
+              ) : null}
+              {item.description?.trim() ? (
+                <div
+                  className="mt-3 text-sm leading-relaxed text-stone-600"
+                  {...getVisualEditorAttributes(item.descriptionFieldPath)}
+                >
+                  <ReactMarkdown>{item.description}</ReactMarkdown>
+                </div>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default FeatureGrid;

--- a/components/sections/MediaCopy.tsx
+++ b/components/sections/MediaCopy.tsx
@@ -1,0 +1,254 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import { getCloudinaryUrl } from '../../utils/imageUrl';
+import { useLanguage } from '../../contexts/LanguageContext';
+import type { MediaCopySectionContent, LocalizedNumber, LocalizedValue } from '../../types';
+
+interface MediaCopyProps {
+  section: MediaCopySectionContent;
+  fieldPath?: string;
+}
+
+type MediaCopyLayout = 'image-left' | 'image-right' | 'overlay';
+
+const coerceNumber = (
+  translate: ReturnType<typeof useLanguage>['translate'],
+  value: LocalizedNumber | undefined,
+): number | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+
+  const translated = translate<number | string>(value);
+  if (typeof translated === 'number') {
+    return translated;
+  }
+
+  const parsed = Number(translated);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const coerceEnum = <T extends string>(
+  translate: ReturnType<typeof useLanguage>['translate'],
+  value: LocalizedValue<T> | undefined,
+  allowed: readonly T[],
+  fallback: T,
+): T => {
+  if (value == null) {
+    return fallback;
+  }
+
+  const translated = translate<T | string>(value);
+  if (allowed.includes(translated as T)) {
+    return translated as T;
+  }
+
+  return fallback;
+};
+
+const MediaCopy: React.FC<MediaCopyProps> = ({ section, fieldPath }) => {
+  const { translate } = useLanguage();
+
+  const titleSource = section.content?.heading ?? section.title;
+  const bodySource = section.content?.body ?? section.body;
+  const imageSource = section.content?.image ?? null;
+
+  const resolvedTitle = titleSource ? translate(titleSource) : '';
+  const resolvedBody = bodySource ? translate(bodySource) : '';
+
+  const hasContentHeading = Boolean(section.content && 'heading' in section.content);
+  const hasContentBody = Boolean(section.content && 'body' in section.content);
+
+  const titleFieldPath = fieldPath
+    ? hasContentHeading
+      ? `${fieldPath}.content.heading`
+      : `${fieldPath}.title`
+    : undefined;
+
+  const bodyFieldPath = fieldPath
+    ? hasContentBody
+      ? `${fieldPath}.content.body`
+      : `${fieldPath}.body`
+    : undefined;
+
+  const layout = coerceEnum<MediaCopyLayout>(
+    translate,
+    section.layout,
+    ['image-left', 'image-right', 'overlay'],
+    'image-right',
+  );
+
+  const columns = coerceNumber(translate, section.columns);
+
+  const rawImage = (() => {
+    if (imageSource?.src) {
+      return imageSource.src;
+    }
+    if (typeof section.image === 'string') {
+      return section.image;
+    }
+    if (section.image && typeof section.image === 'object' && 'src' in section.image) {
+      const candidate = section.image.src;
+      if (typeof candidate === 'string') {
+        return candidate;
+      }
+    }
+    return undefined;
+  })();
+
+  const trimmedImage = rawImage?.trim();
+  const imageUrl = trimmedImage ? getCloudinaryUrl(trimmedImage) ?? trimmedImage : undefined;
+
+  const hasContentImage = Boolean(section.content && 'image' in section.content && section.content.image !== undefined);
+  const usesObjectImage = !hasContentImage
+    && typeof section.image === 'object'
+    && section.image !== null
+    && 'src' in section.image;
+
+  const imageFieldPath = fieldPath
+    ? hasContentImage
+      ? `${fieldPath}.content.image.src`
+      : usesObjectImage
+        ? `${fieldPath}.image.src`
+        : `${fieldPath}.image`
+    : undefined;
+
+  const altSource = imageSource?.alt ?? section.imageAlt;
+  const imageAlt = altSource ? translate(altSource) : resolvedTitle || 'Featured media';
+
+  const overlaySettings = section.overlay ?? {};
+
+  const hasText = Boolean(resolvedTitle?.trim() || resolvedBody?.trim());
+  const hasImage = Boolean(imageUrl);
+
+  if (!hasText && !hasImage) {
+    return null;
+  }
+
+  const containerAttributes = getVisualEditorAttributes(fieldPath);
+
+  const textBlock = (
+    <div className="space-y-6">
+      {resolvedTitle?.trim() ? (
+        <h2
+          className="text-3xl sm:text-4xl font-semibold text-stone-900"
+          {...getVisualEditorAttributes(titleFieldPath)}
+        >
+          {resolvedTitle}
+        </h2>
+      ) : null}
+      {resolvedBody?.trim() ? (
+        <div
+          className="prose prose-stone max-w-none text-stone-600"
+          {...getVisualEditorAttributes(bodyFieldPath)}
+        >
+          <ReactMarkdown>{resolvedBody}</ReactMarkdown>
+        </div>
+      ) : null}
+    </div>
+  );
+
+  if (layout === 'overlay' && hasImage) {
+    const textAlign = coerceEnum(
+      translate,
+      overlaySettings.textAlign,
+      ['left', 'center', 'right'],
+      'left',
+    );
+    const verticalAlign = coerceEnum(
+      translate,
+      overlaySettings.verticalAlign,
+      ['start', 'center', 'end'],
+      'start',
+    );
+    const theme = coerceEnum(
+      translate,
+      overlaySettings.theme,
+      ['light', 'dark'],
+      'light',
+    );
+    const alignmentClass = {
+      start: 'items-start',
+      center: 'items-center',
+      end: 'items-end',
+    }[verticalAlign];
+    const textAlignClass = {
+      left: 'text-left',
+      center: 'text-center',
+      right: 'text-right',
+    }[textAlign];
+    const themeClass = theme === 'dark' ? 'text-stone-900' : 'text-white';
+    const backgroundClass = (() => {
+      const background = coerceEnum(
+        translate,
+        overlaySettings.background,
+        ['none', 'scrim-light', 'scrim-dark', 'panel'],
+        'scrim-dark',
+      );
+      switch (background) {
+        case 'panel':
+          return theme === 'dark'
+            ? 'bg-white/90 backdrop-blur'
+            : 'bg-black/60 backdrop-blur';
+        case 'scrim-light':
+          return 'bg-white/30 backdrop-blur';
+        case 'scrim-dark':
+          return 'bg-black/40 backdrop-blur';
+        default:
+          return '';
+      }
+    })();
+
+    return (
+      <section className="py-16 sm:py-24" {...containerAttributes} data-sb-field-path={fieldPath}>
+        <div className="container mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+          <div className="relative overflow-hidden rounded-3xl">
+            <img
+              src={imageUrl}
+              alt={imageAlt}
+              className="h-full w-full object-cover"
+              {...getVisualEditorAttributes(imageFieldPath)}
+            />
+            <div className="absolute inset-0 flex p-6 sm:p-10">
+              <div
+                className={`flex w-full max-w-2xl flex-col gap-6 ${alignmentClass} ${textAlignClass} ${themeClass} ${backgroundClass} p-6 sm:p-8 rounded-3xl`}
+                style={{ margin: 'auto' }}
+              >
+                {textBlock}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const gridColumns = columns && columns >= 1 ? Math.min(Math.round(columns), 2) : hasImage ? 2 : 1;
+  const gridClass = gridColumns === 1 ? 'grid-cols-1' : 'lg:grid-cols-2';
+  const imageFirst = layout === 'image-left';
+
+  return (
+    <section className="py-16 sm:py-24 bg-white" {...containerAttributes} data-sb-field-path={fieldPath}>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <div className={`grid gap-10 ${gridClass} items-center`}>
+          {hasImage ? (
+            <div className={imageFirst ? 'order-1' : gridColumns === 1 ? 'order-2' : 'order-2 lg:order-2'}>
+              <img
+                src={imageUrl}
+                alt={imageAlt}
+                className="w-full rounded-2xl object-cover shadow-sm"
+                {...getVisualEditorAttributes(imageFieldPath)}
+              />
+            </div>
+          ) : null}
+          <div className={hasImage ? (imageFirst ? 'order-2 lg:order-2' : 'order-1') : 'order-1'}>
+            {textBlock}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default MediaCopy;

--- a/components/sections/MediaShowcase.tsx
+++ b/components/sections/MediaShowcase.tsx
@@ -1,91 +1,128 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { buildLocalizedPath } from '../../utils/localePaths';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
 import { getCloudinaryUrl } from '../../utils/imageUrl';
-
-export interface MediaShowcaseItem {
-  eyebrow?: string;
-  title?: string;
-  body?: string;
-  image?: string;
-  imageAlt?: string;
-  fieldPath?: string;
-  imageFieldPath?: string;
-  eyebrowFieldPath?: string;
-  titleFieldPath?: string;
-  bodyFieldPath?: string;
-  ctaLabel?: string;
-  ctaHref?: string;
-  ctaLabelFieldPath?: string;
-  ctaHrefFieldPath?: string;
-}
+import type { MediaShowcaseSectionContent } from '../../types';
 
 interface MediaShowcaseProps {
-  title?: string;
-  items: MediaShowcaseItem[];
+  section: MediaShowcaseSectionContent;
   fieldPath?: string;
 }
 
-const isInternal = (href?: string) => Boolean(href && (href.startsWith('/') || href.startsWith('#/')));
+const isInternal = (href: string) => href.startsWith('/') || href.startsWith('#/');
 
 const normalizeInternal = (href: string) => {
   if (href.startsWith('#/')) {
     const normalized = href.slice(1);
     return normalized.startsWith('/') ? normalized : `/${normalized}`;
   }
-
   return href.startsWith('/') ? href : `/${href}`;
 };
 
-const MediaShowcase: React.FC<MediaShowcaseProps> = ({ title, items, fieldPath }) => {
-  const { language } = useLanguage();
+const MediaShowcase: React.FC<MediaShowcaseProps> = ({ section, fieldPath }) => {
+  const { translate, language } = useLanguage();
+
+  const title = section.title ? translate(section.title) : '';
+
+  const items = (section.items ?? []).map((item, index) => {
+    const eyebrow = item?.eyebrow ? translate(item.eyebrow) : '';
+    const itemTitle = item?.title ? translate(item.title) : '';
+    const body = item?.body ? translate(item.body) : '';
+    const description = item?.description ? translate(item.description) : '';
+    const label = item?.label ? translate(item.label) : '';
+    const ctaLabel = item?.ctaLabel ? translate(item.ctaLabel) : '';
+    const ctaHref = item?.ctaHref ? translate(item.ctaHref) : '';
+    const imageSrc = item?.image?.trim();
+    const imageUrl = imageSrc ? getCloudinaryUrl(imageSrc) ?? imageSrc : undefined;
+    const imageAlt = item?.imageAlt ? translate(item.imageAlt) : itemTitle || label || eyebrow || 'Showcase image';
+    const itemFieldPath = fieldPath ? `${fieldPath}.items.${index}` : undefined;
+
+    return {
+      eyebrow,
+      title: itemTitle,
+      body,
+      description,
+      label,
+      ctaLabel,
+      ctaHref,
+      imageUrl,
+      imageAlt,
+      fieldPath: itemFieldPath,
+      eyebrowFieldPath: itemFieldPath ? `${itemFieldPath}.eyebrow` : undefined,
+      titleFieldPath: itemFieldPath ? `${itemFieldPath}.title` : undefined,
+      bodyFieldPath: itemFieldPath ? `${itemFieldPath}.body` : undefined,
+      descriptionFieldPath: itemFieldPath ? `${itemFieldPath}.description` : undefined,
+      labelFieldPath: itemFieldPath ? `${itemFieldPath}.label` : undefined,
+      ctaLabelFieldPath: itemFieldPath ? `${itemFieldPath}.ctaLabel` : undefined,
+      ctaHrefFieldPath: itemFieldPath ? `${itemFieldPath}.ctaHref` : undefined,
+      imageFieldPath: itemFieldPath ? `${itemFieldPath}.image` : undefined,
+      imageAltFieldPath: itemFieldPath ? `${itemFieldPath}.imageAlt` : undefined,
+      hasContent: Boolean(itemTitle?.trim() || body?.trim() || description?.trim() || label?.trim() || imageUrl),
+    };
+  }).filter((item) => item.hasContent);
+
+  if (!title?.trim() && items.length === 0) {
+    return null;
+  }
+
+  const renderCta = (item: (typeof items)[number]) => {
+    if (!item.ctaLabel?.trim() || !item.ctaHref?.trim()) {
+      return null;
+    }
+
+    if (isInternal(item.ctaHref)) {
+      return (
+        <Link
+          to={buildLocalizedPath(normalizeInternal(item.ctaHref), language)}
+          className="inline-flex items-center rounded-full border border-white/60 bg-white/10 px-5 py-2 text-sm font-medium tracking-wide text-white transition hover:bg-white hover:text-stone-900"
+          {...getVisualEditorAttributes(item.ctaHrefFieldPath)}
+        >
+          <span {...getVisualEditorAttributes(item.ctaLabelFieldPath)}>{item.ctaLabel}</span>
+        </Link>
+      );
+    }
+
+    return (
+      <a
+        href={item.ctaHref}
+        className="inline-flex items-center rounded-full border border-white/60 bg-white/10 px-5 py-2 text-sm font-medium tracking-wide text-white transition hover:bg-white hover:text-stone-900"
+        target="_blank"
+        rel="noreferrer"
+        {...getVisualEditorAttributes(item.ctaHrefFieldPath)}
+      >
+        <span {...getVisualEditorAttributes(item.ctaLabelFieldPath)}>{item.ctaLabel}</span>
+      </a>
+    );
+  };
 
   return (
-    <section
-      className="py-20 sm:py-28 bg-white"
-      {...getVisualEditorAttributes(fieldPath)}
-      data-sb-field-path={fieldPath}
-    >
+    <section className="py-20 sm:py-28 bg-white" {...getVisualEditorAttributes(fieldPath)} data-sb-field-path={fieldPath}>
       <div className="w-full mx-auto px-4 sm:px-6 lg:px-0">
-        {title && (
+        {title?.trim() ? (
           <div
             className="max-w-3xl mb-10"
             {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.title` : undefined)}
-            data-sb-field-path={fieldPath ? `${fieldPath}.title` : undefined}
           >
             <h2 className="text-3xl sm:text-4xl font-semibold text-stone-900 tracking-tight">{title}</h2>
           </div>
-        )}
+        ) : null}
         <div className="grid auto-rows-[minmax(640px,1fr)] gap-y-0 md:grid-cols-4 md:gap-x-0">
           {items.map((item, index) => {
-            const imageSrc = item.image?.trim();
-            const cloudinaryUrl = imageSrc ? getCloudinaryUrl(imageSrc) ?? imageSrc : '';
-            const eyebrow = item.eyebrow?.trim();
-            const itemTitle = item.title?.trim();
-            const body = item.body?.trim();
-            const ctaLabel = item.ctaLabel?.trim();
-            const ctaHref = item.ctaHref?.trim();
-            const altText = item.imageAlt?.trim();
-
             const layoutClasses = (() => {
               if (index === 0) {
                 return 'md:col-span-2 md:row-span-2 lg:row-span-1';
               }
-
               if (index === 1) {
                 return 'md:col-span-2 md:row-span-2 lg:row-span-1';
               }
-
               if (index === 2) {
                 return 'md:col-span-4 lg:col-span-3 lg:row-span-1';
               }
-
               if (index === 3) {
                 return 'md:col-span-2 lg:col-span-1 lg:row-span-1';
               }
-
               return 'md:col-span-2';
             })();
 
@@ -94,92 +131,69 @@ const MediaShowcase: React.FC<MediaShowcaseProps> = ({ title, items, fieldPath }
 
             return (
               <article
-                key={`${item.fieldPath ?? index}`}
+                key={item.fieldPath ?? index}
                 className={`relative overflow-hidden bg-stone-900 text-white flex ${layoutClasses}`}
                 {...getVisualEditorAttributes(item.fieldPath)}
                 data-sb-field-path={item.fieldPath}
               >
-                {imageSrc ? (
+                {item.imageUrl ? (
                   <img
-                    src={cloudinaryUrl}
-                    alt={altText ?? itemTitle ?? 'Kapunka highlight'}
+                    src={item.imageUrl}
+                    alt={item.imageAlt}
                     className="absolute inset-0 h-full w-full object-cover"
                     {...getVisualEditorAttributes(item.imageFieldPath)}
-                    data-sb-field-path={item.imageFieldPath}
                   />
                 ) : (
                   <div
                     className="absolute inset-0 flex items-center justify-center border border-dashed border-white/40"
                     {...getVisualEditorAttributes(item.imageFieldPath)}
-                    data-sb-field-path={item.imageFieldPath}
                   >
                     <span className="text-sm text-white/70">Add an image</span>
                   </div>
                 )}
                 <div className="relative z-10 flex h-full w-full">
                   <div className={`flex flex-col justify-end gap-4 p-6 sm:p-8 lg:p-10 w-full ${contentAlignment} ${justify}`}>
-                    {eyebrow && (
+                    {item.eyebrow?.trim() ? (
                       <span
                         className="text-xs font-semibold uppercase tracking-[0.24em] text-white/80"
                         {...getVisualEditorAttributes(item.eyebrowFieldPath)}
-                        data-sb-field-path={item.eyebrowFieldPath}
                       >
-                        {eyebrow}
+                        {item.eyebrow}
                       </span>
-                    )}
-                    {itemTitle && (
+                    ) : null}
+                    {item.title?.trim() ? (
                       <h3
                         className="text-2xl sm:text-3xl font-semibold leading-snug"
                         {...getVisualEditorAttributes(item.titleFieldPath)}
-                        data-sb-field-path={item.titleFieldPath}
                       >
-                        {itemTitle}
+                        {item.title}
                       </h3>
-                    )}
-                    {body && (
+                    ) : null}
+                    {item.label?.trim() ? (
+                      <span
+                        className="text-sm font-medium uppercase tracking-[0.16em] text-white/70"
+                        {...getVisualEditorAttributes(item.labelFieldPath)}
+                      >
+                        {item.label}
+                      </span>
+                    ) : null}
+                    {item.description?.trim() ? (
                       <p
                         className="text-sm sm:text-base text-white/85 max-w-md"
-                        {...getVisualEditorAttributes(item.bodyFieldPath)}
-                        data-sb-field-path={item.bodyFieldPath}
+                        {...getVisualEditorAttributes(item.descriptionFieldPath)}
                       >
-                        {body}
+                        {item.description}
                       </p>
-                    )}
-                    {ctaLabel && ctaHref && (
-                      <div className="pt-2">
-                        {isInternal(ctaHref) ? (
-                          <Link
-                            to={buildLocalizedPath(normalizeInternal(ctaHref), language)}
-                            className="inline-flex items-center rounded-full border border-white/60 bg-white/10 px-5 py-2 text-sm font-medium tracking-wide text-white transition hover:bg-white hover:text-stone-900"
-                            {...getVisualEditorAttributes(item.ctaHrefFieldPath)}
-                            data-sb-field-path={item.ctaHrefFieldPath}
-                          >
-                            <span
-                              {...getVisualEditorAttributes(item.ctaLabelFieldPath)}
-                              data-sb-field-path={item.ctaLabelFieldPath}
-                            >
-                              {ctaLabel}
-                            </span>
-                          </Link>
-                        ) : (
-                          <a
-                            href={ctaHref}
-                            className="inline-flex items-center rounded-full border border-white/60 bg-white/10 px-5 py-2 text-sm font-medium tracking-wide text-white transition hover:bg-white hover:text-stone-900"
-                            {...getVisualEditorAttributes(item.ctaHrefFieldPath)}
-                            data-sb-field-path={item.ctaHrefFieldPath}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            <span
-                              {...getVisualEditorAttributes(item.ctaLabelFieldPath)}
-                              data-sb-field-path={item.ctaLabelFieldPath}
-                            >
-                              {ctaLabel}
-                            </span>
-                          </a>
-                        )}
-                      </div>
-                    )}
+                    ) : null}
+                    {item.body?.trim() ? (
+                      <p
+                        className="text-sm sm:text-base text-white/80 max-w-md"
+                        {...getVisualEditorAttributes(item.bodyFieldPath)}
+                      >
+                        {item.body}
+                      </p>
+                    ) : null}
+                    {renderCta(item)}
                   </div>
                 </div>
               </article>

--- a/components/sections/NewsletterSignup.tsx
+++ b/components/sections/NewsletterSignup.tsx
@@ -1,0 +1,132 @@
+import React, { useCallback, useState } from 'react';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import type { NewsletterSignupSectionContent, LocalizedValue } from '../../types';
+
+interface NewsletterSignupProps {
+  section: NewsletterSignupSectionContent;
+  fieldPath?: string;
+}
+
+type BackgroundVariant = 'light' | 'beige' | 'dark';
+type AlignmentVariant = 'left' | 'center';
+
+const coerceEnum = <T extends string>(
+  translate: ReturnType<typeof useLanguage>['translate'],
+  value: LocalizedValue<T> | undefined,
+  allowed: readonly T[],
+  fallback: T,
+): T => {
+  if (value == null) {
+    return fallback;
+  }
+
+  const translated = translate<T | string>(value);
+  if (allowed.includes(translated as T)) {
+    return translated as T;
+  }
+
+  return fallback;
+};
+
+const backgroundClasses: Record<BackgroundVariant, string> = {
+  light: 'bg-stone-200 text-stone-900',
+  beige: 'bg-amber-50 text-stone-900',
+  dark: 'bg-stone-900 text-white',
+};
+
+const NewsletterSignup: React.FC<NewsletterSignupProps> = ({ section, fieldPath }) => {
+  const { translate, t } = useLanguage();
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const title = section.title ? translate(section.title) : '';
+  const subtitle = section.subtitle ? translate(section.subtitle) : '';
+  const placeholder = section.placeholder ? translate(section.placeholder) : t('home.newsletterPlaceholder');
+  const ctaLabel = section.ctaLabel ? translate(section.ctaLabel) : t('home.newsletterSubmit');
+  const confirmation = section.confirmation ? translate(section.confirmation) : t('home.newsletterThanks');
+
+  const background = coerceEnum<BackgroundVariant>(translate, section.background, ['light', 'beige', 'dark'], 'light');
+  const alignment = coerceEnum<AlignmentVariant>(translate, section.alignment, ['left', 'center'], 'center');
+
+  const handleSubmit = useCallback((event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitted(true);
+  }, []);
+
+  const handleChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(event.target.value);
+  }, []);
+
+  const backgroundClass = backgroundClasses[background];
+  const isDark = background === 'dark';
+  const alignmentWrapper = alignment === 'left' ? 'items-start text-left' : 'items-center text-center';
+  const formAlignment = alignment === 'left' ? 'sm:flex-row sm:justify-start' : 'sm:flex-row sm:justify-center';
+  const containerWidth = alignment === 'left' ? 'max-w-3xl' : 'max-w-2xl';
+
+  const inputClasses = isDark
+    ? 'flex-grow px-4 py-3 rounded-md border border-white/40 bg-white/10 text-white placeholder:text-white/60 focus:outline-none focus:ring-2 focus:ring-white/60 focus:border-white/60 transition'
+    : 'flex-grow px-4 py-3 rounded-md border border-stone-300 focus:outline-none focus:ring-2 focus:ring-stone-500 focus:border-stone-500 transition';
+
+  const buttonClasses = isDark
+    ? 'px-6 py-3 bg-white text-stone-900 font-semibold rounded-md hover:bg-white/90 transition-colors'
+    : 'px-6 py-3 bg-stone-900 text-white font-semibold rounded-md hover:bg-stone-700 transition-colors';
+
+  if (!title?.trim() && !subtitle?.trim()) {
+    return null;
+  }
+
+  return (
+    <section className={`py-16 sm:py-24 ${backgroundClass}`} {...getVisualEditorAttributes(fieldPath)} data-sb-field-path={fieldPath}>
+      <div className={`container mx-auto px-4 sm:px-6 lg:px-8 ${containerWidth}`}>
+        <div className={`flex flex-col gap-4 ${alignmentWrapper}`}>
+          {title?.trim() ? (
+            <h2
+              className="text-3xl sm:text-4xl font-semibold"
+              {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.title` : undefined)}
+            >
+              {title}
+            </h2>
+          ) : null}
+          {subtitle?.trim() ? (
+            <p
+              className={`text-base sm:text-lg ${isDark ? 'text-white/80' : 'text-stone-600'}`}
+              {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.subtitle` : undefined)}
+            >
+              {subtitle}
+            </p>
+          ) : null}
+
+          {submitted ? (
+            <p
+              className={`text-lg font-semibold ${isDark ? 'text-white' : 'text-green-700'}`}
+              {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.confirmation` : undefined)}
+            >
+              {confirmation}
+            </p>
+          ) : (
+            <form
+              onSubmit={handleSubmit}
+              className={`flex w-full flex-col gap-2 sm:max-w-xl ${formAlignment}`}
+            >
+              <input
+                type="email"
+                value={email}
+                onChange={handleChange}
+                placeholder={placeholder}
+                required
+                className={inputClasses}
+                {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.placeholder` : undefined)}
+              />
+              <button type="submit" className={buttonClasses}>
+                <span {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.ctaLabel` : undefined)}>{ctaLabel}</span>
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default NewsletterSignup;

--- a/components/sections/ProductGrid.tsx
+++ b/components/sections/ProductGrid.tsx
@@ -1,0 +1,294 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { Link } from 'react-router-dom';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { useVisualEditorSync } from '../../contexts/VisualEditorSyncContext';
+import ProductCard from '../ProductCard';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import { fetchVisualEditorJson } from '../../utils/fetchVisualEditorJson';
+import { getCloudinaryUrl } from '../../utils/imageUrl';
+import { buildLocalizedPath } from '../../utils/localePaths';
+import type { Product, ProductGridSectionContent, LocalizedNumber } from '../../types';
+
+interface ProductGridProps {
+  section: ProductGridSectionContent;
+  fieldPath?: string;
+}
+
+interface ProductsResponse {
+  items?: Product[];
+}
+
+const coerceNumber = (
+  translate: ReturnType<typeof useLanguage>['translate'],
+  value: LocalizedNumber | undefined,
+): number | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+
+  const translated = translate<number | string>(value);
+  if (typeof translated === 'number') {
+    return translated;
+  }
+
+  const parsed = Number(translated);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const isInternalUrl = (href: string) => href.startsWith('/') || href.startsWith('#/');
+
+const normalizeInternal = (href: string) => {
+  if (href.startsWith('#/')) {
+    const normalized = href.slice(1);
+    return normalized.startsWith('/') ? normalized : `/${normalized}`;
+  }
+  return href.startsWith('/') ? href : `/${href}`;
+};
+
+const ProductGrid: React.FC<ProductGridProps> = ({ section, fieldPath }) => {
+  const { translate, language } = useLanguage();
+  const { contentVersion } = useVisualEditorSync();
+  const [catalog, setCatalog] = useState<Product[]>([]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadProducts = async () => {
+      try {
+        const data = await fetchVisualEditorJson<ProductsResponse>('/content/products/index.json');
+        if (!isMounted) {
+          return;
+        }
+
+        setCatalog(Array.isArray(data?.items) ? data.items : []);
+      } catch (error) {
+        console.error('Failed to load products for product grid section', error);
+        if (isMounted) {
+          setCatalog([]);
+        }
+      }
+    };
+
+    loadProducts().catch((error) => {
+      console.error('Unhandled product grid load error', error);
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [contentVersion]);
+
+  const productIndexMap = useMemo(() => {
+    const map = new Map<string, number>();
+    catalog.forEach((product, index) => {
+      map.set(product.id, index);
+    });
+    return map;
+  }, [catalog]);
+
+  const resolvedTitle = section.title ? translate(section.title) : '';
+  const resolvedColumns = coerceNumber(translate, section.columns);
+
+  const referencedProducts = useMemo(() => {
+    const ids = (section.products ?? []).map((ref) => {
+      const rawId = ref?.id ? translate(ref.id) : '';
+      return rawId?.trim();
+    }).filter((id): id is string => Boolean(id));
+
+    if (ids.length === 0) {
+      return [] as Array<{ product: Product; fieldPath?: string }>;
+    }
+
+    return ids
+      .map((id) => {
+        const product = catalog.find((item) => item.id === id);
+        if (!product) {
+          return null;
+        }
+        const productIndex = productIndexMap.get(product.id);
+        const productFieldPath = productIndex != null ? `products.items.${productIndex}` : undefined;
+        return { product, fieldPath: productFieldPath };
+      })
+      .filter((entry): entry is { product: Product; fieldPath?: string } => entry !== null);
+  }, [section.products, translate, catalog, productIndexMap]);
+
+  const highlightItems = (section.items ?? []).map((item, index) => {
+    const eyebrow = item?.eyebrow ? translate(item.eyebrow) : '';
+    const title = item?.title ? translate(item.title) : '';
+    const label = item?.label ? translate(item.label) : '';
+    const description = item?.description ? translate(item.description) : '';
+    const body = item?.body ? translate(item.body) : '';
+    const ctaLabel = item?.ctaLabel ? translate(item.ctaLabel) : '';
+    const ctaHref = item?.ctaHref ? translate(item.ctaHref) : '';
+    const imageSrc = item?.image?.trim();
+    const imageUrl = imageSrc ? getCloudinaryUrl(imageSrc) ?? imageSrc : undefined;
+    const imageAlt = item?.imageAlt ? translate(item.imageAlt) : title || label || eyebrow || 'Highlight image';
+    const itemFieldPath = fieldPath ? `${fieldPath}.items.${index}` : undefined;
+
+    return {
+      eyebrow,
+      title,
+      label,
+      description,
+      body,
+      ctaLabel,
+      ctaHref,
+      imageUrl,
+      imageAlt,
+      fieldPath: itemFieldPath,
+      eyebrowFieldPath: itemFieldPath ? `${itemFieldPath}.eyebrow` : undefined,
+      titleFieldPath: itemFieldPath ? `${itemFieldPath}.title` : undefined,
+      labelFieldPath: itemFieldPath ? `${itemFieldPath}.label` : undefined,
+      descriptionFieldPath: itemFieldPath ? `${itemFieldPath}.description` : undefined,
+      bodyFieldPath: itemFieldPath ? `${itemFieldPath}.body` : undefined,
+      ctaLabelFieldPath: itemFieldPath ? `${itemFieldPath}.ctaLabel` : undefined,
+      ctaHrefFieldPath: itemFieldPath ? `${itemFieldPath}.ctaHref` : undefined,
+      imageFieldPath: itemFieldPath ? `${itemFieldPath}.image` : undefined,
+      hasContent: Boolean(title?.trim() || label?.trim() || description?.trim() || body?.trim() || imageUrl),
+    };
+  }).filter((item) => item.hasContent);
+
+  if (!resolvedTitle?.trim() && referencedProducts.length === 0 && highlightItems.length === 0) {
+    return null;
+  }
+
+  const productGridColumns = referencedProducts.length >= 3 ? 'md:grid-cols-2 lg:grid-cols-3' : 'md:grid-cols-2';
+  const highlightColumns = (() => {
+    const columns = resolvedColumns && resolvedColumns >= 1 ? Math.min(Math.round(resolvedColumns), 4) : undefined;
+    switch (columns) {
+      case 4:
+        return 'grid-cols-1 md:grid-cols-2 xl:grid-cols-4';
+      case 3:
+        return 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3';
+      case 2:
+        return 'grid-cols-1 md:grid-cols-2';
+      default:
+        return 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3';
+    }
+  })();
+
+  const renderHighlightCta = (item: (typeof highlightItems)[number]) => {
+    if (!item.ctaLabel?.trim() || !item.ctaHref?.trim()) {
+      return null;
+    }
+
+    if (isInternalUrl(item.ctaHref)) {
+      return (
+        <Link
+          to={buildLocalizedPath(normalizeInternal(item.ctaHref), language)}
+          className="inline-flex items-center rounded-full border border-stone-900 px-4 py-2 text-sm font-medium text-stone-900 transition hover:bg-stone-900 hover:text-white"
+          {...getVisualEditorAttributes(item.ctaHrefFieldPath)}
+        >
+          <span {...getVisualEditorAttributes(item.ctaLabelFieldPath)}>{item.ctaLabel}</span>
+        </Link>
+      );
+    }
+
+    return (
+      <a
+        href={item.ctaHref}
+        className="inline-flex items-center rounded-full border border-stone-300 px-4 py-2 text-sm font-medium text-stone-600 transition hover:border-stone-500 hover:text-stone-900"
+        target="_blank"
+        rel="noreferrer"
+        {...getVisualEditorAttributes(item.ctaHrefFieldPath)}
+      >
+        <span {...getVisualEditorAttributes(item.ctaLabelFieldPath)}>{item.ctaLabel}</span>
+      </a>
+    );
+  };
+
+  return (
+    <section className="py-16 sm:py-24 bg-stone-100" {...getVisualEditorAttributes(fieldPath)} data-sb-field-path={fieldPath}>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        {resolvedTitle?.trim() ? (
+          <div className="mb-12 text-center">
+            <h2
+              className="text-3xl sm:text-4xl font-semibold text-stone-900"
+              {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.title` : undefined)}
+            >
+              {resolvedTitle}
+            </h2>
+          </div>
+        ) : null}
+
+        {referencedProducts.length > 0 ? (
+          <div className={`grid gap-8 ${productGridColumns}`}>
+            {referencedProducts.map(({ product, fieldPath: productField }, index) => (
+              <ProductCard key={product.id ?? index} product={product} fieldPath={productField} />
+            ))}
+          </div>
+        ) : null}
+
+        {highlightItems.length > 0 ? (
+          <div
+            className={`${referencedProducts.length > 0 ? 'mt-14' : ''} grid gap-8 ${highlightColumns}`.trim()}
+          >
+            {highlightItems.map((item, index) => (
+              <article
+                key={item.fieldPath ?? index}
+                className="rounded-3xl bg-white p-6 shadow-sm"
+                {...getVisualEditorAttributes(item.fieldPath)}
+                data-sb-field-path={item.fieldPath}
+              >
+                {item.imageUrl ? (
+                  <img
+                    src={item.imageUrl}
+                    alt={item.imageAlt}
+                    className="mb-4 h-48 w-full rounded-2xl object-cover"
+                    {...getVisualEditorAttributes(item.imageFieldPath)}
+                  />
+                ) : null}
+                {item.eyebrow?.trim() ? (
+                  <span
+                    className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500"
+                    {...getVisualEditorAttributes(item.eyebrowFieldPath)}
+                  >
+                    {item.eyebrow}
+                  </span>
+                ) : null}
+                {item.title?.trim() ? (
+                  <h3
+                    className="mt-2 text-2xl font-semibold text-stone-900"
+                    {...getVisualEditorAttributes(item.titleFieldPath)}
+                  >
+                    {item.title}
+                  </h3>
+                ) : null}
+                {item.label?.trim() ? (
+                  <p
+                    className="mt-1 text-sm font-medium uppercase tracking-[0.12em] text-stone-500"
+                    {...getVisualEditorAttributes(item.labelFieldPath)}
+                  >
+                    {item.label}
+                  </p>
+                ) : null}
+                {item.description?.trim() ? (
+                  <p
+                    className="mt-3 text-sm text-stone-600"
+                    {...getVisualEditorAttributes(item.descriptionFieldPath)}
+                  >
+                    {item.description}
+                  </p>
+                ) : null}
+                {item.body?.trim() ? (
+                  <div
+                    className="mt-4 text-sm leading-relaxed text-stone-600"
+                    {...getVisualEditorAttributes(item.bodyFieldPath)}
+                  >
+                    <ReactMarkdown>{item.body}</ReactMarkdown>
+                  </div>
+                ) : null}
+                {item.ctaLabel?.trim() && item.ctaHref?.trim() ? (
+                  <div className="mt-6">{renderHighlightCta(item)}</div>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+};
+
+export default ProductGrid;

--- a/components/sections/Specialties.tsx
+++ b/components/sections/Specialties.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import type { SpecialtiesSectionContent } from '../../types';
+
+interface SpecialtiesProps {
+  section: SpecialtiesSectionContent;
+  fieldPath?: string;
+}
+
+const Specialties: React.FC<SpecialtiesProps> = ({ section, fieldPath }) => {
+  const { translate } = useLanguage();
+
+  const title = section.title ? translate(section.title) : '';
+  const items = (section.items ?? []).map((item, index) => {
+    const titleText = item?.title ? translate(item.title) : '';
+    const bullets = (item?.bullets ?? []).map((bullet, bulletIndex) => {
+      const text = bullet ? translate(bullet) : '';
+      const bulletFieldPath = fieldPath ? `${fieldPath}.items.${index}.bullets.${bulletIndex}` : undefined;
+      return {
+        text,
+        fieldPath: bulletFieldPath,
+        hasContent: Boolean(text?.trim()),
+      };
+    }).filter((bullet) => bullet.hasContent);
+    const itemFieldPath = fieldPath ? `${fieldPath}.items.${index}` : undefined;
+
+    return {
+      title: titleText,
+      bullets,
+      fieldPath: itemFieldPath,
+      titleFieldPath: itemFieldPath ? `${itemFieldPath}.title` : undefined,
+      hasContent: Boolean(titleText?.trim() || bullets.length > 0),
+    };
+  }).filter((item) => item.hasContent);
+
+  if (!title?.trim() && items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="py-16 sm:py-24 bg-white" {...getVisualEditorAttributes(fieldPath)} data-sb-field-path={fieldPath}>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        {title?.trim() ? (
+          <div className="mb-10 max-w-3xl">
+            <h2
+              className="text-3xl sm:text-4xl font-semibold text-stone-900"
+              {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.title` : undefined)}
+            >
+              {title}
+            </h2>
+          </div>
+        ) : null}
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {items.map((item, index) => (
+            <article
+              key={item.fieldPath ?? index}
+              className="rounded-3xl border border-stone-200 bg-stone-50 p-6 shadow-sm"
+              {...getVisualEditorAttributes(item.fieldPath)}
+              data-sb-field-path={item.fieldPath}
+            >
+              {item.title?.trim() ? (
+                <h3
+                  className="text-xl font-semibold text-stone-900"
+                  {...getVisualEditorAttributes(item.titleFieldPath)}
+                >
+                  {item.title}
+                </h3>
+              ) : null}
+              {item.bullets.length > 0 ? (
+                <ul className="mt-4 space-y-2 text-sm text-stone-700">
+                  {item.bullets.map((bullet, bulletIndex) => (
+                    <li
+                      key={bullet.fieldPath ?? bulletIndex}
+                      className="flex items-start gap-2"
+                      {...getVisualEditorAttributes(bullet.fieldPath)}
+                      data-sb-field-path={bullet.fieldPath}
+                    >
+                      <span className="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-stone-400" aria-hidden />
+                      <span {...getVisualEditorAttributes(bullet.fieldPath)}>{bullet.text}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Specialties;

--- a/components/sections/Testimonials.tsx
+++ b/components/sections/Testimonials.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import type { TestimonialsSectionContent } from '../../types';
+
+interface TestimonialsProps {
+  section: TestimonialsSectionContent;
+  fieldPath?: string;
+}
+
+const Testimonials: React.FC<TestimonialsProps> = ({ section, fieldPath }) => {
+  const { translate } = useLanguage();
+
+  const title = section.title ? translate(section.title) : '';
+
+  const quotes = (section.quotes ?? []).map((quote, index) => {
+    const text = quote?.text ? translate(quote.text) : '';
+    const author = quote?.author ? translate(quote.author) : '';
+    const role = quote?.role ? translate(quote.role) : '';
+    const quoteFieldPath = fieldPath ? `${fieldPath}.quotes.${index}` : undefined;
+
+    return {
+      text,
+      author,
+      role,
+      fieldPath: quoteFieldPath,
+      textFieldPath: quoteFieldPath ? `${quoteFieldPath}.text` : undefined,
+      authorFieldPath: quoteFieldPath ? `${quoteFieldPath}.author` : undefined,
+      roleFieldPath: quoteFieldPath ? `${quoteFieldPath}.role` : undefined,
+      hasContent: Boolean(text?.trim() || author?.trim() || role?.trim()),
+    };
+  }).filter((quote) => quote.hasContent);
+
+  if (!title?.trim() && quotes.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="py-16 sm:py-24 bg-white" {...getVisualEditorAttributes(fieldPath)} data-sb-field-path={fieldPath}>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        {title?.trim() ? (
+          <div className="mb-10 max-w-3xl">
+            <h2
+              className="text-3xl sm:text-4xl font-semibold text-stone-900"
+              {...getVisualEditorAttributes(fieldPath ? `${fieldPath}.title` : undefined)}
+            >
+              {title}
+            </h2>
+          </div>
+        ) : null}
+
+        <div className="grid gap-6 md:grid-cols-2">
+          {quotes.map((quote, index) => (
+            <blockquote
+              key={quote.fieldPath ?? index}
+              className="rounded-3xl border border-stone-200 bg-stone-50 p-6 shadow-sm"
+              {...getVisualEditorAttributes(quote.fieldPath)}
+              data-sb-field-path={quote.fieldPath}
+            >
+              {quote.text?.trim() ? (
+                <div
+                  className="text-base italic leading-relaxed text-stone-700"
+                  {...getVisualEditorAttributes(quote.textFieldPath)}
+                >
+                  <ReactMarkdown>{`“${quote.text}”`}</ReactMarkdown>
+                </div>
+              ) : null}
+              <footer className="mt-4 text-xs uppercase tracking-[0.2em] text-stone-500">
+                {quote.author?.trim() ? (
+                  <div {...getVisualEditorAttributes(quote.authorFieldPath)}>{quote.author}</div>
+                ) : null}
+                {quote.role?.trim() ? (
+                  <div
+                    className="mt-1 text-[11px] font-normal normal-case tracking-normal text-stone-400"
+                    {...getVisualEditorAttributes(quote.roleFieldPath)}
+                  >
+                    {quote.role}
+                  </div>
+                ) : null}
+              </footer>
+            </blockquote>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Testimonials;

--- a/docs/decap-netlify-rolling-log.md
+++ b/docs/decap-netlify-rolling-log.md
@@ -1,5 +1,10 @@
 # Decap CMS & Netlify Rolling Log
 
+## 2025-10-31 — Expanded section renderer coverage
+- **What changed**: Added strongly typed models for every Stackbit builder block in `types.ts`, introduced reusable section components (media copy, feature grid, banner, newsletter, product grid, testimonials, facts, bullets, specialties), and updated `SectionRenderer` plus the story/about/training/videos page loaders to recognise the new variants with proper Visual Editor field bindings.
+- **Impact & follow-up**: Visual Editor sections now render consistently across detail pages and inline editing works for the newly supported blocks, reducing manual QA when editors add builder sections. Monitor upcoming content syncs to confirm product grids resolve product references correctly.
+- **References**: Pending PR
+
 ## 2025-10-30 — Restored localized Home hero content
 - **What changed**: Re-applied the English Home markdown hero showcase copy directly from commit `4f69023` so the supply chain and rituals tiles use the design-approved wording while confirming the Portuguese and Spanish files already matched the same structure.
 - **Impact & follow-up**: Ensures the homepage hero module renders with the expected headings and CTAs across locales, keeping the visual editor in sync with the reference layout. Monitor future homepage edits in Decap to make sure the localized markdown stays aligned with the design baseline.

--- a/pages/About.tsx
+++ b/pages/About.tsx
@@ -79,26 +79,51 @@ const isImageGridSection = (value: unknown): value is PageSection => {
   return section.type === 'imageGrid' && Array.isArray(section.items) && section.items.every(isImageGridItem);
 };
 
+const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
+  'timeline',
+  'imageTextHalf',
+  'imageGrid',
+  'communityCarousel',
+  'videoGallery',
+  'trainingList',
+  'productTabs',
+  'mediaCopy',
+  'mediaShowcase',
+  'featureGrid',
+  'productGrid',
+  'banner',
+  'newsletterSignup',
+  'testimonials',
+  'facts',
+  'bullets',
+  'specialties',
+]);
+
 const isPageSection = (value: unknown): value is PageSection => {
   if (!value || typeof value !== 'object') {
     return false;
   }
 
   const section = value as Record<string, unknown>;
+  const type = section.type;
 
-  if (section.type === 'timeline') {
+  if (typeof type !== 'string' || !SUPPORTED_SECTION_TYPES.has(type as PageSection['type'])) {
+    return false;
+  }
+
+  if (type === 'timeline') {
     return isTimelineSection(section);
   }
 
-  if (section.type === 'imageTextHalf') {
+  if (type === 'imageTextHalf') {
     return isImageTextHalfSection(section);
   }
 
-  if (section.type === 'imageGrid') {
+  if (type === 'imageGrid') {
     return isImageGridSection(section);
   }
 
-  return false;
+  return true;
 };
 
 const isPageContent = (value: unknown): value is PageContent => {

--- a/pages/Story.tsx
+++ b/pages/Story.tsx
@@ -17,6 +17,18 @@ const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
   'imageGrid',
   'videoGallery',
   'trainingList',
+  'communityCarousel',
+  'productTabs',
+  'mediaCopy',
+  'mediaShowcase',
+  'featureGrid',
+  'productGrid',
+  'banner',
+  'newsletterSignup',
+  'testimonials',
+  'facts',
+  'bullets',
+  'specialties',
 ]);
 
 interface StoryBlock {
@@ -69,19 +81,11 @@ const isPageSection = (value: unknown): value is PageSection => {
     return Array.isArray(section.entries);
   }
 
-  if (type === 'imageTextHalf') {
-    return true;
-  }
-
-  if (type === 'videoGallery') {
+  if (type === 'videoGallery' || type === 'trainingList') {
     return section.entries === undefined || Array.isArray(section.entries);
   }
 
-  if (type === 'trainingList') {
-    return section.entries === undefined || Array.isArray(section.entries);
-  }
-
-  return false;
+  return true;
 };
 
 const isStoryPageContent = (value: unknown): value is StoryPageContent => {

--- a/pages/Training.tsx
+++ b/pages/Training.tsx
@@ -18,6 +18,18 @@ const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
   'imageGrid',
   'videoGallery',
   'trainingList',
+  'communityCarousel',
+  'productTabs',
+  'mediaCopy',
+  'mediaShowcase',
+  'featureGrid',
+  'productGrid',
+  'banner',
+  'newsletterSignup',
+  'testimonials',
+  'facts',
+  'bullets',
+  'specialties',
 ]);
 
 const isPageSection = (value: unknown): value is PageSection => {
@@ -40,19 +52,11 @@ const isPageSection = (value: unknown): value is PageSection => {
     return Array.isArray(section.entries);
   }
 
-  if (type === 'imageTextHalf') {
-    return true;
-  }
-
-  if (type === 'videoGallery') {
+  if (type === 'videoGallery' || type === 'trainingList') {
     return section.entries === undefined || Array.isArray(section.entries);
   }
 
-  if (type === 'trainingList') {
-    return section.entries === undefined || Array.isArray(section.entries);
-  }
-
-  return false;
+  return true;
 };
 
 const isPageContent = (value: unknown): value is PageContent => {

--- a/pages/Videos.tsx
+++ b/pages/Videos.tsx
@@ -17,6 +17,18 @@ const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
   'imageGrid',
   'videoGallery',
   'trainingList',
+  'communityCarousel',
+  'productTabs',
+  'mediaCopy',
+  'mediaShowcase',
+  'featureGrid',
+  'productGrid',
+  'banner',
+  'newsletterSignup',
+  'testimonials',
+  'facts',
+  'bullets',
+  'specialties',
 ]);
 
 const isPageSection = (value: unknown): value is PageSection => {
@@ -39,19 +51,11 @@ const isPageSection = (value: unknown): value is PageSection => {
     return Array.isArray(section.entries);
   }
 
-  if (type === 'imageTextHalf') {
-    return true;
-  }
-
-  if (type === 'videoGallery') {
+  if (type === 'videoGallery' || type === 'trainingList') {
     return section.entries === undefined || Array.isArray(section.entries);
   }
 
-  if (type === 'trainingList') {
-    return section.entries === undefined || Array.isArray(section.entries);
-  }
-
-  return false;
+  return true;
 };
 
 const isPageContent = (value: unknown): value is PageContent => {

--- a/pages/story.tsx
+++ b/pages/story.tsx
@@ -19,6 +19,7 @@ const SUPPORTED_SECTION_TYPES = new Set<PageSection['type']>([
   'mediaShowcase',
   'featureGrid',
   'productGrid',
+  'productTabs',
   'banner',
   'newsletterSignup',
   'communityCarousel',

--- a/types.ts
+++ b/types.ts
@@ -19,6 +19,8 @@ export type TranslatableArray = {
 };
 
 export type LocalizedText = string | Partial<Record<Language, string>>;
+export type LocalizedValue<T> = T | Partial<Record<Language, T>>;
+export type LocalizedNumber = LocalizedValue<number>;
 
 export interface SeoSettings {
     defaultTitle?: LocalizedText;
@@ -203,6 +205,39 @@ export interface TimelineSectionContent extends VisibilityFlag {
   entries: TimelineEntry[];
 }
 
+export interface MediaCopyOverlaySettings {
+  columnStart?: LocalizedNumber;
+  columnSpan?: LocalizedNumber;
+  rowStart?: LocalizedNumber;
+  rowSpan?: LocalizedNumber;
+  textAlign?: LocalizedValue<'left' | 'center' | 'right'>;
+  verticalAlign?: LocalizedValue<'start' | 'center' | 'end'>;
+  theme?: LocalizedValue<'light' | 'dark'>;
+  background?: LocalizedValue<'none' | 'scrim-light' | 'scrim-dark' | 'panel'>;
+  cardWidth?: LocalizedValue<'sm' | 'md' | 'lg'>;
+}
+
+export interface MediaCopyContentBlock {
+  heading?: LocalizedText;
+  body?: LocalizedText;
+  image?: {
+    src?: string | null;
+    alt?: LocalizedText;
+  };
+}
+
+export interface MediaCopySectionContent extends VisibilityFlag {
+  type: 'mediaCopy';
+  title?: LocalizedText;
+  body?: LocalizedText;
+  image?: string | { src?: string | null };
+  imageAlt?: LocalizedText;
+  layout?: LocalizedValue<'image-left' | 'image-right' | 'overlay'>;
+  columns?: LocalizedNumber;
+  overlay?: MediaCopyOverlaySettings;
+  content?: MediaCopyContentBlock;
+}
+
 export interface ImageTextHalfSectionContent extends VisibilityFlag {
   type: 'imageTextHalf';
   image?: string;
@@ -237,6 +272,115 @@ export interface CommunityCarouselSectionContent extends VisibilityFlag {
   slides?: CommunityCarouselSlide[];
   slideDuration?: number;
   quoteDuration?: number;
+}
+
+export interface MediaShowcaseItemContent {
+  eyebrow?: LocalizedText;
+  title?: LocalizedText;
+  body?: LocalizedText;
+  description?: LocalizedText;
+  label?: LocalizedText;
+  image?: string;
+  imageAlt?: LocalizedText;
+  ctaLabel?: LocalizedText;
+  ctaHref?: LocalizedText;
+}
+
+export interface MediaShowcaseSectionContent extends VisibilityFlag {
+  type: 'mediaShowcase';
+  title?: LocalizedText;
+  items?: MediaShowcaseItemContent[];
+}
+
+export interface FeatureGridItemContent {
+  label?: LocalizedText;
+  description?: LocalizedText;
+  icon?: string;
+}
+
+export interface FeatureGridSectionContent extends VisibilityFlag {
+  type: 'featureGrid';
+  title?: LocalizedText;
+  columns?: LocalizedNumber;
+  items?: FeatureGridItemContent[];
+}
+
+export interface ProductGridProductReference {
+  id?: LocalizedText;
+}
+
+export interface ProductGridHighlightItem {
+  eyebrow?: LocalizedText;
+  title?: LocalizedText;
+  label?: LocalizedText;
+  description?: LocalizedText;
+  body?: LocalizedText;
+  image?: string;
+  imageAlt?: LocalizedText;
+  ctaLabel?: LocalizedText;
+  ctaHref?: LocalizedText;
+}
+
+export interface ProductGridSectionContent extends VisibilityFlag {
+  type: 'productGrid';
+  title?: LocalizedText;
+  columns?: LocalizedNumber;
+  products?: ProductGridProductReference[];
+  items?: ProductGridHighlightItem[];
+}
+
+export interface BannerSectionContent extends VisibilityFlag {
+  type: 'banner';
+  text?: LocalizedText;
+  cta?: LocalizedText;
+  url?: LocalizedText;
+  style?: LocalizedText;
+}
+
+export interface NewsletterSignupSectionContent extends VisibilityFlag {
+  type: 'newsletterSignup';
+  title?: LocalizedText;
+  subtitle?: LocalizedText;
+  placeholder?: LocalizedText;
+  ctaLabel?: LocalizedText;
+  confirmation?: LocalizedText;
+  background?: LocalizedValue<'light' | 'beige' | 'dark'>;
+  alignment?: LocalizedValue<'left' | 'center'>;
+}
+
+export interface TestimonialQuoteContent {
+  text?: LocalizedText;
+  author?: LocalizedText;
+  role?: LocalizedText;
+}
+
+export interface TestimonialsSectionContent extends VisibilityFlag {
+  type: 'testimonials';
+  title?: LocalizedText;
+  quotes?: TestimonialQuoteContent[];
+}
+
+export interface FactsSectionContent extends VisibilityFlag {
+  type: 'facts';
+  title?: LocalizedText;
+  text?: LocalizedText;
+}
+
+export interface BulletsSectionContent extends VisibilityFlag {
+  type: 'bullets';
+  title?: LocalizedText;
+  items?: LocalizedText[];
+}
+
+export interface SpecialtyItemContent {
+  title?: LocalizedText;
+  bullets?: LocalizedText[];
+}
+
+export interface SpecialtiesSectionContent extends VisibilityFlag {
+  type: 'specialties';
+  title?: LocalizedText;
+  items?: SpecialtyItemContent[];
 }
 
 export interface ClinicsBlockContent {
@@ -327,12 +471,22 @@ export interface ProductTabsSectionContent extends VisibilityFlag {
 
 export type PageSection =
   | TimelineSectionContent
+  | MediaCopySectionContent
   | ImageTextHalfSectionContent
   | ImageGridSectionContent
   | CommunityCarouselSectionContent
+  | MediaShowcaseSectionContent
+  | FeatureGridSectionContent
+  | ProductGridSectionContent
   | VideoGallerySectionContent
   | TrainingListSectionContent
-  | ProductTabsSectionContent;
+  | ProductTabsSectionContent
+  | BannerSectionContent
+  | NewsletterSignupSectionContent
+  | TestimonialsSectionContent
+  | FactsSectionContent
+  | BulletsSectionContent
+  | SpecialtiesSectionContent;
 
 export interface PageContent extends VisibilityFlag {
   sections: PageSection[];


### PR DESCRIPTION
## Summary
- add type coverage and reusable section components for the current Stackbit builder models with Visual Editor bindings
- map the new sections through SectionRenderer and refresh page loaders so About, Story, Training, and Videos accept the variants
- document the change in the Decap/Netlify rolling log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e408d74c8c8320b78aea150ca95137