### PR TITLE
feat: render contact hero via section renderer

### DIFF
--- a/components/SectionRenderer.tsx
+++ b/components/SectionRenderer.tsx
@@ -15,8 +15,9 @@ import Specialties from './sections/Specialties';
 import VideoGallery from './VideoGallery';
 import TrainingList from './TrainingList';
 import CommunityCarousel from './sections/CommunityCarousel';
+import HeroSimple from './sections/HeroSimple';
 import { getVisualEditorAttributes } from '../utils/stackbitBindings';
-import type { PageSection, ProductTab, ProductTabsSectionContent } from '../types';
+import type { HeroSimpleSectionContent, PageSection, ProductTab, ProductTabsSectionContent } from '../types';
 import { filterVisible } from '../utils/contentVisibility';
 
 const ProductTabsSection: React.FC<{ section: ProductTabsSectionContent }> = ({ section }) => {
@@ -122,6 +123,19 @@ const buildSectionKey = (prefix: string, section: PageSection): string => {
   return prefix;
 };
 
+const getSectionFieldPath = (
+  section: PageSection,
+  baseFieldPath: string | undefined,
+  index: number,
+): string | undefined => {
+  const override = (section as HeroSimpleSectionContent | undefined)?.fieldPathOverride;
+  if (typeof override === 'string' && override.length > 0) {
+    return override;
+  }
+
+  return baseFieldPath ? `${baseFieldPath}.${index}` : undefined;
+};
+
 const SectionRenderer: React.FC<SectionRendererProps> = ({ sections, fieldPath }) => {
   const safeSections = filterVisible(sections);
 
@@ -132,9 +146,17 @@ const SectionRenderer: React.FC<SectionRendererProps> = ({ sections, fieldPath }
   return (
     <>
       {safeSections.map((section, index) => {
-        const sectionFieldPath = fieldPath ? `${fieldPath}.${index}` : undefined;
+        const sectionFieldPath = getSectionFieldPath(section, fieldPath, index);
 
         switch (section.type) {
+          case 'heroSimple':
+            return (
+              <HeroSimple
+                key={buildSectionKey('hero-simple', section)}
+                section={section}
+                fieldPath={sectionFieldPath}
+              />
+            );
           case 'timeline':
             return (
               <TimelineSection

--- a/components/sections/HeroSimple.tsx
+++ b/components/sections/HeroSimple.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { getVisualEditorAttributes } from '../../utils/stackbitBindings';
+import type { HeroSimpleSectionContent } from '../../types';
+
+interface HeroSimpleProps {
+  section: HeroSimpleSectionContent;
+  fieldPath?: string;
+}
+
+const HeroSimple: React.FC<HeroSimpleProps> = ({ section, fieldPath }) => {
+  const title = section.title?.trim();
+  const subtitle = section.subtitle?.trim();
+  const eyebrow = section.eyebrow?.trim();
+
+  if (!title && !subtitle && !eyebrow) {
+    return null;
+  }
+
+  const containerAttributes = getVisualEditorAttributes(fieldPath);
+  const titleFieldPath = section.titleFieldPath ?? (fieldPath ? `${fieldPath}.title` : undefined);
+  const subtitleFieldPath = section.subtitleFieldPath ?? (fieldPath ? `${fieldPath}.subtitle` : undefined);
+  const eyebrowFieldPath = section.eyebrowFieldPath ?? (fieldPath ? `${fieldPath}.eyebrow` : undefined);
+
+  return (
+    <section className="py-16 sm:py-24" {...containerAttributes} data-sb-field-path={fieldPath}>
+      <div className="container mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+        <div className="space-y-4 text-center">
+          {eyebrow ? (
+            <p
+              className="text-xs font-semibold uppercase tracking-[0.3em] text-stone-500"
+              {...getVisualEditorAttributes(eyebrowFieldPath)}
+            >
+              {eyebrow}
+            </p>
+          ) : null}
+          {title ? (
+            <h1
+              className="text-4xl font-semibold tracking-tight text-stone-900 sm:text-5xl"
+              {...getVisualEditorAttributes(titleFieldPath)}
+            >
+              {title}
+            </h1>
+          ) : null}
+          {subtitle ? (
+            <p
+              className="mx-auto max-w-2xl text-lg text-stone-600"
+              {...getVisualEditorAttributes(subtitleFieldPath)}
+            >
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HeroSimple;

--- a/types.ts
+++ b/types.ts
@@ -238,6 +238,17 @@ export interface MediaCopySectionContent extends VisibilityFlag {
   content?: MediaCopyContentBlock;
 }
 
+export interface HeroSimpleSectionContent extends VisibilityFlag {
+  type: 'heroSimple';
+  title?: string;
+  subtitle?: string;
+  eyebrow?: string;
+  titleFieldPath?: string;
+  subtitleFieldPath?: string;
+  eyebrowFieldPath?: string;
+  fieldPathOverride?: string;
+}
+
 export interface ImageTextHalfSectionContent extends VisibilityFlag {
   type: 'imageTextHalf';
   image?: string;
@@ -470,6 +481,7 @@ export interface ProductTabsSectionContent extends VisibilityFlag {
 }
 
 export type PageSection =
+  | HeroSimpleSectionContent
   | TimelineSectionContent
   | MediaCopySectionContent
   | ImageTextHalfSectionContent

--- a/utils/loadContactPageContent.ts
+++ b/utils/loadContactPageContent.ts
@@ -1,4 +1,4 @@
-import type { Language } from '../types';
+import type { Language, PageSection } from '../types';
 import { fetchVisualEditorMarkdown, type VisualEditorContentSource } from './fetchVisualEditorMarkdown';
 import { loadUnifiedPage } from './unifiedPageLoader';
 import { loadPage } from '../src/lib/content';
@@ -12,7 +12,7 @@ export interface ContactPageData {
   phone?: string;
   address?: string;
   mapEmbedUrl?: string;
-  sections?: unknown[];
+  sections?: PageSection[];
 }
 
 export interface ContactPageContentResult {


### PR DESCRIPTION
## Summary
- add a reusable HeroSimple section type and renderer hook so hero copy can flow through SectionRenderer with visual-editor bindings
- load contact hero and sections from unified content, render them through SectionRenderer, and keep the sidebar/contact form working with existing fallbacks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68e412b145f08320ad551b21d634e81d