### PR TITLE
fix: restore home hero overlay and media showcase

### DIFF
--- a/components/sections/MediaShowcase.tsx
+++ b/components/sections/MediaShowcase.tsx
@@ -101,7 +101,7 @@ const MediaShowcase: React.FC<MediaShowcaseProps> = ({ section, fieldPath }) => 
 
   return (
     <section className="py-20 sm:py-28 bg-white" {...getVisualEditorAttributes(fieldPath)} data-sb-field-path={fieldPath}>
-      <div className="w-full mx-auto px-4 sm:px-6 lg:px-0">
+      <div className="container mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         {title?.trim() ? (
           <div
             className="max-w-3xl mb-10"
@@ -110,7 +110,7 @@ const MediaShowcase: React.FC<MediaShowcaseProps> = ({ section, fieldPath }) => 
             <h2 className="text-3xl sm:text-4xl font-semibold text-stone-900 tracking-tight">{title}</h2>
           </div>
         ) : null}
-        <div className="grid auto-rows-[minmax(640px,1fr)] gap-y-0 md:grid-cols-4 md:gap-x-0">
+        <div className="grid auto-rows-[minmax(360px,1fr)] gap-6 md:auto-rows-[minmax(420px,1fr)] md:grid-cols-4">
           {items.map((item, index) => {
             const layoutClasses = (() => {
               if (index === 0) {
@@ -132,22 +132,32 @@ const MediaShowcase: React.FC<MediaShowcaseProps> = ({ section, fieldPath }) => 
             const justify = index === 3 ? 'lg:items-end' : 'lg:items-start';
             const objectPosition = getObjectPositionFromFocal(item.imageFocal ?? undefined);
             const imageStyle = objectPosition ? { objectPosition } : undefined;
+            const articleClasses = [
+              'relative flex overflow-hidden rounded-3xl bg-stone-900 text-white shadow-xl ring-1 ring-black/10',
+              layoutClasses,
+            ].join(' ');
 
-          return (
+            return (
               <article
                 key={item.fieldPath ?? index}
-                className={`relative overflow-hidden bg-stone-900 text-white flex ${layoutClasses}`}
+                className={articleClasses}
                 {...getVisualEditorAttributes(item.fieldPath)}
                 data-sb-field-path={item.fieldPath}
               >
                 {item.imageUrl ? (
-                  <img
-                    src={item.imageUrl}
-                    alt={item.imageAlt}
-                    className="absolute inset-0 h-full w-full object-cover"
-                    style={imageStyle}
-                    {...getVisualEditorAttributes(item.imageFieldPath)}
-                  />
+                  <>
+                    <img
+                      src={item.imageUrl}
+                      alt={item.imageAlt}
+                      className="absolute inset-0 h-full w-full object-cover"
+                      style={imageStyle}
+                      {...getVisualEditorAttributes(item.imageFieldPath)}
+                    />
+                    <div
+                      className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/70 via-black/40 to-transparent"
+                      aria-hidden="true"
+                    />
+                  </>
                 ) : (
                   <div
                     className="absolute inset-0 flex items-center justify-center border border-dashed border-white/40"

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -576,7 +576,8 @@ const HERO_CTA_ALIGNMENT_CLASSES: Record<HeroHorizontalAlignment, string> = {
   right: 'sm:justify-end',
 };
 
-const HERO_GRID_CONTAINER_CLASSES = 'grid grid-cols-3 grid-rows-3 w-full h-full p-6 sm:p-10';
+const HERO_GRID_CONTAINER_CLASSES =
+  'grid grid-cols-3 grid-rows-3 w-full h-full max-w-6xl mx-auto px-6 sm:px-10 py-16 md:py-20';
 
 const HERO_GRID_COLUMN_CLASSES: Record<HeroHorizontalAlignment, string> = {
   left: 'col-start-1 col-end-2',
@@ -966,10 +967,50 @@ const normalizeHeroTextAnchor = (value?: string | null): HeroTextAnchor | undefi
   return undefined;
 };
 
+const HERO_OVERLAY_PRESETS: Record<string, string> = {
+  none: 'rgba(0,0,0,0)',
+  off: 'rgba(0,0,0,0)',
+  transparent: 'rgba(0,0,0,0)',
+  light: 'rgba(0,0,0,0.24)',
+  soft: 'rgba(0,0,0,0.32)',
+  gentle: 'rgba(0,0,0,0.32)',
+  medium: 'rgba(0,0,0,0.48)',
+  balanced: 'rgba(0,0,0,0.48)',
+  dark: 'rgba(0,0,0,0.64)',
+  strong: 'rgba(0,0,0,0.64)',
+  heavy: 'rgba(0,0,0,0.72)',
+  deep: 'rgba(0,0,0,0.72)',
+  black: 'rgba(0,0,0,0.72)',
+  'scrim-dark': 'rgba(0,0,0,0.6)',
+  'scrim-light': 'rgba(255,255,255,0.35)',
+  white: 'rgba(255,255,255,0.4)',
+  bright: 'rgba(255,255,255,0.4)',
+};
+
 const resolveHeroOverlay = (value?: string | number | boolean | null): string | undefined => {
   if (typeof value === 'string') {
     const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : undefined;
+    if (!trimmed) {
+      return undefined;
+    }
+
+    const normalized = trimmed.toLowerCase();
+    if (normalized in HERO_OVERLAY_PRESETS) {
+      return HERO_OVERLAY_PRESETS[normalized];
+    }
+
+    if (
+      trimmed.startsWith('#')
+      || /^rgba?\(/i.test(trimmed)
+      || /^hsla?\(/i.test(trimmed)
+      || normalized.startsWith('linear-gradient')
+      || normalized.startsWith('radial-gradient')
+      || normalized.startsWith('conic-gradient')
+    ) {
+      return trimmed;
+    }
+
+    return undefined;
   }
 
   if (typeof value === 'number') {


### PR DESCRIPTION
## Summary
- map CMS-provided hero overlay tokens to consistent RGBA colors and center the overlay grid to restore the intended hero composition
- refresh the media showcase section spacing, container width, and gradient overlay so the homepage mosaic matches the reference design while keeping editor bindings intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e59bb0354c83208eba481a8f187c50